### PR TITLE
Add links manifest key to prevent cross-version linkage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "Rust bindings for Pieter Wuille's `libsecp256k1` library. Impleme
 keywords = [ "crypto", "ECDSA", "secp256k1", "libsecp256k1", "bitcoin" ]
 readme = "README.md"
 build = "build.rs"
+links = "secp256k1"
 
 # Should make docs.rs show all functions, even those behind non-default features
 [package.metadata.docs.rs]


### PR DESCRIPTION
As mentioned in https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key:

> The purpose of this manifest key is to give Cargo an understanding about the set of native dependencies that a package has, as well as providing a principled system of passing metadata between package build scripts. Primarily, Cargo requires that there is at most one package per links value. In other words, it’s forbidden to have two packages link to the same native library.