### PR TITLE
Trying to prevent accidental usage of the fuzztarget functions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
   - cargo test --verbose --features="rand rand-std"
   - cargo test --verbose --features="rand serde"
   - cargo test --verbose --features="rand serde recovery endomorphism"
+  - cargo test --verbose --lib --features=fuzztarget
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --verbose --release

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -108,6 +108,7 @@ mod fuzz_dummy {
                                                    _noncefn: NonceFn,
                                                    _noncedata: *const c_void)
                                                    -> c_int {
+        assert!(UNSAFE_CRYPTO_FUZZING, UNSAFE_CRYPTO_WARNING);
         assert!(!cx.is_null() && (*cx).flags() & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
         assert!((*cx).flags() & SECP256K1_START_SIGN == SECP256K1_START_SIGN);
         if secp256k1_ec_seckey_verify(cx, sk) != 1 { return 0; }

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -79,9 +79,10 @@ mod fuzz_dummy {
     use self::std::ptr;
     use super::RecoverableSignature;
     use types::*;
-    use ::{Signature, Context, PublicKey, NonceFn, secp256k1_ec_seckey_verify,
-        SECP256K1_START_NONE, SECP256K1_START_VERIFY, SECP256K1_START_SIGN};
-
+    use ::{
+        secp256k1_ec_seckey_verify, Context, NonceFn, PublicKey, Signature, SECP256K1_START_NONE,
+        SECP256K1_START_SIGN, SECP256K1_START_VERIFY, UNSAFE_CRYPTO_FUZZING, UNSAFE_CRYPTO_WARNING,
+    };
     pub unsafe fn secp256k1_ecdsa_recoverable_signature_parse_compact(_cx: *const Context, _sig: *mut RecoverableSignature,
                                                                       _input64: *const c_uchar, _recid: c_int)
                                                                       -> c_int {

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -162,7 +162,7 @@ impl SharedSecret {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "fuzztarget")))]
 mod tests {
     use rand::thread_rng;
     use super::SharedSecret;

--- a/src/key.rs
+++ b/src/key.rs
@@ -443,7 +443,7 @@ impl<'de> ::serde::Deserialize<'de> for PublicKey {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "fuzztarget")))]
 mod test {
     use Secp256k1;
     use from_hex;

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -191,7 +191,7 @@ impl<C: Verification> Secp256k1<C> {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "fuzztarget")))]
 mod tests {
     use rand::{RngCore, thread_rng};
 


### PR DESCRIPTION
A suggestion of a way to solve https://github.com/rust-bitcoin/rust-secp256k1/issues/90


This is a result of a conversation with @real-or-random and some feedback from @TheBlueMatt 

The part i'm less sure of is the tests here, because rust tests run in concurrent threads and I want to test both with the bool set and without I had to use some Mutex to make sure they don't run together


Another thing that isn't too nice is that we need to put this is all the fuzzing functions.
if proc macros were stabilized before 1.22 we could've wrote an attribute macro and made it a bit nicer but it would've still required doing it on every function.