### PR TITLE
Implemented context create/destroy in rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.1 - 2019-07-14
+
+* Implemented FFI functions: `secp256k1_context_create` and `secp256k1_context_destroy` in rust.
+
 # 0.14.0 - 2019-07-08
 
 * [Feature-gate endormorphism optimization](https://github.com/rust-bitcoin/rust-secp256k1/pull/120)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.14.0"
+version = "0.14.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
This is an approach to fixing the problems raised here: https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/9

Because C has no notion as fat pointers like rust we need to store the allocated size somewhere for deallocation.

what I've done here is writing the size of the allocation, offset the pointer by the size of the size and use that.
then for deallocation we can offset it to read the size for deallocation.

I tried minimizing alignments problems by using the most aligned type we need, if I understand correctly if `assert!(mem::align_of::<usize>() >= mem::align_of::<u8>());` is true than everything aligned to usize will be also aligned to u8.

Then I just allocate everything using usizes instead of u8.
And I added some assertions that should never fail. (the check for usize->u8 alignments would probably even be evaluated in compile time)

when the day comes and we upgrade to rust 1.28 we could use this instead: https://doc.rust-lang.org/alloc/alloc/struct.Layout.html

I do think that aligning to usize/u8 and not to [u8] and [usize] is correct because arrays and the types in them should be aligned the same way (and you can't check alignments of unsized types) and the construction of the fat pointer is done via slice::from_raw_parts which accepts `*const T` and returns `&[T]`.
and in rust references are a pointer + length, and `*const [T]` is semantically equivalent to *const T(source: https://github.com/rust-lang/rust-bindgen/issues/1561#issuecomment-493771225).

Would more than love feedback :)
cc @jonasnick 