### PR TITLE
export `serde`, `rand` and `libc`; update version to 0.11.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.11.4"
+version = "0.11.5"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,11 +135,11 @@
 
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
-#[cfg(any(test, feature = "rand"))] extern crate rand;
-#[cfg(feature = "serde")] extern crate serde;
+#[cfg(any(test, feature = "rand"))] pub extern crate rand;
+#[cfg(feature = "serde")] pub extern crate serde;
 #[cfg(all(test, feature = "serde"))] extern crate serde_test;
 
-extern crate libc;
+pub extern crate libc;
 
 use libc::size_t;
 use std::{error, fmt, ops, ptr, str};


### PR DESCRIPTION
Fixes #79 