### PR TITLE
Test builds using cargo-web on Travis to ensure they dont break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ script:
   - cargo test --release
   - cargo bench
   - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cargo doc; fi
+  - if [ "$(rustup show | grep default | grep stable)" != "" -a "$TRAVIS_OS_NAME" = "linux" ]; then cargo install --force cargo-web && cargo web build --target=asmjs-unknown-emscripten && cargo web test --target=asmjs-unknown-emscripten --nodejs; fi


### PR DESCRIPTION
I didn't actually test if this thing works, but it claims to run the tests and they claim to pass, so at least we can see if things fail to compile with cargo-web in the future. I spent a bit of time fighting with wasm_pack and didn't get anywhere, it appears to require wasm-targeted crates entirely. Given the dependency tree on cargo web and it downloading the emscripten binaries (!) I woulnd't recommend anyone actually *use* this, but at least its there.