### PR TITLE
Use correct flag on big endian machines.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -61,6 +61,12 @@ fn main() {
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_RECOVERY", Some("1"));
 
+    if let Ok(target_endian) = std::env::var("CARGO_CFG_TARGET_ENDIAN") {
+        if target_endian == "big" {
+            base_config.define("WORDS_BIGENDIAN", Some("1"));
+        }
+    }
+
     if use_64bit_compilation {
         base_config.define("USE_FIELD_5X52", Some("1"))
                    .define("USE_SCALAR_4X64", Some("1"))


### PR DESCRIPTION
This will fix `tests::sign` test case on mips/mips64. Verified with
`cross`[1] tool.

    cross test --target mips-unknown-linux-gnu
    cross test --target mips64el-unknown-linux-gnuabi64

Unfortunately this fix doesn't make `tests::test_debug_output` test case
pass, but this is about debug output so its not as critical as this
patch. See #63 for a discussion.

[1]: https://github.com/japaric/rust-cross