### PR TITLE
Move libsecp USE_ENDOMORPHISM option behind non-default feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ script:
   - cargo build --verbose --features=rand
   - cargo test --verbose --features=rand
   - cargo test --verbose --features="rand serde"
-  - cargo test --verbose --features="rand serde recovery"
+  - cargo test --verbose --features="rand serde recovery endomorphism"
   - cargo build --verbose --no-default-features
   - cargo build --verbose --no-default-features --features="serde"
   - cargo build --verbose --no-default-features --features="rand"
-  - cargo build --verbose --no-default-features --features="rand serde recovery"
+  - cargo build --verbose --no-default-features --features="rand serde recovery endomorphism"
   - cargo build --verbose --no-default-features --features="fuzztarget recovery"
   - cargo build --verbose
   - cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 
 # Should make docs.rs show all functions, even those behind non-default features
 [package.metadata.docs.rs]
-features = [ "rand", "serde", "recovery" ]
+features = [ "rand", "serde", "recovery", "endomorphism" ]
 all-features = true
 
 [build-dependencies]
@@ -31,6 +31,7 @@ default = ["std"]
 fuzztarget = []
 std = []
 recovery = []
+endomorphism = []
 
 [dev-dependencies]
 rand = "0.6"

--- a/build.rs
+++ b/build.rs
@@ -52,9 +52,10 @@ fn main() {
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
                .define("USE_SCALAR_INV_BUILTIN", Some("1"))
-               .define("USE_ENDOMORPHISM", Some("1"))
                .define("ENABLE_MODULE_ECDH", Some("1"));
 
+    #[cfg(feature = "endomorphism")]
+    base_config.define("USE_ENDOMORPHISM", Some("1"));
     #[cfg(feature = "recovery")]
     base_config.define("ENABLE_MODULE_RECOVERY", Some("1"));
 


### PR DESCRIPTION
The motivation behind this is to avoid risk of patent aggression.