### PR TITLE
Fix imports when using recovery with fuzztarget feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - cargo build --verbose --no-default-features --features="serde"
   - cargo build --verbose --no-default-features --features="rand"
   - cargo build --verbose --no-default-features --features="rand serde recovery"
+  - cargo build --verbose --no-default-features --features="fuzztarget recovery"
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --release

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -60,6 +60,13 @@ pub type EcdhHashFn = unsafe extern "C" fn(
 #[derive(Clone, Debug)]
 #[repr(C)] pub struct Context(c_int);
 
+#[cfg(feature = "fuzztarget")]
+impl Context {
+    pub fn flags(&self) -> u32 {
+        self.0 as u32
+    }
+}
+
 /// Library-internal representation of a Secp256k1 public key
 #[repr(C)]
 pub struct PublicKey([c_uchar; 64]);
@@ -250,9 +257,11 @@ extern "C" {
 
 #[cfg(feature = "fuzztarget")]
 mod fuzz_dummy {
-    use std::os::raw::{c_int, c_uchar, c_uint, c_void};
+    extern crate std;
+    use types::*;
     use ffi::*;
-    use std::ptr;
+    use self::std::ptr;
+    use self::std::boxed::Box;
 
     extern "C" {
         pub static secp256k1_ecdh_hash_function_default: EcdhHashFn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(all(not(test), not(fuzztarget), not(feature = "std")), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 #[cfg(any(test, feature = "rand"))] pub extern crate rand;

--- a/src/recovery/ffi.rs
+++ b/src/recovery/ffi.rs
@@ -69,6 +69,12 @@ extern "C" {
 
 #[cfg(feature = "fuzztarget")]
 mod fuzz_dummy {
+    extern crate std;
+    use types::*;
+    use ffi::*;
+    use self::std::ptr;
+    use super::RecoverableSignature;
+
     pub unsafe fn secp256k1_ecdsa_recoverable_signature_parse_compact(_cx: *const Context, _sig: *mut RecoverableSignature,
                                                                       _input64: *const c_uchar, _recid: c_int)
                                                                       -> c_int {
@@ -95,8 +101,8 @@ mod fuzz_dummy {
                                                    _noncefn: NonceFn,
                                                    _noncedata: *const c_void)
                                                    -> c_int {
-        assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
-        assert!((*cx).0 as u32 & SECP256K1_START_SIGN == SECP256K1_START_SIGN);
+        assert!(!cx.is_null() && (*cx).flags() & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
+        assert!((*cx).flags() & SECP256K1_START_SIGN == SECP256K1_START_SIGN);
         if secp256k1_ec_seckey_verify(cx, sk) != 1 { return 0; }
         if *sk.offset(0) > 0x7f {
             (*sig).0[0] = 2;
@@ -116,3 +122,5 @@ mod fuzz_dummy {
         unimplemented!();
     }
 }
+#[cfg(feature = "fuzztarget")]
+pub use self::fuzz_dummy::*;


### PR DESCRIPTION
This should fix #112. Also adds a test to travis so this can't happen again.