### PR TITLE
Explicit checks for empty slices

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -232,6 +232,8 @@ impl PublicKey {
     /// Creates a public key directly from a slice
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<PublicKey, Error> {
+        if data.is_empty() {return Err(Error::InvalidPublicKey);}
+
         let mut pk = ffi::PublicKey::new();
         unsafe {
             if ffi::secp256k1_ec_pubkey_parse(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,8 @@ impl Signature {
 #[inline]
     /// Converts a DER-encoded byte slice to a signature
     pub fn from_der(data: &[u8]) -> Result<Signature, Error> {
+        if data.is_empty() {return Err(Error::InvalidSignature);}
+
         let mut ret = ffi::Signature::new();
 
         unsafe {
@@ -289,6 +291,8 @@ impl Signature {
     /// 2016. It should never be used in new applications. This library does not
     /// support serializing to this "format"
     pub fn from_der_lax(data: &[u8]) -> Result<Signature, Error> {
+        if data.is_empty() {return Err(Error::InvalidSignature);}
+
         unsafe {
             let mut ret = ffi::Signature::new();
             if ffi::ecdsa_signature_parse_der_lax(

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -57,6 +57,8 @@ impl RecoverableSignature {
     /// representation is nonstandard and defined by the libsecp256k1
     /// library.
     pub fn from_compact(data: &[u8], recid: RecoveryId) -> Result<RecoverableSignature, Error> {
+        if data.is_empty() {return Err(Error::InvalidSignature);}
+
         let mut ret = ffi::RecoverableSignature::new();
 
         unsafe {


### PR DESCRIPTION
An example of the first option i've said here: https://github.com/rust-bitcoin/rust-secp256k1/issues/142