### PR TITLE
Zeroing out secrets 

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -22,7 +22,7 @@ use key::{SecretKey, PublicKey};
 use ffi;
 
 /// A tag used for recovering the public key from a compact signature
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SharedSecret(ffi::SharedSecret);
 
 impl SharedSecret {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,6 +17,9 @@
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {
         impl Copy for $thing {}
+        impl_array_newtype!($thing, $ty, $len, !Copy);
+    };
+    ($thing:ident, $ty:ty, $len:expr, !Copy) => {
 
         impl $thing {
             #[inline]


### PR DESCRIPTION
Hi,
I Implemented the `Drop` trait to `SecretKey` and `SharedSecret` with `write_volatile` to zero out the structs when they get dropped.
this should be essentially the same as `memset_s` meaning the compiler shouldn't optimize this out (https://doc.rust-lang.org/std/ptr/fn.write_volatile.html)

For this I had to remove the Copy trait because Copy types can't implement Drop.
