### PR TITLE
Fix fuzztarget ECDH to be symmetric

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -642,8 +642,17 @@ mod fuzz_dummy {
         assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
         assert!((*cx).0 as u32 & SECP256K1_START_SIGN == SECP256K1_START_SIGN);
         if secp256k1_ec_seckey_verify(cx, scalar) != 1 { return 0; }
-        (*out).0[0..16].copy_from_slice(&(*point).0[0..16]);
-        ptr::copy(scalar, (*out).0[16..32].as_mut_ptr(), 16);
+
+        let mut scalar_prefix = [0; 16];
+        ptr::copy(scalar, scalar_prefix[..].as_mut_ptr(), 16);
+
+        if (*point).0[0..16] > scalar_prefix[0..16] {
+            (*out).0[0..16].copy_from_slice(&(*point).0[0..16]);
+            ptr::copy(scalar, (*out).0[16..32].as_mut_ptr(), 16);
+        } else {
+            ptr::copy(scalar, (*out).0[0..16].as_mut_ptr(), 16);
+            (*out).0[16..32].copy_from_slice(&(*point).0[0..16]);
+        }
         (*out).0[16] = 0x00; // result should always be a valid secret key
         1
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -327,7 +327,7 @@ mod fuzz_dummy {
         assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
         match in_len {
             33 => {
-                if *input != 2 && *input != 3 {
+                if (*input.offset(1) > 0x7f && *input != 2) || (*input.offset(1) <= 0x7f && *input != 3) {
                     0
                 } else {
                     ptr::copy(input.offset(1), (*pk).0[0..32].as_mut_ptr(), 32);


### PR DESCRIPTION
Don't think it matters in any current fuzz targets anywhere, but I was writing a test-case converter to convert from one fuzz target's test cases to another and ran into this.