### PR TITLE
Add no-std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ script:
   - cargo build --verbose --features=rand
   - cargo test --verbose --features=rand
   - cargo test --verbose --features="rand serde"
+  - cargo build --verbose --no-default-features
+  - cargo build --verbose --no-default-features --features="serde"
+  - cargo build --verbose --no-default-features --features="rand"
+  - cargo build --verbose --no-default-features --features="rand serde"
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,9 @@ path = "src/lib.rs"
 
 [features]
 unstable = []
-default = []
+default = ["std"]
 fuzztarget = []
+std = []
 
 [dev-dependencies]
 rand = "0.6"
@@ -38,7 +39,9 @@ serde_test = "1.0"
 [dependencies.rand]
 version = "0.6"
 optional = true
+default-features = false
 
 [dependencies.serde]
 version = "1.0"
 optional = true
+default-features = false

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -16,7 +16,7 @@
 //! Support for shared secret computations
 //!
 
-use std::{ops, ptr};
+use core::{ops, ptr};
 
 use key::{SecretKey, PublicKey};
 use ffi;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,7 +18,7 @@
 //! not be needed for most users.
 use core::{mem, hash};
 use core::ffi::c_void;
-use crate::types::*;
+use types::*;
 // use std::os::raw::{c_int, c_uchar, c_uint, c_void};
 
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -17,7 +17,6 @@
 //! Direct bindings to the underlying C library functions. These should
 //! not be needed for most users.
 use core::{mem, hash};
-use core::ffi::c_void;
 use types::*;
 // use std::os::raw::{c_int, c_uchar, c_uint, c_void};
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,9 +16,11 @@
 //! # FFI bindings
 //! Direct bindings to the underlying C library functions. These should
 //! not be needed for most users.
-use std::mem;
-use std::hash;
-use std::os::raw::{c_int, c_uchar, c_uint, c_void};
+use core::{mem, hash};
+use core::ffi::c_void;
+use crate::types::*;
+// use std::os::raw::{c_int, c_uchar, c_uint, c_void};
+
 
 /// Flag for context to enable no precomputation
 pub const SECP256K1_START_NONE: c_uint = 1;

--- a/src/key.rs
+++ b/src/key.rs
@@ -17,7 +17,7 @@
 
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 
-use std::{fmt, mem, str};
+use core::{fmt, mem, str};
 
 use super::{from_hex, Secp256k1};
 use super::Error::{self, InvalidPublicKey, InvalidSecretKey};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,10 +519,9 @@ pub enum Error {
     InvalidTweak,
 }
 
