### PR TITLE
Add human readable serialization and deserialization to Secret Key

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -158,3 +158,47 @@ macro_rules! impl_raw_debug {
         }
      }
 }
+
+#[cfg(feature="serde")]
+/// Implements `Serialize` and `Deserialize` for a type `$t` which represents
+/// a newtype over a byte-slice over length `$len`. Type `$t` must implement
+/// the `FromStr` and `Display` trait.
+macro_rules! serde_impl(
+    ($t:ident, $len:expr) => (
+        impl ::serde::Serialize for $t {
+            fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                if s.is_human_readable() {
+                    s.collect_str(self)
+                } else {
+                    s.serialize_bytes(&self[..])
+                }
+            }
+        }
+
+        impl<'de> ::serde::Deserialize<'de> for $t {
+            fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
+                use ::serde::de::Error;
+                use core::str::FromStr;
+
+                if d.is_human_readable() {
+                    let sl: &str = ::serde::Deserialize::deserialize(d)?;
+                    SecretKey::from_str(sl).map_err(D::Error::custom)
+                } else {
+                    let sl: &[u8] = ::serde::Deserialize::deserialize(d)?;
+                    if sl.len() != $len {
+                        Err(D::Error::invalid_length(sl.len(), &stringify!($len)))
+                    } else {
+                        let mut ret = [0; $len];
+                        ret.copy_from_slice(sl);
+                        Ok($t(ret))
+                    }
+                }
+            }
+        }
+    )
+);
+
+#[cfg(not(feature="serde"))]
+macro_rules! serde_impl(
+    ($t:ident, $len:expr) => ()
+);


### PR DESCRIPTION
I tested that this fixes issue #73 for both human readable and binary formats. `serde_impl` was copied from bitcoin_hashes ( e5008a4c06583c74b31e97e7e62df37e0844bb1c) with minor modifications which makes it similar to how rust-bitcoin handles PubKeys: the type must implement `FromStr` and `Display` to use `serde::collect_str` (avoids importing hex crate) and `from_str`. 