### PR TITLE
Implementing pre allocation context creation

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -144,9 +144,15 @@ extern "C" {
     // Contexts
     pub fn secp256k1_context_create(flags: c_uint) -> *mut Context;
 
+    pub fn secp256k1_context_preallocated_size(flags: c_uint) -> usize;
+
+    pub fn secp256k1_context_preallocated_create(prealloc: *mut c_void, flags: c_uint) -> *mut Context;
+
     pub fn secp256k1_context_clone(cx: *mut Context) -> *mut Context;
 
     pub fn secp256k1_context_destroy(cx: *mut Context);
+
+    pub fn secp256k1_context_preallocated_destroy(cx: *mut Context);
 
     pub fn secp256k1_context_randomize(cx: *mut Context,
                                        seed32: *const c_uchar)


### PR DESCRIPTION
Hi,
I want to implement https://github.com/bitcoin-core/secp256k1/pull/566

this PR build on top of #115.

I see 2 ways to do it:
1. expose `get_preallocated_size()`, `new_preallocated_context()` functions to the user and add the reference to that buffer into the `Context` struct so rust won't allow him to write into it anymore.

2. just assume that if he can allocate data on the fly then he will Implement the https://doc.rust-lang.org/beta/std/alloc/trait.GlobalAlloc.html and just use liballoc instead. (and allocate ourself with Vec).


This is a first try on how 1 will look like (didn't write function docs and I hope I can find better function names haha)