-// Passthrough Debug to Display, since errors should be user-visible
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let res = match *self {
+impl Error {
+    fn as_str(&self) -> &str {
+        match *self {
             Error::IncorrectSignature => "secp: signature failed verification",
             Error::InvalidMessage => "secp: message was not 32 bytes (do you need to hash?)",
             Error::InvalidPublicKey => "secp: malformed public key",
@@ -530,13 +529,21 @@ impl fmt::Display for Error {
             Error::InvalidSecretKey => "secp: malformed or out-of-range secret key",
             Error::InvalidRecoveryId => "secp: bad recovery id",
             Error::InvalidTweak => "secp: bad tweak",
-        };
-        f.write_str(res)
+        }
+    }
+}
+
+// Passthrough Debug to Display, since errors should be user-visible
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        f.write_str(self.as_str())
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn description(&self) -> &str { self.as_str() }
+}
 
 /// Marker trait for indicating that an instance of `Secp256k1` can be used for signing.
 pub trait Signing {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,7 @@ use core::{fmt, ptr, str};
 
 #[macro_use]
 mod macros;
+mod types;
 pub mod constants;
 pub mod ecdh;
 pub mod ffi;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -53,14 +53,14 @@ macro_rules! impl_array_newtype {
 
         impl PartialOrd for $thing {
             #[inline]
-            fn partial_cmp(&self, other: &$thing) -> Option<::std::cmp::Ordering> {
+            fn partial_cmp(&self, other: &$thing) -> Option<::core::cmp::Ordering> {
                 self[..].partial_cmp(&other[..])
             }
         }
 
         impl Ord for $thing {
             #[inline]
-            fn cmp(&self, other: &$thing) -> ::std::cmp::Ordering {
+            fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
                 self[..].cmp(&other[..])
             }            
         }
@@ -69,8 +69,8 @@ macro_rules! impl_array_newtype {
             #[inline]
             fn clone(&self) -> $thing {
                 unsafe {
-                    use std::intrinsics::copy_nonoverlapping;
-                    use std::mem;
+                    use core::intrinsics::copy_nonoverlapping;
+                    use core::mem;
                     let mut ret: $thing = mem::uninitialized();
                     copy_nonoverlapping(self.as_ptr(),
                                         ret.as_mut_ptr(),
@@ -80,7 +80,7 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl ::std::ops::Index<usize> for $thing {
+        impl ::core::ops::Index<usize> for $thing {
             type Output = $ty;
 
             #[inline]
@@ -90,41 +90,41 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl ::std::ops::Index<::std::ops::Range<usize>> for $thing {
+        impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: ::std::ops::Range<usize>) -> &[$ty] {
+            fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
                 let &$thing(ref dat) = self;
                 &dat[index]
             }
         }
 
-        impl ::std::ops::Index<::std::ops::RangeTo<usize>> for $thing {
+        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: ::std::ops::RangeTo<usize>) -> &[$ty] {
+            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
                 let &$thing(ref dat) = self;
                 &dat[index]
             }
         }
 
-        impl ::std::ops::Index<::std::ops::RangeFrom<usize>> for $thing {
+        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: ::std::ops::RangeFrom<usize>) -> &[$ty] {
+            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
                 let &$thing(ref dat) = self;
                 &dat[index]
             }
         }
 
-        impl ::std::ops::Index<::std::ops::RangeFull> for $thing {
+        impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, _: ::std::ops::RangeFull) -> &[$ty] {
+            fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
                 let &$thing(ref dat) = self;
                 &dat[..]
             }
@@ -134,8 +134,8 @@ macro_rules! impl_array_newtype {
 
 macro_rules! impl_pretty_debug {
     ($thing:ident) => {
-        impl ::std::fmt::Debug for $thing {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Debug for $thing {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 try!(write!(f, "{}(", stringify!($thing)));
                 for i in self[..].iter().cloned() {
                     try!(write!(f, "{:02x}", i));
@@ -148,8 +148,8 @@ macro_rules! impl_pretty_debug {
 
 macro_rules! impl_raw_debug {
     ($thing:ident) => {
-        impl ::std::fmt::Debug for $thing {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Debug for $thing {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 for i in self[..].iter().cloned() {
                     try!(write!(f, "{:02x}", i));
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,5 @@
+#![allow(non_camel_case_types)]
+pub type c_int = i32;
+pub type c_uchar = u8;
+pub type c_uint = u32;
+pub use core::ffi::c_void;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,22 @@
 #![allow(non_camel_case_types)]
+use core::fmt;
+
 pub type c_int = i32;
 pub type c_uchar = u8;
 pub type c_uint = u32;
-pub use core::ffi::c_void;
+
+/// This is an exact copy of https://doc.rust-lang.org/core/ffi/enum.c_void.html
+/// It should be Equivalent to C's void type when used as a pointer.
+/// 
+/// We can replace this with `core::ffi::c_void` once we update the rustc version to >=1.30.0.
+#[repr(u8)]
+pub enum c_void {
+    #[doc(hidden)] __variant1,
+    #[doc(hidden)] __variant2,
+}
+
+impl fmt::Debug for c_void {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("c_void")
+    }
+}


### PR DESCRIPTION
Hi,
This make this library support `no-std`.
first I replaced everything from std to get it from core.
then I had 2 things that I had to change and would love you input:

1. the C types from `std::os::raw`, I see few options. one which I did is just declare it manually which I don't really love, another is to make a feature if it will be received from std or libc.

2. Replacing the Vec in the DER serialization. I talked with Maxwell and he told me that the signature can be anywhere between 8 and 72 bytes, so the only way I thought I can achieve this without breaking the API is using the ArrayVec crate which initializes the Vector on the stack,
A different approach will be accepting `&mut [u8; 72]` and returning a slice to the correct signature that will be a part of that mutable.