### PR TITLE
Remove dependency on libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,6 @@ fuzztarget = []
 rand = "0.4"
 serde_test = "1.0"
 
-[dependencies]
-libc = "0.2"
-
 [dependencies.rand]
 version = "0.4"
 optional = true

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,8 +18,7 @@
 //! not be needed for most users.
 use std::mem;
 use std::hash;
-
-use libc::{c_int, c_uchar, c_uint, c_void, size_t};
+use std::os::raw::{c_int, c_uchar, c_uint, c_void};
 
 /// Flag for context to enable no precomputation
 pub const SECP256K1_START_NONE: c_uint = (1 << 0) | 0;
@@ -151,17 +150,17 @@ extern "C" {
 
     // Pubkeys
     pub fn secp256k1_ec_pubkey_parse(cx: *const Context, pk: *mut PublicKey,
-                                     input: *const c_uchar, in_len: size_t)
+                                     input: *const c_uchar, in_len: usize)
                                      -> c_int;
 
     pub fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *mut c_uchar,
-                                         out_len: *mut size_t, pk: *const PublicKey,
+                                         out_len: *mut usize, pk: *const PublicKey,
                                          compressed: c_uint)
                                          -> c_int;
 
     // Signatures
     pub fn secp256k1_ecdsa_signature_parse_der(cx: *const Context, sig: *mut Signature,
-                                               input: *const c_uchar, in_len: size_t)
+                                               input: *const c_uchar, in_len: usize)
                                                -> c_int;
 
     pub fn secp256k1_ecdsa_signature_parse_compact(cx: *const Context, sig: *mut Signature,
@@ -169,11 +168,11 @@ extern "C" {
                                                    -> c_int;
 
     pub fn ecdsa_signature_parse_der_lax(cx: *const Context, sig: *mut Signature,
-                                         input: *const c_uchar, in_len: size_t)
+                                         input: *const c_uchar, in_len: usize)
                                          -> c_int;
 
     pub fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *mut c_uchar,
-                                                   out_len: *mut size_t, sig: *const Signature)
+                                                   out_len: *mut usize, sig: *const Signature)
                                                    -> c_int;
 
     pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *const c_uchar,
