### PR TITLE
Propagating std to rand dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.15.0"
+version = "0.15.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 unstable = []
 default = ["std"]
 fuzztarget = []
-std = []
+std = ["rand/std"]
 recovery = []
 endomorphism = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ links = "secp256k1"
 # Should make docs.rs show all functions, even those behind non-default features
 [package.metadata.docs.rs]
 features = [ "rand", "serde", "recovery", "endomorphism" ]
-all-features = true
 
 [build-dependencies]
 cc = ">= 1.0.28"


### PR DESCRIPTION
As requested by @apoelstra 
Without this a user doesn't have access to std RNGs through our re-exported rand library **unless** they also import rand with std enable.

cc https://github.com/rust-bitcoin/rust-bitcoin/pull/298