### PR TITLE
Relax cc requirements more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ features = [ "rand", "serde", "recovery", "endomorphism" ]
 all-features = true
 
 [build-dependencies]
-cc = ">= 1.0.28, <= 1.0.35"
+cc = ">= 1.0.28"
 
 [lib]
 name = "secp256k1"


### PR DESCRIPTION
Once again, `cc` related PR :/

This will help fix the problems that arose here https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/9 (and should prevent any future linking problems with dependencies that use any cc version above `1.0.28` )

I didn't give `cc` an upper bound because these days it's CI test against 1.16.0: https://github.com/alexcrichton/cc-rs/blob/master/azure-pipelines.yml

If anyone thinks we should still be cautious and put an upper bound I'm fine with that, but I do hope that this PR can be the last will hear about `cc`.

I tested that this actually fix everything: https://ci.appveyor.com/project/elichai/rust-bitcoinconsensus/builds/26027109
https://github.com/elichai/rust-bitcoinconsensus/tree/cc

@TheBlueMatt you had a lot of troubles with `cc` in the past so would like to hear your opinion :)
CC @jonasnick  