@@ -273,7 +272,7 @@ extern "C" {
 
 #[cfg(feature = "fuzztarget")]
 mod fuzz_dummy {
-    use libc::{c_int, c_uchar, c_uint, c_void, size_t};
+    use std::os::raw::{c_int, c_uchar, c_uint, c_void};
     use ffi::*;
     use std::ptr;
 
@@ -319,7 +318,7 @@ mod fuzz_dummy {
     // Pubkeys
     /// Parse 33/65 byte pubkey into PublicKey, losing compressed information
     pub unsafe fn secp256k1_ec_pubkey_parse(cx: *const Context, pk: *mut PublicKey,
-                                            input: *const c_uchar, in_len: size_t)
+                                            input: *const c_uchar, in_len: usize)
                                             -> c_int {
         assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
         match in_len {
@@ -346,7 +345,7 @@ mod fuzz_dummy {
 
     /// Serialize PublicKey back to 33/65 byte pubkey
     pub unsafe fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *mut c_uchar,
-                                                out_len: *mut size_t, pk: *const PublicKey,
+                                                out_len: *mut usize, pk: *const PublicKey,
                                                 compressed: c_uint)
                                                 -> c_int {
         assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
@@ -371,7 +370,7 @@ mod fuzz_dummy {
 
     // Signatures
     pub unsafe fn secp256k1_ecdsa_signature_parse_der(cx: *const Context, sig: *mut Signature,
-                                                      input: *const c_uchar, in_len: size_t)
+                                                      input: *const c_uchar, in_len: usize)
                                                       -> c_int {
         unimplemented!();
     }
@@ -387,14 +386,14 @@ mod fuzz_dummy {
     }
 
     pub unsafe fn ecdsa_signature_parse_der_lax(cx: *const Context, sig: *mut Signature,
-                                                input: *const c_uchar, in_len: size_t)
+                                                input: *const c_uchar, in_len: usize)
                                                 -> c_int {
         unimplemented!();
     }
 
     /// Copies up to 72 bytes into output from sig
     pub unsafe fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *mut c_uchar,
-                                                          out_len: *mut size_t, sig: *const Signature)
+                                                          out_len: *mut usize, sig: *const Signature)
                                                           -> c_int {
         assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
 
@@ -407,7 +406,7 @@ mod fuzz_dummy {
             len_s -= 1;
         }
 
-        assert!(*out_len >= (6 + len_s + len_r) as size_t);
+        assert!(*out_len >= (6 + len_s + len_r) as usize);
 
         *output.offset(0) = 0x30;
         *output.offset(1) = 4 + len_r + len_s;

--- a/src/key.rs
+++ b/src/key.rs
@@ -243,7 +243,7 @@ impl PublicKey {
                 ffi::secp256k1_context_no_precomp,
                 &mut pk,
                 data.as_ptr(),
-                data.len() as ::libc::size_t,
+                data.len() as usize,
             ) == 1
             {
                 Ok(PublicKey(pk))
@@ -261,7 +261,7 @@ impl PublicKey {
         let mut ret = [0; constants::PUBLIC_KEY_SIZE];
 
         unsafe {
-            let mut ret_len = constants::PUBLIC_KEY_SIZE as ::libc::size_t;
+            let mut ret_len = constants::PUBLIC_KEY_SIZE as usize;
             let err = ffi::secp256k1_ec_pubkey_serialize(
                 ffi::secp256k1_context_no_precomp,
                 ret.as_mut_ptr(),
@@ -280,7 +280,7 @@ impl PublicKey {
         let mut ret = [0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
 
         unsafe {
-            let mut ret_len = constants::UNCOMPRESSED_PUBLIC_KEY_SIZE as ::libc::size_t;
+            let mut ret_len = constants::UNCOMPRESSED_PUBLIC_KEY_SIZE as usize;
             let err = ffi::secp256k1_ec_pubkey_serialize(
                 ffi::secp256k1_context_no_precomp,
                 ret.as_mut_ptr(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,9 +139,6 @@
 #[cfg(feature = "serde")] pub extern crate serde;
 #[cfg(all(test, feature = "serde"))] extern crate serde_test;
 
-pub extern crate libc;
-
-use libc::size_t;
 use std::{error, fmt, ptr, str};
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 
@@ -173,7 +170,7 @@ fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 impl fmt::Display for Signature {
 fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     let mut v = [0; 72];
-    let mut len = v.len() as size_t;
+    let mut len = v.len() as usize;
     unsafe {
         let err = ffi::secp256k1_ecdsa_signature_serialize_der(
             ffi::secp256k1_context_no_precomp,
@@ -241,7 +238,7 @@ impl Signature {
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_ptr(),
-                data.len() as libc::size_t,
+                data.len() as usize,
             ) == 1
             {
                 Ok(Signature(ret))
@@ -283,7 +280,7 @@ impl Signature {
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_ptr(),
-                data.len() as libc::size_t,
+                data.len() as usize,
             ) == 1
             {
                 Ok(Signature(ret))
@@ -338,7 +335,7 @@ impl Signature {
     /// Serializes the signature in DER format
     pub fn serialize_der(&self) -> Vec<u8> {
         let mut ret = Vec::with_capacity(72);
-        let mut len: size_t = ret.capacity() as size_t;
+        let mut len: usize = ret.capacity() as usize;
         unsafe {
             let err = ffi::secp256k1_ecdsa_signature_serialize_der(
                 ffi::secp256k1_context_no_precomp,


### PR DESCRIPTION
The `libc` library doesn't compile for `wasm32-unknown-unknown` (see https://github.com/rust-lang/libc/pull/831), so this PR removes the dependency on `libc` and makes it possible to compile for this target.