### PR TITLE
Fix `Rand` trait bounds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ fuzztarget = []
 
 [dev-dependencies]
 rand = "0.6"
-rand_core = "0.3"
+rand_core = "0.4"
 serde_test = "1.0"
 
 [dependencies.rand]

--- a/src/key.rs
+++ b/src/key.rs
@@ -90,7 +90,7 @@ impl str::FromStr for PublicKey {
 }
 
 #[cfg(any(test, feature = "rand"))]
-fn random_32_bytes<R: Rng>(rng: &mut R) -> [u8; 32] {
+fn random_32_bytes<R: Rng + ?Sized>(rng: &mut R) -> [u8; 32] {
     let mut ret = [0u8; 32];
     rng.fill_bytes(&mut ret);
     ret
@@ -100,7 +100,7 @@ impl SecretKey {
     /// Creates a new random secret key. Requires compilation with the "rand" feature.
     #[inline]
     #[cfg(any(test, feature = "rand"))]
-    pub fn new<R: Rng>(rng: &mut R) -> SecretKey {
+    pub fn new<R: Rng + ?Sized>(rng: &mut R) -> SecretKey {
         let mut data = random_32_bytes(rng);
         unsafe {
             while ffi::secp256k1_ec_seckey_verify(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -651,7 +651,7 @@ impl<C> Secp256k1<C> {
     /// see comment in libsecp256k1 commit d2275795f by Gregory Maxwell. Requires
     /// compilation with "rand" feature.
     #[cfg(any(test, feature = "rand"))]
-    pub fn randomize<R: Rng>(&mut self, rng: &mut R) {
+    pub fn randomize<R: Rng + ?Sized>(&mut self, rng: &mut R) {
         let mut seed = [0; 32];
         rng.fill_bytes(&mut seed);
         unsafe {
@@ -720,7 +720,7 @@ impl<C: Signing> Secp256k1<C> {
     /// with the "rand" feature.
     #[inline]
     #[cfg(any(test, feature = "rand"))]
-    pub fn generate_keypair<R: Rng>(&self, rng: &mut R)
+    pub fn generate_keypair<R: Rng + ?Sized>(&self, rng: &mut R)
                                     -> (key::SecretKey, key::PublicKey) {
         let sk = key::SecretKey::new(rng);
         let pk = key::PublicKey::from_secret_key(self, &sk);


### PR DESCRIPTION
In according of this example https://docs.rs/rand/0.6.5/rand/distributions/index.html#examples we should also add `?Sized` bound to allow library users to implement custom distributions for data structures which contains `secp256k1` primitives like keypairs.