### PR TITLE
Add tests for no-std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ script:
   - cargo test --verbose --release
   - if [ ${TRAVIS_RUST_VERSION} == "stable" ]; then cargo doc --verbose --features="rand,serde,recovery,endomorphism"; fi
   - if [ ${TRAVIS_RUST_VERSION} == "nightly" ]; then cargo test --verbose --benches --features=unstable; fi
+  - if [ ${TRAVIS_RUST_VERSION} == "nightly" -a "$TRAVIS_OS_NAME" = "linux" ]; then 
+    cd no_std_test &&
+    cargo run --release | grep -q "Verified Successfully";
+    fi
   - if [ ${TRAVIS_RUST_VERSION} == "stable" -a "$TRAVIS_OS_NAME" = "linux" ]; then 
     CARGO_TARGET_DIR=cargo_web cargo install --verbose --force cargo-web && 
     cargo web build --verbose --target=asmjs-unknown-emscripten && 

--- a/no_std_test/Cargo.toml
+++ b/no_std_test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Elichai Turkel <elichai.turkel@gmail.com>"]
 
 [dependencies]
-secp256k1 = { path = "../", default-features = false }
+secp256k1 = { path = "../", default-features = false, features = ["rand"] }
 libc = { version = "0.2", default-features = false }
 
 

--- a/no_std_test/Cargo.toml
+++ b/no_std_test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "no_std_test"
+version = "0.1.0"
+authors = ["Elichai Turkel <elichai.turkel@gmail.com>"]
+
+[dependencies]
+secp256k1 = { path = "../", default-features = false }
+libc = { version = "0.2", default-features = false }
+
+
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+panic = "abort"

--- a/no_std_test/Cargo.toml
+++ b/no_std_test/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 authors = ["Elichai Turkel <elichai.turkel@gmail.com>"]
 
 [dependencies]
-secp256k1 = { path = "../", default-features = false, features = ["rand"] }
+secp256k1 = { path = "../", default-features = false, features = ["serde", "rand"] }
 libc = { version = "0.2", default-features = false }
+serde_cbor = { version = "0.10", default-features = false } # A random serializer that supports no-std.
 
 
 [profile.release]

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -1,3 +1,44 @@
+// Bitcoin secp256k1 bindings
+// Written in 2019 by
+//   Elichai Turkel
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # secp256k1 no-std test.
+//! This binary is a short smallest rust code to produce a working binary *without libstd*.
+//! This gives us 2 things: 
+//!     1. Test that the parts of the code that should work in a no-std enviroment actually work.
+//!     2. Test that we don't accidentally import libstd into `secp256k1`.
+//! 
+//! The first is tested using the following command `cargo run --release | grep -q "Verified Successfully"`.
+//! (Making sure that it successfully printed that. i.e. it didn't abort before that).
+//! 
+//! The second is tested by the fact that it compiles. if we accidentally link against libstd we should see the following error:
+//! `error[E0152]: duplicate lang item found`.
+//! Example:
+//! ```
+//! error[E0152]: duplicate lang item found: `eh_personality`.
+//!   --> src/main.rs:37:1
+//!    |
+//! 37 | pub extern "C" fn rust_eh_personality() {}
+//!    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//!    |
+//!    = note: first defined in crate `panic_unwind` (which `std` depends on).
+//! ```
+//! 
+//! Notes: 
+//!     * Requires `panic=abort` and `--release` to not depend on libunwind(which is provided usually by libstd) https://github.com/rust-lang/rust/issues/47493
+//!     * Requires linking with `libc` for calling `printf`.
+//!     
+
 #![feature(lang_items)]
 #![feature(start)]
 #![feature(core_intrinsics)]

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -1,0 +1,90 @@
+#![feature(lang_items)]
+#![feature(start)]
+#![feature(core_intrinsics)]
+#![feature(panic_info_message)]
+#![no_std]
+extern crate libc;
+extern crate secp256k1;
+
+use core::fmt::*;
+use core::intrinsics;
+use core::panic::PanicInfo;
+
+use secp256k1::*;
+
+#[start]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    let mut buf = [0u8; 600_000];
+    let size = Secp256k1::preallocate_size();
+    unsafe { libc::printf("needed size: %d\n\0".as_ptr() as _, size) };
+
+    let secp = Secp256k1::preallocated_new(&mut buf).unwrap();
+    let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
+    let public_key = PublicKey::from_secret_key(&secp, &secret_key);
+    let message = Message::from_slice(&[0xab; 32]).expect("32 bytes");
+
+    let sig = secp.sign(&message, &secret_key);
+    assert!(secp.verify(&message, &sig, &public_key).is_ok());
+    unsafe { libc::printf("Verified Successfully!\n\0".as_ptr() as _) };
+    0
+}
+
+// These functions are used by the compiler, but not
+// for a bare-bones hello world. These are normally
+// provided by libstd.
+#[lang = "eh_personality"]
+#[no_mangle]
+pub extern "C" fn rust_eh_personality() {}
+
+// This function may be needed based on the compilation target.
+#[lang = "eh_unwind_resume"]
+#[no_mangle]
+pub extern "C" fn rust_eh_unwind_resume() {}
+
+const MAX_PRINT: usize = 511;
+struct Print {
+    loc: usize,
+    buf: [u8; 512],
+}
+
+impl Print {
+    pub fn new() -> Self {
+        Self {
+            loc: 0,
+            buf: [0u8; 512],
+        }
+    }
+
+    pub fn print(&self) {
+        unsafe {
+            let newline = "\n";
+            libc::printf(self.buf.as_ptr() as _);
+            libc::printf(newline.as_ptr() as _);
+        }
+    }
+}
+
+impl Write for Print {
+    fn write_str(&mut self, s: &str) -> Result {
+        let curr = self.loc;
+        if curr + s.len() > MAX_PRINT {
+            unsafe {
+                libc::printf("overflow\n\0".as_ptr() as _);
+                intrinsics::abort();
+            }
+        }
+        self.loc += s.len();
+        self.buf[curr..self.loc].copy_from_slice(s.as_bytes());
+        Ok(())
+    }
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    unsafe { libc::printf("shi1\n\0".as_ptr() as _) };
+    let msg = info.message().unwrap();
+    let mut buf = Print::new();
+    write(&mut buf, *msg).unwrap();
+    buf.print();
+    unsafe { intrinsics::abort() }
+}


### PR DESCRIPTION
This will not compile if std is somehow involved.
You can see yourself by removing `default-features = false` from the Cargo.toml and you'll get:
```
error[E0152]: duplicate lang item found: `eh_personality`.
  --> src/main.rs:37:1
   |
37 | pub extern "C" fn rust_eh_personality() {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: first defined in crate `panic_unwind` (which `std` depends on).

error[E0152]: duplicate lang item found: `panic_impl`.
  --> src/main.rs:83:1
   |
83 | / fn panic(info: &PanicInfo) -> ! {
84 | |     unsafe { libc::printf("shi1\n\0".as_ptr() as _) };
85 | |     let msg = info.message().unwrap();
86 | |     let mut buf = Print::new();
...  |
89 | |     unsafe { intrinsics::abort() }
90 | | }
   | |_^
   |
   = note: first defined in crate `std` (which `secp256k1` depends on).

error: aborting due to 2 previous errors
```

This currently only runs in release mode due to a bug that debug mode always tries to link to libunwind (which isn't available) even when we use abort instead of panic.