### PR TITLE
Add AlignType and use it for buffer allocations

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -82,9 +82,9 @@ impl RngCore for FakeRng {
 
 #[start]
 fn start(_argc: isize, _argv: *const *const u8) -> isize {
-    let mut buf = [0u8; 600_000];
+    let mut buf = [0; 75_000];
     let size = Secp256k1::preallocate_size();
-    unsafe { libc::printf("needed size: %d\n\0".as_ptr() as _, size) };
+    unsafe { libc::printf("needed size: %zu\n\0".as_ptr() as _, size) };
 
     let mut secp = Secp256k1::preallocated_new(&mut buf).unwrap();
     secp.randomize(&mut FakeRng);

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -39,9 +39,15 @@ pub mod recovery;
 use core::{hash, slice, ptr};
 use types::*;
 
+/// A type that represents the type with the biggest alignment we can get in rust.
+/// Trying to match what `malloc` does in C, this should be aligned enough to contain pointers too.
+/// This type can have different size/alignment depending on the architecture.
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "16", target_pointer_width = "8"))]
 pub type AlignType = u64;
 
+/// A type that represents the type with the biggest alignment we can get in rust.
+/// Trying to match what `malloc` does in C, this should be aligned enough to contain pointers too.
+/// This type can have different size/alignment depending on the architecture.
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", target_pointer_width = "8")))]
 pub type AlignType = usize;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -218,7 +218,18 @@ impl<'buf> Secp256k1<AllPreallocated<'buf>> {
     pub fn preallocated_new(buf: &'buf mut [AlignType]) -> Result<Secp256k1<AllPreallocated<'buf>>, Error> {
         Secp256k1::preallocated_gen_new(buf)
     }
-    /// Uses the ffi `secp256k1_context_preallocated_size` to check the memory size needed for a context
+    /// Returns the required memory for a preallocated context buffer in a generic manner(sign/verify/all)
+    ///
+    /// Notice that the memory returned is in [AlignType](type.AlignType.html)
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use secp256k1::*;
+    /// let buf_size = Secp256k1::preallocate_size();
+    /// let mut buf = vec![0; buf_size];
+    /// let secp = Secp256k1::preallocated_new(&mut buf).unwrap();
+    ///
+    /// ```
     pub fn preallocate_size() -> usize {
         Self::preallocate_size_gen()
     }
@@ -249,7 +260,18 @@ impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
         Secp256k1::preallocated_gen_new(buf)
     }
 
-    /// Uses the ffi `secp256k1_context_preallocated_size` to check the memory size needed for the context
+    /// Returns the required memory for a preallocated context buffer in a generic manner(sign/verify/all)
+    ///
+    /// Notice that the memory returned is in [AlignType](type.AlignType.html)
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use secp256k1::*;
+    /// let buf_size = Secp256k1::preallocate_signing_size();
+    /// let mut buf = vec![0; buf_size];
+    /// let secp = Secp256k1::preallocated_signing_only(&mut buf).unwrap();
+    ///
+    /// ```
     #[inline]
     pub fn preallocate_signing_size() -> usize {
         Self::preallocate_size_gen()
@@ -281,7 +303,18 @@ impl<'buf> Secp256k1<VerifyOnlyPreallocated<'buf>> {
         Secp256k1::preallocated_gen_new(buf)
     }
 
-    /// Uses the ffi `secp256k1_context_preallocated_size` to check the memory size needed for the context
+    /// Returns the required memory for a preallocated context buffer in a generic manner(sign/verify/all)
+    /// 
+    /// Notice that the memory returned is in [AlignType](type.AlignType.html)
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use secp256k1::*;
+    /// let buf_size = Secp256k1::preallocate_verification_size();
+    /// let mut buf = vec![0; buf_size];
+    /// let secp = Secp256k1::preallocated_verification_only(&mut buf).unwrap();
+    ///
+    /// ```
     #[inline]
     pub fn preallocate_verification_size() -> usize {
         Self::preallocate_size_gen()

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use ptr;
-use ffi::{self, CPtr};
+use ffi::{self, CPtr, AlignType};
 use ffi::types::{c_uint, c_void};
 use Error;
 use Secp256k1;
@@ -17,7 +17,7 @@ pub unsafe trait Context : private::Sealed {
     /// A constant description of the context.
     const DESCRIPTION: &'static str;
     /// A function to deallocate the memory when the context is dropped.
-    unsafe fn deallocate(ptr: *mut [u8]);
+    unsafe fn deallocate(ptr: *mut [AlignType]);
 }
 
 /// Marker trait for indicating that an instance of `Secp256k1` can be used for signing.
@@ -80,7 +80,7 @@ mod std_only {
         const FLAGS: c_uint = ffi::SECP256K1_START_SIGN;
         const DESCRIPTION: &'static str = "signing only";
 
-        unsafe fn deallocate(ptr: *mut [u8]) {
+        unsafe fn deallocate(ptr: *mut [AlignType]) {
             let _ = Box::from_raw(ptr);
         }
     }
@@ -89,7 +89,7 @@ mod std_only {
         const FLAGS: c_uint = ffi::SECP256K1_START_VERIFY;
         const DESCRIPTION: &'static str = "verification only";
 
-        unsafe fn deallocate(ptr: *mut [u8]) {
+        unsafe fn deallocate(ptr: *mut [AlignType]) {
             let _ = Box::from_raw(ptr);
         }
     }
@@ -98,7 +98,7 @@ mod std_only {
         const FLAGS: c_uint = VerifyOnly::FLAGS | SignOnly::FLAGS;
         const DESCRIPTION: &'static str = "all capabilities";
 
-        unsafe fn deallocate(ptr: *mut [u8]) {
+        unsafe fn deallocate(ptr: *mut [AlignType]) {
             let _ = Box::from_raw(ptr);
         }
     }
@@ -109,7 +109,7 @@ mod std_only {
             #[cfg(target_arch = "wasm32")]
             ffi::types::sanity_checks_for_wasm();
 
-            let buf = vec![0u8; Self::preallocate_size_gen()].into_boxed_slice();
+            let buf = vec![0 as AlignType; Self::preallocate_size_gen()].into_boxed_slice();
             let ptr = Box::into_raw(buf);
             Secp256k1 {
                 ctx: unsafe { ffi::secp256k1_context_preallocated_create(ptr as *mut c_void, C::FLAGS) },
@@ -149,7 +149,7 @@ mod std_only {
     impl<C: Context> Clone for Secp256k1<C> {
         fn clone(&self) -> Secp256k1<C> {
             let clone_size = unsafe {ffi::secp256k1_context_preallocated_clone_size(self.ctx)};
-            let ptr_buf = Box::into_raw(vec![0u8; clone_size].into_boxed_slice());
+            let ptr_buf = Box::into_raw(vec![0 as AlignType; clone_size].into_boxed_slice());
             Secp256k1 {
                 ctx: unsafe { ffi::secp256k1_context_preallocated_clone(self.ctx, ptr_buf as *mut c_void) },
                 phantom: PhantomData,
@@ -169,7 +169,7 @@ unsafe impl<'buf> Context for SignOnlyPreallocated<'buf> {
     const FLAGS: c_uint = ffi::SECP256K1_START_SIGN;
     const DESCRIPTION: &'static str = "signing only";
 
-    unsafe fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut [AlignType]) {
         // Allocated by the user
     }
 }
@@ -178,7 +178,7 @@ unsafe impl<'buf> Context for VerifyOnlyPreallocated<'buf> {
     const FLAGS: c_uint = ffi::SECP256K1_START_VERIFY;
     const DESCRIPTION: &'static str = "verification only";
 
-    unsafe fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut [AlignType]) {
         // Allocated by the user
     }
 }
@@ -187,14 +187,14 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
     const FLAGS: c_uint = SignOnlyPreallocated::FLAGS | VerifyOnlyPreallocated::FLAGS;
     const DESCRIPTION: &'static str = "all capabilities";
 
-    unsafe fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut [AlignType]) {
         // Allocated by the user
     }
 }
 
 impl<'buf, C: Context + 'buf> Secp256k1<C> {
     /// Lets you create a context with preallocated buffer in a generic manner(sign/verify/all)
-    pub fn preallocated_gen_new(buf: &'buf mut [u8]) -> Result<Secp256k1<C>, Error> {
+    pub fn preallocated_gen_new(buf: &'buf mut [AlignType]) -> Result<Secp256k1<C>, Error> {
         #[cfg(target_arch = "wasm32")]
         ffi::types::sanity_checks_for_wasm();
 
@@ -208,14 +208,14 @@ impl<'buf, C: Context + 'buf> Secp256k1<C> {
                     C::FLAGS)
             },
             phantom: PhantomData,
-            buf: buf as *mut [u8],
+            buf: buf as *mut [AlignType],
         })
     }
 }
 
 impl<'buf> Secp256k1<AllPreallocated<'buf>> {
     /// Creates a new Secp256k1 context with all capabilities
-    pub fn preallocated_new(buf: &'buf mut [u8]) -> Result<Secp256k1<AllPreallocated<'buf>>, Error> {
+    pub fn preallocated_new(buf: &'buf mut [AlignType]) -> Result<Secp256k1<AllPreallocated<'buf>>, Error> {
         Secp256k1::preallocated_gen_new(buf)
     }
     /// Uses the ffi `secp256k1_context_preallocated_size` to check the memory size needed for a context
@@ -238,14 +238,14 @@ impl<'buf> Secp256k1<AllPreallocated<'buf>> {
         ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
-            buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
+            buf: ptr::null_mut::<[AlignType;0]>() as *mut [AlignType] ,
         })
     }
 }
 
 impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
     /// Creates a new Secp256k1 context that can only be used for signing
-    pub fn preallocated_signing_only(buf: &'buf mut [u8]) -> Result<Secp256k1<SignOnlyPreallocated<'buf>>, Error> {
+    pub fn preallocated_signing_only(buf: &'buf mut [AlignType]) -> Result<Secp256k1<SignOnlyPreallocated<'buf>>, Error> {
         Secp256k1::preallocated_gen_new(buf)
     }
 
@@ -270,14 +270,14 @@ impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
         ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
-            buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
+            buf: ptr::null_mut::<[AlignType;0]>() as *mut [AlignType] ,
         })
     }
 }
 
 impl<'buf> Secp256k1<VerifyOnlyPreallocated<'buf>> {
     /// Creates a new Secp256k1 context that can only be used for verification
-    pub fn preallocated_verification_only(buf: &'buf mut [u8]) -> Result<Secp256k1<VerifyOnlyPreallocated<'buf>>, Error> {
+    pub fn preallocated_verification_only(buf: &'buf mut [AlignType]) -> Result<Secp256k1<VerifyOnlyPreallocated<'buf>>, Error> {
         Secp256k1::preallocated_gen_new(buf)
     }
 
@@ -302,7 +302,7 @@ impl<'buf> Secp256k1<VerifyOnlyPreallocated<'buf>> {
         ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
-            buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
+            buf: ptr::null_mut::<[AlignType;0]>() as *mut [AlignType] ,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,6 +603,9 @@ impl<C: Context> Secp256k1<C> {
     }
 
     /// Returns the required memory for a preallocated context buffer in a generic manner(sign/verify/all)
+    ///
+    /// Notice that the memory returned is in [AlignType](type.AlignType.html)
+    ///
     pub fn preallocate_size_gen() -> usize {
         assert!(mem::align_of::<AlignType>() >= mem::align_of::<u8>());
         assert!(mem::align_of::<AlignType>() >= mem::align_of::<usize>());
@@ -728,7 +731,7 @@ mod tests {
     use super::constants;
     use super::{Secp256k1, Signature, Message};
     use super::Error::{InvalidMessage, IncorrectSignature, InvalidSignature};
-    use ffi;
+    use ffi::{self, AlignType};
     use context::*;
 
     macro_rules! hex {
@@ -746,7 +749,7 @@ mod tests {
         let ctx_sign = unsafe { ffi::secp256k1_context_create(SignOnlyPreallocated::FLAGS) };
         let ctx_vrfy = unsafe { ffi::secp256k1_context_create(VerifyOnlyPreallocated::FLAGS) };
 
-        let buf: *mut [u8] = &mut [0u8;0] as _;
+        let buf: *mut [AlignType] = &mut [0 as AlignType;0] as _;
         let full: Secp256k1<AllPreallocated> = Secp256k1{ctx: ctx_full, phantom: PhantomData, buf};
         let sign: Secp256k1<SignOnlyPreallocated> = Secp256k1{ctx: ctx_sign, phantom: PhantomData, buf};
         let vrfy: Secp256k1<VerifyOnlyPreallocated> = Secp256k1{ctx: ctx_vrfy, phantom: PhantomData, buf};
@@ -805,10 +808,10 @@ mod tests {
 
     #[test]
     fn test_preallocation() {
-        let mut buf_ful = vec![0u8; Secp256k1::preallocate_size()];
-        let mut buf_sign = vec![0u8; Secp256k1::preallocate_signing_size()];
-        let mut buf_vfy = vec![0u8; Secp256k1::preallocate_verification_size()];
-//
+        let mut buf_ful = vec![0; Secp256k1::preallocate_size()];
+        let mut buf_sign = vec![0; Secp256k1::preallocate_signing_size()];
+        let mut buf_vfy = vec![0; Secp256k1::preallocate_verification_size()];
+
         let full = Secp256k1::preallocated_new(&mut buf_ful).unwrap();
         let sign = Secp256k1::preallocated_signing_only(&mut buf_sign).unwrap();
         let vrfy = Secp256k1::preallocated_verification_only(&mut buf_vfy).unwrap();


### PR DESCRIPTION
This addresses #138 
In rust 1.22, we cannot get any type with alignment bigger than 8.
so we take `u64` for any platform that is lower than 64bit and `usize` for any platform that is u64 and up.

I'm not entirely sure if the assertions are needed, I mostly use them as sanity checks and I hope that they're optimized out by the compiler(they can be easily checked at compile time), but if anyone feel differently I can remove some/all of them.