### PR TITLE
Fixes and tests for the ffi

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -41,8 +41,9 @@ pub type NonceFn = unsafe extern "C" fn(nonce32: *mut c_uchar,
                                         msg32: *const c_uchar,
                                         key32: *const c_uchar,
                                         algo16: *const c_uchar,
+                                        data: *mut c_void,
                                         attempt: c_uint,
-                                        data: *const c_void);
+);
 
 /// Hash function to use to post-process an ECDH point to get
 /// a shared secret.
@@ -50,7 +51,7 @@ pub type EcdhHashFn = unsafe extern "C" fn(
     output: *mut c_uchar,
     x: *const c_uchar,
     y: *const c_uchar,
-    data: *const c_void,
+    data: *mut c_void,
 );
 
 /// A Secp256k1 context, containing various precomputed values and such
@@ -186,7 +187,7 @@ extern "C" {
                                                    out_len: *mut usize, sig: *const Signature)
                                                    -> c_int;
 
-    pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *const c_uchar,
+    pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *mut c_uchar,
                                                        sig: *const Signature)
                                                        -> c_int;
 

--- a/src/recovery/ffi.rs
+++ b/src/recovery/ffi.rs
@@ -45,7 +45,7 @@ extern "C" {
                                                                input64: *const c_uchar, recid: c_int)
                                                                -> c_int;
 
-    pub fn secp256k1_ecdsa_recoverable_signature_serialize_compact(cx: *const Context, output64: *const c_uchar,
+    pub fn secp256k1_ecdsa_recoverable_signature_serialize_compact(cx: *const Context, output64: *mut c_uchar,
                                                                    recid: *mut c_int, sig: *const RecoverableSignature)
                                                                    -> c_int;
 
@@ -82,7 +82,7 @@ mod fuzz_dummy {
         unimplemented!();
     }
 
-    pub unsafe fn secp256k1_ecdsa_recoverable_signature_serialize_compact(_cx: *const Context, _output64: *const c_uchar,
+    pub unsafe fn secp256k1_ecdsa_recoverable_signature_serialize_compact(_cx: *const Context, _output64: *mut c_uchar,
                                                                           _recid: *mut c_int, _sig: *const RecoverableSignature)
                                                                           -> c_int {
         unimplemented!();

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,3 +24,18 @@ impl fmt::Debug for c_void {
         f.pad("c_void")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::raw;
+    use std::any::TypeId;
+    use types;
+
+    #[test]
+    fn verify_types() {
+        assert_eq!(TypeId::of::<types::c_int>(), TypeId::of::<raw::c_int>());
+        assert_eq!(TypeId::of::<types::c_uchar>(), TypeId::of::<raw::c_uchar>());
+        assert_eq!(TypeId::of::<types::c_uint>(), TypeId::of::<raw::c_uint>());
+        assert_eq!(TypeId::of::<types::c_char>(), TypeId::of::<raw::c_char>());
+    }
+}


### PR DESCRIPTION
#161 got me thinking, I went over all the ffi declarations here and found a few errors.
also added tests to make sure the types we're using are the same libstd exposes.

(Reviewers please double check me against the header files :) )

Tried thinking of ways to integrate https://github.com/rust-lang/rust-bindgen into our testing, but the only way to compare 2 function signatures is by manually writing functions that accept a specific `Fn` type and feeding it both checking that it compiles. and that's a lot of work and more stuff to maintain :/

The problem is ffi mistakes can easily lead to undetectable UB.


FYI, didn't include here the fix that #161 is fixing. new contributors is a good thing :)

FYI2, this is a *breaking change* heh.