### PR TITLE
Add a feature to disable replacing C symbols with rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,15 @@ path = "src/lib.rs"
 [features]
 unstable = []
 default = ["std"]
-fuzztarget = []
 std = ["rand/std"]
 recovery = []
 endomorphism = []
 lowmemory = []
+
+# Do not use this feature! HAZMAT. (meant for Bitcoin Core only)
 dont_replace_c_symbols = []
+# Do not use this feature! HAZMAT. (meant for Fuzzing only. this is *BROKEN CRYPTOGRAPHY*)
+fuzztarget = []
 
 [dev-dependencies]
 rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ std = ["rand/std"]
 recovery = []
 endomorphism = []
 lowmemory = []
+dont_replace_c_symbols = []
 
 [dev-dependencies]
 rand = "0.6"

--- a/build.rs
+++ b/build.rs
@@ -52,14 +52,15 @@ fn main() {
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
                .define("USE_SCALAR_INV_BUILTIN", Some("1"))
-               .define("ENABLE_MODULE_ECDH", Some("1"))
-               .define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
+               .define("ENABLE_MODULE_ECDH", Some("1"));
 
     if cfg!(feature = "lowmemory") {
         base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
     } else {
         base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
     }
+    #[cfg(not(feature = "dont_replace_c_symbols"))]
+    base_config.define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
     #[cfg(feature = "endomorphism")]
     base_config.define("USE_ENDOMORPHISM", Some("1"));
     #[cfg(feature = "recovery")]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -256,7 +256,7 @@ extern "C" {
 }
 
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "dont_replace_c_symbols")))]
 #[no_mangle]
 /// A reimplementation of the C function `secp256k1_context_create` in rust.
 ///
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn secp256k1_context_create(flags: c_uint) -> *mut Context
     secp256k1_context_preallocated_create(ptr as *mut c_void, flags)
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "dont_replace_c_symbols")))]
 #[no_mangle]
 /// A reimplementation of the C function `secp256k1_context_destroy` in rust.
 ///
@@ -300,6 +300,7 @@ pub unsafe extern "C" fn secp256k1_context_destroy(ctx: *mut Context) {
 }
 
 
+#[cfg(not(feature = "dont_replace_c_symbols"))]
 #[no_mangle]
 /// **This function is an override for the C function, this is the an edited version of the original description:**
 ///
@@ -326,6 +327,7 @@ pub unsafe extern "C" fn secp256k1_default_illegal_callback_fn(message: *const c
     panic!("[libsecp256k1] illegal argument. {}", msg);
 }
 
+#[cfg(not(feature = "dont_replace_c_symbols"))]
 #[no_mangle]
 /// **This function is an override for the C function, this is the an edited version of the original description:**
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,6 +717,7 @@ mod tests {
 
 
     #[test]
+    #[cfg(not(feature = "dont_replace_c_symbols"))]
     fn test_manual_create_destroy() {
         let ctx_full = unsafe { ffi::secp256k1_context_create(AllPreallocated::FLAGS) };
         let ctx_sign = unsafe { ffi::secp256k1_context_create(SignOnlyPreallocated::FLAGS) };


### PR DESCRIPTION
Hi,
Requested in IRC by @TheBlueMatt the main use case is bitcoin core integration.
such that you can use upstream's libsecp256k1 with this library.

this feature *is not* compatible with `no-std`.