### PR TITLE
Update a couple dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 # [Unreleased]
 
+* Update `rand` to 0.4 and `gcc` 0.3 to `cc` 1.0. (`rand` 0.5 exists but has a lot of breaking changes and no longer compiles with 1.14.0.)
+
 # 0.10.0 - 2018-07-25
 
 * A [complete API overhaul](https://github.com/rust-bitcoin/rust-secp256k1/pull/27) to move many runtime errors into compiletime errors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ default = []
 fuzztarget = []
 
 [dev-dependencies]
-rand = "0.3"
+rand = "0.4"
 serde_test = "1.0"
 
 [dependencies]
 libc = "0.2"
 
 [dependencies.rand]
-version = "0.3"
+version = "0.4"
 optional = true
 
 [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 build = "build.rs"
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 [lib]
 name = "secp256k1"

--- a/build.rs
+++ b/build.rs
@@ -21,10 +21,10 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-    let mut base_config = gcc::Build::new();
+    let mut base_config = cc::Build::new();
     base_config.include("depend/secp256k1/")
                .include("depend/secp256k1/include")
                .include("depend/secp256k1/src")


### PR DESCRIPTION
Update `cc` to 1.0, on the basis that moving to a 1.0 dependency means a move to more mature code.

Update `rand` to 0.4, since 0.3 seems to have 0.4 as a dependency anyway, so this cleans up our dep tree a bit. 0.5 is available but this breaks compilation on 1.14.0.