### PR TITLE
remove `ops::Index` impls for `Signature`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# (Unreleased)
+
+* Remove `ops::Index` implementations for `Signature`
 
 # 0.11.1 - 2018-08-22
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@
 extern crate libc;
 
 use libc::size_t;
-use std::{error, fmt, ops, ptr};
+use std::{error, fmt, ptr};
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 
 #[macro_use]
@@ -365,42 +365,6 @@ impl From<ffi::RecoverableSignature> for RecoverableSignature {
     #[inline]
     fn from(sig: ffi::RecoverableSignature) -> RecoverableSignature {
         RecoverableSignature(sig)
-    }
-}
-
-impl ops::Index<usize> for Signature {
-    type Output = u8;
-
-    #[inline]
-    fn index(&self, index: usize) -> &u8 {
-        &self.0[index]
-    }
-}
-
-impl ops::Index<ops::Range<usize>> for Signature {
-    type Output = [u8];
-
-    #[inline]
-    fn index(&self, index: ops::Range<usize>) -> &[u8] {
-        &self.0[index]
-    }
-}
-
-impl ops::Index<ops::RangeFrom<usize>> for Signature {
-    type Output = [u8];
-
-    #[inline]
-    fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] {
-        &self.0[index.start..]
-    }
-}
-
-impl ops::Index<ops::RangeFull> for Signature {
-    type Output = [u8];
-
-    #[inline]
-    fn index(&self, _: ops::RangeFull) -> &[u8] {
-        &self.0[..]
     }
 }
 


### PR DESCRIPTION
It's nuts that these were ever exposed. This lets you read bytes directly from a `Signature` object in a way that (a) can never be parsed back into a Signature without unsafe code; (b) has no semantic meaning to users whatsoever; (c) is not even consistent across architectures.