### PR TITLE
Pin version of build dependency cc to <1.0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+# 0.15.4 - 2019-09-06
+
+- Add `rand-std` feature.
+- Pin the cc build-dep version to `< 1.0.42` to remain
+  compatible with rustc 1.22.0.
+- Changed all `as_*ptr()` to a new safer `CPtr` trait
+
 # 0.15.2 - 2019-08-08
 
 - Add feature `lowmemory` that reduces the EC mult window size to require

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.15.3"
+version = "0.15.4"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ links = "secp256k1"
 features = [ "rand", "serde", "recovery", "endomorphism" ]
 
 [build-dependencies]
-cc = ">= 1.0.28"
+cc = ">= 1.0.28, < 1.0.42"
 
 [lib]
 name = "secp256k1"


### PR DESCRIPTION
Version 1.0.42 broke compatibility with rustc 1.22.0.