### PR TITLE
 Implement Ord for arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.9.0"
+version = "0.9.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/key.rs
+++ b/src/key.rs
@@ -49,9 +49,8 @@ pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
                                           0, 0, 0, 0, 0, 0, 0, 1]);
 
 /// A Secp256k1 public key, used for verification of signatures
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
 pub struct PublicKey(ffi::PublicKey);
-
 
 #[cfg(any(test, feature = "rand"))]
 fn random_32_bytes<R: Rng>(rng: &mut R) -> [u8; 32] {

--- a/src/key.rs
+++ b/src/key.rs
@@ -558,6 +558,31 @@ mod test {
         assert_eq!(sum1, sum2);
         assert_eq!(sum1.unwrap(), exp_sum);
     }
+
+    #[test]
+    fn pubkey_equal() {
+        let s = Secp256k1::new();
+        let pk1 = PublicKey::from_slice(
+            &s,
+            &hex!("0241cc121c419921942add6db6482fb36243faf83317c866d2a28d8c6d7089f7ba"),
+        ).unwrap();
+        let pk2 = pk1.clone();
+        let pk3 = PublicKey::from_slice(
+            &s,
+            &hex!("02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443"),
+        ).unwrap();
+
+        assert!(pk1 == pk2);
+        assert!(pk1 <= pk2);
+        assert!(pk2 <= pk1);
+        assert!(!(pk2 < pk1));
+        assert!(!(pk1 < pk2));
+        
+        assert!(pk3 < pk1);
+        assert!(pk1 > pk3);
+        assert!(pk3 <= pk1);
+        assert!(pk1 >= pk3);
+    }
 }
 
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,6 +51,20 @@ macro_rules! impl_array_newtype {
 
         impl Eq for $thing {}
 
+        impl PartialOrd for $thing {
+            #[inline]
+            fn partial_cmp(&self, other: &$thing) -> Option<::std::cmp::Ordering> {
+                self[..].partial_cmp(&other[..])
+            }
+        }
+
+        impl Ord for $thing {
+            #[inline]
+            fn cmp(&self, other: &$thing) -> ::std::cmp::Ordering {
+                self[..].cmp(&other[..])
+            }            
+        }
+
         impl Clone for $thing {
             #[inline]
             fn clone(&self) -> $thing {


### PR DESCRIPTION
This change allows to use PublicKeys as key in `BTreeMap`.