### PR TITLE
Optimizing travis build time and fixing benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
-cache: cargo
+cache: 
+  directories:
+  - cargo_web
 
 rust:
   - stable
@@ -10,31 +12,34 @@ os:
  - linux
  - windows
 
+addons:
+  chrome: stable
+
 matrix:
-  # rand 0.6 actually needs Rust 1.22, which leads to build failures on Rust 1.14 on Windows.
-  # This is a problem, because
-  #  - we insist on rust 1.22 since #92
-  #  - but "rand" is only an optional dependency.
   exclude:
   - rust: 1.22.0
     os: windows
 
 script:
+  - cargo build --verbose --no-default-features
+  - cargo build --verbose --no-default-features --features="serde"
+  - cargo build --verbose --no-default-features --features="lowmemory"
+  - cargo build --verbose --no-default-features --features="rand"
+  - cargo build --verbose --no-default-features --features="rand serde recovery endomorphism"
+  - cargo build --verbose --no-default-features --features="fuzztarget recovery"
   - cargo build --verbose --features=fuzztarget
   - cargo build --verbose --features=rand
   - cargo test --verbose --features=rand
   - cargo test --verbose --features="rand serde"
   - cargo test --verbose --features="rand serde recovery endomorphism"
-  - cargo build --verbose --no-default-features
-  - cargo build --verbose --no-default-features --features="serde"
-  - cargo build --verbose --no-default-features --features="rand"
-  - cargo build --verbose --no-default-features --features="rand serde recovery endomorphism"
-  - cargo build --verbose --no-default-features --features="fuzztarget recovery"
-  - cargo build --verbose --no-default-features --features="lowmemory"
   - cargo build --verbose
   - cargo test --verbose
-  - cargo build --release
-  - cargo test --release
-  - cargo bench
-  - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cargo doc; fi
-  - if [ "$(rustup show | grep default | grep stable)" != "" -a "$TRAVIS_OS_NAME" = "linux" ]; then cargo install --force cargo-web && cargo web build --target=asmjs-unknown-emscripten && cargo web test --target=asmjs-unknown-emscripten --nodejs; fi
+  - cargo build --verbose --release
+  - cargo test --verbose --release
+  - if [ ${TRAVIS_RUST_VERSION} == "stable" ]; then cargo doc --verbose --features="rand,serde,recovery,endomorphism"; fi
+  - if [ ${TRAVIS_RUST_VERSION} == "nightly" ]; then cargo test --verbose --benches --features=unstable; fi
+  - if [ ${TRAVIS_RUST_VERSION} == "stable" -a "$TRAVIS_OS_NAME" = "linux" ]; then 
+    CARGO_TARGET_DIR=cargo_web cargo install --verbose --force cargo-web && 
+    cargo web build --verbose --target=asmjs-unknown-emscripten && 
+    cargo web test --verbose --target=asmjs-unknown-emscripten; 
+    fi


### PR DESCRIPTION
Hi,
I did a couple of things here:
1. telling rust to use `./cargo_web` dir when installing `cargo web` and then caching that directory.
2. Replacing the nodejs tests with chrome (in my tests the chrome ones are way faster)
3. tried sorting the build/tests so that they makes sense close to each other (build and test with the same features should be one after the other), though I'm not sure if that really made any real difference.
4. Added `cargo test --benches --features=unstable` on nightly, so that it will build the benchmarks (currently they fail compilation).
5. Added the same features from the toml(https://github.com/rust-bitcoin/rust-secp256k1/blob/master/Cargo.toml#L19) to the `cargo doc` test 

And cherry-picked this commit: https://github.com/rust-bitcoin/rust-secp256k1/pull/132/commits/185284ceb5eb5d9c721dc09fa91d799df139965d which fixes the benchmarks

This PR contradicts with #147 and I'm hoping to open another PR today for appveyor windows tests. (that way we can keep the cache and just do the windows builds there) cc @real-or-random 