### PR TITLE
Add as_mut_ptr to PublicKey

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -213,10 +213,16 @@ impl<'de> ::serde::Deserialize<'de> for SecretKey {
 }
 
 impl PublicKey {
-    /// Obtains a raw pointer suitable for use with FFI functions
+    /// Obtains a raw const pointer suitable for use with FFI functions
     #[inline]
     pub fn as_ptr(&self) -> *const ffi::PublicKey {
         &self.0 as *const _
+    }
+
+    /// Obtains a raw mutable pointer suitable for use with FFI functions
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::PublicKey {
+        &mut self.0 as *mut _
     }
 
     /// Creates a new public key from a secret key.


### PR DESCRIPTION
I'm working on `rust-secp256k1-zkp` and there's a function that MuSig-combines a bunch of pubkeys into a single pubkey. In principle returning the pubkey could work very similar to how `from_secret_key` works (https://github.com/rust-bitcoin/rust-secp256k1/compare/master...jonasnick:pk_as_mut_ptr?expand=1#diff-6fb5c8f31a9b0420853a8e3f5af3e391L227). But that doesn't work because we don't have access to the `PublicKey` constructor from outside the module because the inner field is private. Instead the same effect is achieved with `as_mut_ptr` (https://github.com/jonasnick/rust-secp256k1-zkp/commit/9428b6c299307d8921c4d0a4cf26d7b4f2528568#diff-21a76c1f1f03ad91cc16d9ab499374ddR44).