### PR TITLE
Remove always debug mode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,7 +45,6 @@ fn main() {
     base_config.include("depend/secp256k1/")
                .include("depend/secp256k1/include")
                .include("depend/secp256k1/src")
-               .debug(true)
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
                .define("SECP256K1_BUILD", Some("1"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged


### PR DESCRIPTION
By *not* specifying debug=true `cc` will use the same settings that the user used for the rust compilation (i.e. in release no debug, and in cargo build with debug)
which in my opinion is the correct way to do this.
https://docs.rs/cc/1.0.45/cc/struct.Build.html#method.debug