### PR TITLE
zeroize secretkey on drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,8 @@ default-features = false
 version = "1.0"
 optional = true
 default-features = false
+
+[dependencies.zeroize]
+version = "0.10"
+optional = true
+default-features = false

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -22,7 +22,8 @@ use key::{SecretKey, PublicKey};
 use ffi::{self, CPtr};
 
 /// A tag used for recovering the public key from a compact signature
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(not(feature = "zeroize"), derive(Copy))]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SharedSecret(ffi::SharedSecret);
 
 impl SharedSecret {

--- a/src/key.rs
+++ b/src/key.rs
@@ -57,6 +57,14 @@ impl str::FromStr for SecretKey {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.zeroize()
+    }
+}
+
 /// The number 1 encoded as a secret key
 pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
                                           0, 0, 0, 0, 0, 0, 0, 0,
@@ -64,7 +72,8 @@ pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
                                           0, 0, 0, 0, 0, 0, 0, 1]);
 
 /// A Secp256k1 public key, used for verification of signatures
-#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(not(feature = "zeroize"), derive(Copy))]
+#[derive(Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
 pub struct PublicKey(ffi::PublicKey);
 
 impl fmt::LowerHex for PublicKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@
 #[cfg(all(test, feature = "serde"))] extern crate serde_test;
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 #[cfg(any(test, feature = "std"))] extern crate core;
+#[cfg(feature = "zeroize")] extern crate zeroize;
 
 use core::{fmt, ptr, str};
 
@@ -164,7 +165,8 @@ use core::ops::Deref;
 use ffi::CPtr;
 
 /// An ECDSA signature
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(not(feature = "zeroize"), derive(Copy))]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Signature(ffi::Signature);
 
 /// A DER serialized Signature

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,7 +16,16 @@
 // This is a macro that routinely comes in handy
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {
+        #[cfg(not(feature = "zeroize"))]
         impl Copy for $thing {}
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $thing {
+            fn zeroize(&mut self) {
+                let &mut $thing(ref mut dat) = self;
+                dat.zeroize()
+            }
+        }
 
         impl $thing {
             #[inline]
@@ -62,7 +71,7 @@ macro_rules! impl_array_newtype {
             #[inline]
             fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
                 self[..].cmp(&other[..])
-            }            
+            }
         }
 
         impl Clone for $thing {


### PR DESCRIPTION
I'd like to be able to be sure a private key is not in memory once I'm done with it. Since I included a new dependency, and removed `Copy` from several key types, I have put this behind a feature flag.