### PR TITLE
build.rs: Add feature 'lowmemory' to reduce memory usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - cargo build --verbose --no-default-features --features="rand"
   - cargo build --verbose --no-default-features --features="rand serde recovery endomorphism"
   - cargo build --verbose --no-default-features --features="fuzztarget recovery"
+  - cargo build --verbose --no-default-features --features="lowmemory"
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-# 0.15.1 - ????-??-??
+# 0.15.2 - 2019-08-08
 
 - Add feature `lowmemory` that reduces the EC mult window size to require
-  significantly less memory for the validation context (~340B instead of
-  ~520kB), at the cost of slower validation. It does not affect signing, nor
-  the size of the signing context.
+  significantly less memory for the validation context (~680B instead of
+  ~520kB), at the cost of slower validation. It does not affect the speed of
+  signing, nor the size of the signing context.
 
 # 0.15.0 - 2019-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.15.1 - ????-??-??
+
+- Add feature `lowmemory` that reduces the EC mult window size to require
+  significantly less memory for the validation context (~340B instead of
+  ~520kB), at the cost of slower validation. It does not affect signing, nor
+  the size of the signing context.
+
 # 0.15.0 - 2019-07-25
 
 * Implement hex human-readable serde for PublicKey

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ fuzztarget = []
 std = ["rand/std"]
 recovery = []
 endomorphism = []
+lowmemory = []
 
 [dev-dependencies]
 rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.15.1"
+version = "0.15.2"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/build.rs
+++ b/build.rs
@@ -53,9 +53,13 @@ fn main() {
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
                .define("USE_SCALAR_INV_BUILTIN", Some("1"))
                .define("ENABLE_MODULE_ECDH", Some("1"))
-               .define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"))
-               .define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
+               .define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
 
+    if cfg!(feature = "lowmemory") {
+        base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
+    } else {
+        base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
+    }
     #[cfg(feature = "endomorphism")]
     base_config.define("USE_ENDOMORPHISM", Some("1"));
     #[cfg(feature = "recovery")]


### PR DESCRIPTION
Currently, this only set `ECMULT_WINDOW_SIZE` to 4 instead of 15.

Fixes #139.