### PR TITLE
Increase version to 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.11.4 - 2018-11-04
+
+* Add `FromStr` and `Display` for `Signature` and both key types
+* Fix `build.rs` for Windows and rustfmt configuration for docs.rs
+* Correct endianness issue for `Signature` `Debug` output
+
+# 0.11.3 - 2018-10-28
+
+* No changes, just fixed docs.rs configuration
 
 # 0.11.2 - 2018-09-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.11.3"
+version = "0.11.4"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
Also commit `Cargo.lock`, which we should've been doing forever. This will prevent any dependencies from upgrading without a git commit, and therefore prevent any surprising breakage.