### PR TITLE
Detecting and linking against libgmp

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -66,34 +66,34 @@ fn main() {
                .include("depend/secp256k1/include")
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
-               .define("SECP256K1_BUILD", Some("1"))
-               .define("ENABLE_MODULE_ECDH", Some("1"))
-               .define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
+               .define("SECP256K1_BUILD", "1")
+               .define("ENABLE_MODULE_ECDH", "1")
+               .define("USE_EXTERNAL_DEFAULT_CALLBACKS", "1");
 
     if cfg!(feature = "lowmemory") {
-        base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
+        base_config.define("ECMULT_WINDOW_SIZE", "4"); // A low-enough value to consume neglible memory
     } else {
-        base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
+        base_config.define("ECMULT_WINDOW_SIZE", "15"); // This is the default in the configure file (`auto`)
     }
     base_config.define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
     #[cfg(feature = "endomorphism")]
-    base_config.define("USE_ENDOMORPHISM", Some("1"));
+    base_config.define("USE_ENDOMORPHISM", "1");
     #[cfg(feature = "recovery")]
-    base_config.define("ENABLE_MODULE_RECOVERY", Some("1"));
+    base_config.define("ENABLE_MODULE_RECOVERY", "1");
 
     if let Ok(target_endian) = env::var("CARGO_CFG_TARGET_ENDIAN") {
         if target_endian == "big" {
-            base_config.define("WORDS_BIGENDIAN", Some("1"));
+            base_config.define("WORDS_BIGENDIAN", "1");
         }
     }
 
     if use_64bit_compilation {
-        base_config.define("USE_FIELD_5X52", Some("1"))
-                   .define("USE_SCALAR_4X64", Some("1"))
-                   .define("HAVE___INT128", Some("1"));
+        base_config.define("USE_FIELD_5X52", "1")
+                   .define("USE_SCALAR_4X64", "1")
+                   .define("HAVE___INT128", "1");
     } else {
-        base_config.define("USE_FIELD_10X26", Some("1"))
-                   .define("USE_SCALAR_8X32", Some("1"));
+        base_config.define("USE_FIELD_10X26", "1")
+                   .define("USE_SCALAR_8X32", "1");
     }
 
     if env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
@@ -101,19 +101,19 @@ fn main() {
     }
 
     if has_gmp {
-        base_config.define("HAVE_LIBGMP", Some("1"))
-                   .define("USE_NUM_GMP", Some("1"))
-                   .define("USE_FIELD_INV_NUM", Some("1"))
-                   .define("USE_SCALAR_INV_NUM", Some("1"))
+        base_config.define("HAVE_LIBGMP", "1")
+                   .define("USE_NUM_GMP", "1")
+                   .define("USE_FIELD_INV_NUM", "1")
+                   .define("USE_SCALAR_INV_NUM", "1")
                    .flag("-lgmp")
                    .flag(&format!("-L{}", DEFAULT_LIBS_PATHS.join(" -L")));
         for include in DEFAULT_INCLUDE_PATHS.iter() {
             base_config.include(include);
         }
     } else {
-        base_config.define("USE_NUM_NONE", Some("1"))
-                   .define("USE_FIELD_INV_BUILTIN", Some("1"))
-                   .define("USE_SCALAR_INV_BUILTIN", Some("1"));
+        base_config.define("USE_NUM_NONE", "1")
+                   .define("USE_FIELD_INV_BUILTIN", "1")
+                   .define("USE_SCALAR_INV_BUILTIN", "1");
     }
 
     // secp256k1

--- a/secp256k1-sys/depend/check_gmp.c
+++ b/secp256k1-sys/depend/check_gmp.c
@@ -1,0 +1,18 @@
+#include <gmp.h>
+#include <stdio.h>
+
+int main(void) {
+    mpz_t a, b;
+    mpz_init(a);
+    mpz_init(b);
+
+    mpz_set_ui(a, 1);
+    mpz_set_ui(b, 2);
+    mpz_add(b, b, a);
+
+    if (mpz_cmp_ui(b, 3) == 0) {
+        return 0;
+    }
+    return -1;
+}
+


### PR DESCRIPTION
Hi,
I hope this can solve #118

I try to link against all the default paths I could think of, not sure how important is this but I wanted to try and make it as robust as possible.


Would love if people can try and run it on their machines and hopefully also machines *without* gmp to make sure it works correctly.


FYI I ran some benchmarks:
without gmp:
```
test benches::bench_sign       ... bench:      37,741 ns/iter (+/- 2,715)
test benches::bench_verify     ... bench:      56,191 ns/iter (+/- 1,943)
test benches::generate         ... bench:      22,192 ns/iter (+/- 1,482)
test ecdh::benches::bench_ecdh ... bench:      61,198 ns/iter (+/- 3,360)


test benches::bench_sign       ... bench:      37,081 ns/iter (+/- 4,044)
test benches::bench_verify     ... bench:      58,233 ns/iter (+/- 2,599)
test benches::generate         ... bench:      22,114 ns/iter (+/- 946)
test ecdh::benches::bench_ecdh ... bench:      61,475 ns/iter (+/- 3,203)
```

with gmp:
```
test benches::bench_sign       ... bench:      39,418 ns/iter (+/- 2,815)
test benches::bench_verify     ... bench:      49,183 ns/iter (+/- 1,411)
test benches::generate         ... bench:      22,517 ns/iter (+/- 390)
test ecdh::benches::bench_ecdh ... bench:      61,905 ns/iter (+/- 1,251)

test benches::bench_sign       ... bench:      38,450 ns/iter (+/- 3,045)
test benches::bench_verify     ... bench:      49,546 ns/iter (+/- 1,447)
test benches::generate         ... bench:      22,758 ns/iter (+/- 3,818)
test ecdh::benches::bench_ecdh ... bench:      61,198 ns/iter (+/- 1,918)

test benches::bench_sign       ... bench:      38,054 ns/iter (+/- 3,151)
test benches::bench_verify     ... bench:      48,028 ns/iter (+/- 738)
test benches::generate         ... bench:      22,130 ns/iter (+/- 901)
test ecdh::benches::bench_ecdh ... bench:      61,243 ns/iter (+/- 741)
```

looks like ~15% improvement in verification time.

cc @apoelstra 