### PR TITLE
bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.15.0 - 2019-07-25
+
+* Implement hex human-readable serde for PublicKey
+* Implement fmt::LowerHex for SecretKey and PublicKey
+* Relax `cc` dependency requirements
+* Add links manifest key to prevent cross-version linkage
+
 # 0.14.1 - 2019-07-14
 
 * Implemented FFI functions: `secp256k1_context_create` and `secp256k1_context_destroy` in rust.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.14.1"
+version = "0.15.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
New minor version instead of patch because serialization of `PublicKey` changed.