### PR TITLE
Remove all usage of `mem::uninitialized()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.15.2"
+version = "0.15.3"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -30,7 +30,7 @@ impl SharedSecret {
     #[inline]
     pub fn new(point: &PublicKey, scalar: &SecretKey) -> SharedSecret {
         unsafe {
-            let mut ss = ffi::SharedSecret::blank();
+            let mut ss = ffi::SharedSecret::new();
             let res = ffi::secp256k1_ecdh(
                 ffi::secp256k1_context_no_precomp,
                 &mut ss,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -77,7 +77,8 @@ impl PublicKey {
     /// Create a new (zeroed) public key usable for the FFI interface
     pub fn new() -> PublicKey { PublicKey([0; 64]) }
     /// Create a new (uninitialized) public key usable for the FFI interface
-    pub unsafe fn blank() -> PublicKey { mem::uninitialized() }
+    #[deprecated(since = "0.15.3", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> PublicKey { PublicKey::new() }
 }
 
 impl Default for PublicKey {
@@ -102,7 +103,8 @@ impl Signature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> Signature { Signature([0; 64]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> Signature { mem::uninitialized() }
+    #[deprecated(since = "0.15.3", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> Signature { Signature::new() }
 }
 
 impl Default for Signature {
@@ -121,7 +123,8 @@ impl SharedSecret {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> SharedSecret { SharedSecret([0; 32]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> SharedSecret { mem::uninitialized() }
+    #[deprecated(since = "0.15.3", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> SharedSecret { SharedSecret::new() }
 }
 
 impl Default for SharedSecret {

--- a/src/key.rs
+++ b/src/key.rs
@@ -219,7 +219,7 @@ impl PublicKey {
     pub fn from_secret_key<C: Signing>(secp: &Secp256k1<C>,
                            sk: &SecretKey)
                            -> PublicKey {
-        let mut pk = unsafe { ffi::PublicKey::blank() };
+        let mut pk = ffi::PublicKey::new();
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid `SecretKey` without transmute trickery or something
@@ -232,7 +232,7 @@ impl PublicKey {
     /// Creates a public key directly from a slice
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<PublicKey, Error> {
-        let mut pk = unsafe { ffi::PublicKey::blank() };
+        let mut pk = ffi::PublicKey::new();
         unsafe {
             if ffi::secp256k1_ec_pubkey_parse(
                 ffi::secp256k1_context_no_precomp,

--- a/src/key.rs
+++ b/src/key.rs
@@ -17,7 +17,7 @@
 
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 
-use core::{fmt, mem, str};
+use core::{fmt, str};
 
 use super::{from_hex, Secp256k1};
 use super::Error::{self, InvalidPublicKey, InvalidSecretKey};
@@ -338,7 +338,7 @@ impl PublicKey {
     /// to its own negation
     pub fn combine(&self, other: &PublicKey) -> Result<PublicKey, Error> {
         unsafe {
-            let mut ret = mem::uninitialized();
+            let mut ret = ffi::PublicKey::new();
             let ptrs = [self.as_ptr(), other.as_ptr()];
             if ffi::secp256k1_ec_pubkey_combine(
                 ffi::secp256k1_context_no_precomp,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ impl Signature {
 #[inline]
     /// Converts a DER-encoded byte slice to a signature
     pub fn from_der(data: &[u8]) -> Result<Signature, Error> {
-        let mut ret = unsafe { ffi::Signature::blank() };
+        let mut ret = ffi::Signature::new();
 
         unsafe {
             if ffi::secp256k1_ecdsa_signature_parse_der(
@@ -265,7 +265,7 @@ impl Signature {
 
     /// Converts a 64-byte compact-encoded byte slice to a signature
     pub fn from_compact(data: &[u8]) -> Result<Signature, Error> {
-        let mut ret = unsafe { ffi::Signature::blank() };
+        let mut ret = ffi::Signature::new();
         if data.len() != 64 {
             return Err(Error::InvalidSignature)
         }
@@ -290,7 +290,7 @@ impl Signature {
     /// support serializing to this "format"
     pub fn from_der_lax(data: &[u8]) -> Result<Signature, Error> {
         unsafe {
-            let mut ret = ffi::Signature::blank();
+            let mut ret = ffi::Signature::new();
             if ffi::ecdsa_signature_parse_der_lax(
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
@@ -605,7 +605,7 @@ impl<C: Signing> Secp256k1<C> {
     pub fn sign(&self, msg: &Message, sk: &key::SecretKey)
                 -> Signature {
 
-        let mut ret = unsafe { ffi::Signature::blank() };
+        let mut ret = ffi::Signature::new();
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid signature from a valid `Message` and `SecretKey`

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -68,15 +68,8 @@ macro_rules! impl_array_newtype {
         impl Clone for $thing {
             #[inline]
             fn clone(&self) -> $thing {
-                unsafe {
-                    use core::intrinsics::copy_nonoverlapping;
-                    use core::mem;
-                    let mut ret: $thing = mem::uninitialized();
-                    copy_nonoverlapping(self.as_ptr(),
-                                        ret.as_mut_ptr(),
-                                        $len);
-                    ret
-                }
+                let &$thing(ref dat) = self;
+                $thing(dat.clone())
             }
         }
 

--- a/src/recovery/ffi.rs
+++ b/src/recovery/ffi.rs
@@ -29,7 +29,8 @@ impl RecoverableSignature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> RecoverableSignature { RecoverableSignature([0; 65]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> RecoverableSignature { mem::uninitialized() }
+    #[deprecated(since = "0.15.3", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> RecoverableSignature { RecoverableSignature::new() }
 }
 
 impl Default for RecoverableSignature {

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -57,7 +57,7 @@ impl RecoverableSignature {
     /// representation is nonstandard and defined by the libsecp256k1
     /// library.
     pub fn from_compact(data: &[u8], recid: RecoveryId) -> Result<RecoverableSignature, Error> {
-        let mut ret = unsafe { ffi::RecoverableSignature::blank() };
+        let mut ret = ffi::RecoverableSignature::new();
 
         unsafe {
             if data.len() != 64 {
@@ -103,7 +103,7 @@ impl RecoverableSignature {
     /// for verification
     #[inline]
     pub fn to_standard(&self) -> Signature {
-        let mut ret = unsafe { super_ffi::Signature::blank() };
+        let mut ret = super_ffi::Signature::new();
         unsafe {
             let err = ffi::secp256k1_ecdsa_recoverable_signature_convert(
                 super_ffi::secp256k1_context_no_precomp,
@@ -130,7 +130,7 @@ impl<C: Signing> Secp256k1<C> {
     pub fn sign_recoverable(&self, msg: &Message, sk: &key::SecretKey)
                             -> RecoverableSignature {
 
-        let mut ret = unsafe { ffi::RecoverableSignature::blank() };
+        let mut ret = ffi::RecoverableSignature::new();
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid signature from a valid `Message` and `SecretKey`
@@ -157,7 +157,7 @@ impl<C: Verification> Secp256k1<C> {
     pub fn recover(&self, msg: &Message, sig: &RecoverableSignature)
                    -> Result<key::PublicKey, Error> {
 
-        let mut pk = unsafe { super_ffi::PublicKey::blank() };
+        let mut pk = super_ffi::PublicKey::new();
 
         unsafe {
             if ffi::secp256k1_ecdsa_recover(self.ctx, &mut pk,


### PR DESCRIPTION
the `uninitialized` function is highly unsafe in rust, because rust assumes that everything is correctly initialized (except raw pointers)
so `let a: bool = mem::uninitialized();` for example is an immediate UB.
and of course a lot of other types. 
(No need to worry, right now we only use it for primitive integers array which is not UB)
And it's going to be deprecated soon.
https://doc.rust-lang.org/std/mem/fn.uninitialized.html