### PR TITLE
Explicit checks for ZST + null fallbacks

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use core::marker::PhantomData;
-use ffi;
+use ffi::{self, CPtr};
 use types::{c_uint, c_void};
 use Error;
 use Secp256k1;
@@ -181,7 +181,7 @@ impl<'buf, C: Context + 'buf> Secp256k1<C> {
         Ok(Secp256k1 {
             ctx: unsafe {
                 ffi::secp256k1_context_preallocated_create(
-                    buf.as_mut_ptr() as *mut c_void,
+                    buf.as_mut_c_ptr() as *mut c_void,
                     C::FLAGS)
             },
             phantom: PhantomData,

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -19,7 +19,7 @@
 use core::{ops, ptr};
 
 use key::{SecretKey, PublicKey};
-use ffi;
+use ffi::{self, CPtr};
 
 /// A tag used for recovering the public key from a compact signature
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -34,8 +34,8 @@ impl SharedSecret {
             let res = ffi::secp256k1_ecdh(
                 ffi::secp256k1_context_no_precomp,
                 &mut ss,
-                point.as_ptr(),
-                scalar.as_ptr(),
+                point.as_c_ptr(),
+                scalar.as_c_ptr(),
                 ffi::secp256k1_ecdh_hash_function_default,
                 ptr::null_mut(),
             );

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,7 +16,7 @@
 //! # FFI bindings
 //! Direct bindings to the underlying C library functions. These should
 //! not be needed for most users.
-use core::{mem, hash, slice};
+use core::{mem, hash, slice, ptr};
 use types::*;
 
 /// Flag for context to enable no precomputation
@@ -364,6 +364,38 @@ unsafe fn strlen(mut str_ptr: *const c_char) -> usize {
     }
     ctr
 }
+
+
+/// A trait for producing pointers that will always be valid in C. (assuming NULL pointer is a valid no-op)
+/// Rust doesn't promise what pointers does it give to ZST (https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts)
+/// In case the type is empty this trait will give a NULL pointer, which should be handled in C.
+/// 
+pub(crate) trait CPtr {
+    type Target;
+    fn as_c_ptr(&self) -> *const Self::Target;
+    fn as_mut_c_ptr(&mut self) -> *mut Self::Target;
+}
+
+impl<T> CPtr for [T] {
+    type Target = T;
+    fn as_c_ptr(&self) -> *const Self::Target {
+        if self.is_empty() {
+            ptr::null()
+        } else {
+            self.as_ptr()
+        }
+    }
+
+    fn as_mut_c_ptr(&mut self) -> *mut Self::Target {
+        if self.is_empty() {
+            ptr::null::<Self::Target>() as *mut _
+        } else {
+            self.as_mut_ptr()
+        }
+    }
+}
+
+
 
 
 #[cfg(feature = "fuzztarget")]

--- a/src/key.rs
+++ b/src/key.rs
@@ -24,7 +24,7 @@ use super::Error::{self, InvalidPublicKey, InvalidSecretKey};
 use Signing;
 use Verification;
 use constants;
-use ffi;
+use ffi::{self, CPtr};
 
 /// Secret 256-bit key used as `x` in an ECDSA signature
 pub struct SecretKey([u8; constants::SECRET_KEY_SIZE]);
@@ -354,6 +354,18 @@ impl PublicKey {
         }
     }
 }
+
+impl CPtr for PublicKey {
+    type Target = ffi::PublicKey;
+    fn as_c_ptr(&self) -> *const Self::Target {
+        self.as_ptr()
+    }
+
+    fn as_mut_c_ptr(&mut self) -> *mut Self::Target {
+        self.as_mut_ptr()
+    }
+}
+
 
 /// Creates a new public key from a FFI public key
 impl From<ffi::PublicKey> for PublicKey {

--- a/src/key.rs
+++ b/src/key.rs
@@ -117,7 +117,7 @@ impl SecretKey {
         unsafe {
             while ffi::secp256k1_ec_seckey_verify(
                 ffi::secp256k1_context_no_precomp,
-                data.as_ptr(),
+                data.as_c_ptr(),
             ) == 0
             {
                 data = random_32_bytes(rng);
@@ -135,7 +135,7 @@ impl SecretKey {
                 unsafe {
                     if ffi::secp256k1_ec_seckey_verify(
                         ffi::secp256k1_context_no_precomp,
-                        data.as_ptr(),
+                        data.as_c_ptr(),
                     ) == 0
                     {
                         return Err(InvalidSecretKey);
@@ -162,8 +162,8 @@ impl SecretKey {
         unsafe {
             if ffi::secp256k1_ec_privkey_tweak_add(
                 ffi::secp256k1_context_no_precomp,
-                self.as_mut_ptr(),
-                other.as_ptr(),
+                self.as_mut_c_ptr(),
+                other.as_c_ptr(),
             ) != 1
             {
                 Err(Error::InvalidTweak)
@@ -187,8 +187,8 @@ impl SecretKey {
         unsafe {
             if ffi::secp256k1_ec_privkey_tweak_mul(
                 ffi::secp256k1_context_no_precomp,
-                self.as_mut_ptr(),
-                other.as_ptr(),
+                self.as_mut_c_ptr(),
+                other.as_c_ptr(),
             ) != 1
             {
                 Err(Error::InvalidTweak)
@@ -223,7 +223,7 @@ impl PublicKey {
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid `SecretKey` without transmute trickery or something
-            let res = ffi::secp256k1_ec_pubkey_create(secp.ctx, &mut pk, sk.as_ptr());
+            let res = ffi::secp256k1_ec_pubkey_create(secp.ctx, &mut pk, sk.as_c_ptr());
             debug_assert_eq!(res, 1);
         }
         PublicKey(pk)
@@ -237,7 +237,7 @@ impl PublicKey {
             if ffi::secp256k1_ec_pubkey_parse(
                 ffi::secp256k1_context_no_precomp,
                 &mut pk,
-                data.as_ptr(),
+                data.as_c_ptr(),
                 data.len() as usize,
             ) == 1
             {
@@ -259,9 +259,9 @@ impl PublicKey {
             let mut ret_len = constants::PUBLIC_KEY_SIZE as usize;
             let err = ffi::secp256k1_ec_pubkey_serialize(
                 ffi::secp256k1_context_no_precomp,
-                ret.as_mut_ptr(),
+                ret.as_mut_c_ptr(),
                 &mut ret_len,
-                self.as_ptr(),
+                self.as_c_ptr(),
                 ffi::SECP256K1_SER_COMPRESSED,
             );
             debug_assert_eq!(err, 1);
@@ -278,9 +278,9 @@ impl PublicKey {
             let mut ret_len = constants::UNCOMPRESSED_PUBLIC_KEY_SIZE as usize;
             let err = ffi::secp256k1_ec_pubkey_serialize(
                 ffi::secp256k1_context_no_precomp,
-                ret.as_mut_ptr(),
+                ret.as_mut_c_ptr(),
                 &mut ret_len,
-                self.as_ptr(),
+                self.as_c_ptr(),
                 ffi::SECP256K1_SER_UNCOMPRESSED,
             );
             debug_assert_eq!(err, 1);
@@ -303,7 +303,7 @@ impl PublicKey {
         }
         unsafe {
             if ffi::secp256k1_ec_pubkey_tweak_add(secp.ctx, &mut self.0 as *mut _,
-                                                  other.as_ptr()) == 1 {
+                                                  other.as_c_ptr()) == 1 {
                 Ok(())
             } else {
                 Err(Error::InvalidTweak)
@@ -325,7 +325,7 @@ impl PublicKey {
         }
         unsafe {
             if ffi::secp256k1_ec_pubkey_tweak_mul(secp.ctx, &mut self.0 as *mut _,
-                                                  other.as_ptr()) == 1 {
+                                                  other.as_c_ptr()) == 1 {
                 Ok(())
             } else {
                 Err(Error::InvalidTweak)
@@ -339,11 +339,11 @@ impl PublicKey {
     pub fn combine(&self, other: &PublicKey) -> Result<PublicKey, Error> {
         unsafe {
             let mut ret = ffi::PublicKey::new();
-            let ptrs = [self.as_ptr(), other.as_ptr()];
+            let ptrs = [self.as_c_ptr(), other.as_c_ptr()];
             if ffi::secp256k1_ec_pubkey_combine(
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
-                ptrs.as_ptr(),
+                ptrs.as_c_ptr(),
                 2
             ) == 1
             {

--- a/src/key.rs
+++ b/src/key.rs
@@ -232,6 +232,8 @@ impl PublicKey {
     /// Creates a public key directly from a slice
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<PublicKey, Error> {
+        if data.is_empty() {return Err(Error::InvalidPublicKey);}
+
         let mut pk = ffi::PublicKey::new();
         unsafe {
             if ffi::secp256k1_ec_pubkey_parse(

--- a/src/key.rs
+++ b/src/key.rs
@@ -576,6 +576,36 @@ mod test {
             PublicKey::from_slice(&[0x55; constants::PUBLIC_KEY_SIZE]),
             Err(InvalidPublicKey)
         );
+        assert_eq!(
+            PublicKey::from_slice(&[]),
+            Err(InvalidPublicKey)
+        );
+    }
+
+    #[test]
+    fn test_seckey_from_bad_slice() {
+        // Bad sizes
+        assert_eq!(
+            SecretKey::from_slice(&[0; constants::SECRET_KEY_SIZE - 1]),
+            Err(InvalidSecretKey)
+        );
+        assert_eq!(
+            SecretKey::from_slice(&[0; constants::SECRET_KEY_SIZE + 1]),
+            Err(InvalidSecretKey)
+        );
+        // Bad parse
+        assert_eq!(
+            SecretKey::from_slice(&[0xff; constants::SECRET_KEY_SIZE]),
+            Err(InvalidSecretKey)
+        );
+        assert_eq!(
+            SecretKey::from_slice(&[0x00; constants::SECRET_KEY_SIZE]),
+            Err(InvalidSecretKey)
+        );
+        assert_eq!(
+            SecretKey::from_slice(&[]),
+            Err(InvalidSecretKey)
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,8 @@ impl Signature {
 #[inline]
     /// Converts a DER-encoded byte slice to a signature
     pub fn from_der(data: &[u8]) -> Result<Signature, Error> {
+        if data.is_empty() {return Err(Error::InvalidSignature);}
+
         let mut ret = ffi::Signature::new();
 
         unsafe {
@@ -290,6 +292,8 @@ impl Signature {
     /// 2016. It should never be used in new applications. This library does not
     /// support serializing to this "format"
     pub fn from_der_lax(data: &[u8]) -> Result<Signature, Error> {
+        if data.is_empty() {return Err(Error::InvalidSignature);}
+
         unsafe {
             let mut ret = ffi::Signature::new();
             if ffi::ecdsa_signature_parse_der_lax(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub use key::PublicKey;
 pub use context::*;
 use core::marker::PhantomData;
 use core::ops::Deref;
+use ffi::CPtr;
 
 /// An ECDSA signature
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -377,6 +378,17 @@ impl Signature {
             debug_assert!(err == 1);
         }
         ret
+    }
+}
+
+impl CPtr for Signature {
+    type Target = ffi::Signature;
+    fn as_c_ptr(&self) -> *const Self::Target {
+        self.as_ptr()
+    }
+
+    fn as_mut_c_ptr(&mut self) -> *mut Self::Target {
+        self.as_mut_ptr()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ impl Signature {
             if ffi::secp256k1_ecdsa_signature_parse_der(
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
-                data.as_ptr(),
+                data.as_c_ptr(),
                 data.len() as usize,
             ) == 1
             {
@@ -275,7 +275,7 @@ impl Signature {
             if ffi::secp256k1_ecdsa_signature_parse_compact(
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
-                data.as_ptr(),
+                data.as_c_ptr(),
             ) == 1
             {
                 Ok(Signature(ret))
@@ -295,7 +295,7 @@ impl Signature {
             if ffi::ecdsa_signature_parse_der_lax(
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
-                data.as_ptr(),
+                data.as_c_ptr(),
                 data.len() as usize,
             ) == 1
             {
@@ -329,8 +329,8 @@ impl Signature {
             // was already normalized. We don't care.
             ffi::secp256k1_ecdsa_signature_normalize(
                 ffi::secp256k1_context_no_precomp,
-                self.as_mut_ptr(),
-                self.as_ptr(),
+                self.as_mut_c_ptr(),
+                self.as_c_ptr(),
             );
         }
     }
@@ -357,7 +357,7 @@ impl Signature {
                 ffi::secp256k1_context_no_precomp,
                 ret.get_data_mut_ptr(),
                 &mut len,
-                self.as_ptr(),
+                self.as_c_ptr(),
             );
             debug_assert!(err == 1);
             ret.set_len(len);
@@ -372,8 +372,8 @@ impl Signature {
         unsafe {
             let err = ffi::secp256k1_ecdsa_signature_serialize_compact(
                 ffi::secp256k1_context_no_precomp,
-                ret.as_mut_ptr(),
-                self.as_ptr(),
+                ret.as_mut_c_ptr(),
+                self.as_c_ptr(),
             );
             debug_assert!(err == 1);
         }
@@ -595,7 +595,7 @@ impl<C: Context> Secp256k1<C> {
         let mut seed = [0; 32];
         rng.fill_bytes(&mut seed);
         unsafe {
-            let err = ffi::secp256k1_context_randomize(self.ctx, seed.as_ptr());
+            let err = ffi::secp256k1_context_randomize(self.ctx, seed.as_c_ptr());
             // This function cannot fail; it has an error return for future-proofing.
             // We do not expose this error since it is impossible to hit, and we have
             // precedent for not exposing impossible errors (for example in
@@ -621,8 +621,8 @@ impl<C: Signing> Secp256k1<C> {
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid signature from a valid `Message` and `SecretKey`
-            assert_eq!(ffi::secp256k1_ecdsa_sign(self.ctx, &mut ret, msg.as_ptr(),
-                                                 sk.as_ptr(), ffi::secp256k1_nonce_function_rfc6979,
+            assert_eq!(ffi::secp256k1_ecdsa_sign(self.ctx, &mut ret, msg.as_c_ptr(),
+                                                 sk.as_c_ptr(), ffi::secp256k1_nonce_function_rfc6979,
                                                  ptr::null()), 1);
         }
 
@@ -652,7 +652,7 @@ impl<C: Verification> Secp256k1<C> {
     #[inline]
     pub fn verify(&self, msg: &Message, sig: &Signature, pk: &key::PublicKey) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ecdsa_verify(self.ctx, sig.as_ptr(), msg.as_ptr(), pk.as_ptr()) == 0 {
+            if ffi::secp256k1_ecdsa_verify(self.ctx, sig.as_c_ptr(), msg.as_c_ptr(), pk.as_c_ptr()) == 0 {
                 Err(Error::IncorrectSignature)
             } else {
                 Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -122,6 +122,24 @@ macro_rules! impl_array_newtype {
                 &dat[..]
             }
         }
+        impl ::ffi::CPtr for $thing {
+            type Target = $ty;
+            fn as_c_ptr(&self) -> *const Self::Target {
+                if self.is_empty() {
+                    ::core::ptr::null()
+                } else {
+                    self.as_ptr()
+                }
+            }
+
+            fn as_mut_c_ptr(&mut self) -> *mut Self::Target {
+                if self.is_empty() {
+                    ::core::ptr::null::<Self::Target>() as *mut _
+                } else {
+                    self.as_mut_ptr()
+                }
+            }
+        }
     }
 }
 

--- a/src/recovery/ffi.rs
+++ b/src/recovery/ffi.rs
@@ -17,7 +17,7 @@
 
 use core::mem;
 use types::*;
-use ffi::{Context, NonceFn, PublicKey, Signature};
+use ffi::{Context, NonceFn, PublicKey, Signature, CPtr};
 
 /// Library-internal representation of a Secp256k1 signature + recovery ID
 #[repr(C)]

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -66,7 +66,7 @@ impl RecoverableSignature {
             } else if ffi::secp256k1_ecdsa_recoverable_signature_parse_compact(
                 super_ffi::secp256k1_context_no_precomp,
                 &mut ret,
-                data.as_ptr(),
+                data.as_c_ptr(),
                 recid.0,
             ) == 1
             {
@@ -97,9 +97,9 @@ impl RecoverableSignature {
         unsafe {
             let err = ffi::secp256k1_ecdsa_recoverable_signature_serialize_compact(
                 super_ffi::secp256k1_context_no_precomp,
-                ret.as_mut_ptr(),
+                ret.as_mut_c_ptr(),
                 &mut recid,
-                self.as_ptr(),
+                self.as_c_ptr(),
             );
             assert!(err == 1);
         }
@@ -115,7 +115,7 @@ impl RecoverableSignature {
             let err = ffi::secp256k1_ecdsa_recoverable_signature_convert(
                 super_ffi::secp256k1_context_no_precomp,
                 &mut ret,
-                self.as_ptr(),
+                self.as_c_ptr(),
             );
             assert!(err == 1);
         }
@@ -157,8 +157,8 @@ impl<C: Signing> Secp256k1<C> {
                 ffi::secp256k1_ecdsa_sign_recoverable(
                     self.ctx,
                     &mut ret,
-                    msg.as_ptr(),
-                    sk.as_ptr(),
+                    msg.as_c_ptr(),
+                    sk.as_c_ptr(),
                     super_ffi::secp256k1_nonce_function_rfc6979,
                     ptr::null()
                 ),
@@ -180,7 +180,7 @@ impl<C: Verification> Secp256k1<C> {
 
         unsafe {
             if ffi::secp256k1_ecdsa_recover(self.ctx, &mut pk,
-                                            sig.as_ptr(), msg.as_ptr()) != 1 {
+                                            sig.as_c_ptr(), msg.as_c_ptr()) != 1 {
                 return Err(Error::InvalidSignature);
             }
         };

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -58,6 +58,8 @@ impl RecoverableSignature {
     /// representation is nonstandard and defined by the libsecp256k1
     /// library.
     pub fn from_compact(data: &[u8], recid: RecoveryId) -> Result<RecoverableSignature, Error> {
+        if data.is_empty() {return Err(Error::InvalidSignature);}
+
         let mut ret = ffi::RecoverableSignature::new();
 
         unsafe {

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -23,6 +23,7 @@ use super::{Secp256k1, Message, Error, Signature, Verification, Signing};
 use super::ffi as super_ffi;
 pub use key::SecretKey;
 pub use key::PublicKey;
+use self::super_ffi::CPtr;
 
 mod ffi;
 
@@ -82,6 +83,12 @@ impl RecoverableSignature {
         &self.0 as *const _
     }
 
+    /// Obtains a raw mutable pointer suitable for use with FFI functions
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::RecoverableSignature {
+        &mut self.0 as *mut _
+    }
+
     #[inline]
     /// Serializes the recoverable signature in compact format
     pub fn serialize_compact(&self) -> (RecoveryId, [u8; 64]) {
@@ -113,6 +120,18 @@ impl RecoverableSignature {
             assert!(err == 1);
         }
         Signature(ret)
+    }
+}
+
+
+impl CPtr for RecoverableSignature {
+    type Target = ffi::RecoverableSignature;
+    fn as_c_ptr(&self) -> *const Self::Target {
+        self.as_ptr()
+    }
+
+    fn as_mut_c_ptr(&mut self) -> *mut Self::Target {
+        self.as_mut_ptr()
     }
 }
 


### PR DESCRIPTION
This is based off a suggestion by @real-or-random https://github.com/rust-bitcoin/rust-secp256k1/pull/145#issuecomment-523021675

This PR is a combination of #144 and #145 but with one difference, calling `as_c_ptr()` on an empty slice will result in a null pointer.

The point is to have explicit checks for empty slices, but if somewhere we miss a check then this will make sure a null is produced which will be caught by `ARG_CHECK` in upstream and make the code panic. 