### PR TITLE
Add raw context getter to Secp256k1 struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,6 +639,14 @@ impl Secp256k1<VerifyOnly> {
 
 impl<C> Secp256k1<C> {
 
+    /// Getter for the raw pointer to the underlying secp256k1 context. This
+    /// shouldn't be needed with normal usage of the library. It enables
+    /// extending the Secp256k1 with more cryptographic algorithms outside of
+    /// this crate.
+    pub fn ctx(&self) -> &*mut ffi::Context {
+        &self.ctx
+    }
+
     /// (Re)randomizes the Secp256k1 context for cheap sidechannel resistance;
     /// see comment in libsecp256k1 commit d2275795f by Gregory Maxwell. Requires
     /// compilation with "rand" feature.


### PR DESCRIPTION
This enables extending the Secp256k1 with more cryptographic algorithms outside of this crate. In particular, I'd like to use algorithms in [secp256k1-zkp](https://github.com/ElementsProject/secp256k1-zkp/pulls) with this crates' Secp256k1. For example, this is how schnorrsig could be added to a rust-secp256k1-zkp crate:  https://github.com/jonasnick/rust-secp256k1-zkp/commit/2cd9bc470827d4aebf958f5161ff3d022a9c27b7#diff-378891ea32c1e0e815ba44b3c9dfaa90R110