### PR TITLE
travis: Speed up Windows jobs by disabling the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-cache: cargo
 
 rust:
   - stable
@@ -18,6 +17,12 @@ matrix:
   exclude:
   - rust: 1.22.0
     os: windows
+
+# Disable caching because it slows down Windows jobs until the point that they timeout when trying
+# to restore the cache. Moreover, caching saves only about one minute in Linux jobs, so it isn't
+# worth the hassle.
+cache:
+  cargo: false
 
 script:
   - cargo build --verbose --features=fuzztarget


### PR DESCRIPTION
I tried multiple options and this seems the best overall. 

Alternatively, we could use some Travis hacks to enable caching on Linux only. But there it saves us at most one minute. So I think it's better to just turn off caching entirely; then we don't need to worry about it anymore.

This reduces the build time for Windows from more than 10 min down to about 7 min.