### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -62,7 +62,7 @@ macro_rules! impl_array_newtype {
             #[inline]
             fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
                 self[..].cmp(&other[..])
-            }            
+            }
         }
 
         impl Clone for $thing {


### PR DESCRIPTION
Removes some trailing whitespace in the `macros.rs` file.