### PR TITLE
Fix a safety problem and make the Context trait unimplementable

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -15,7 +15,7 @@ pub unsafe trait Context : private::Sealed {
     /// A constant description of the context.
     const DESCRIPTION: &'static str;
     /// A function to deallocate the memory when the context is dropped.
-    fn deallocate(ptr: *mut [u8]);
+    unsafe fn deallocate(ptr: *mut [u8]);
 }
 
 /// Marker trait for indicating that an instance of `Secp256k1` can be used for signing.
@@ -78,8 +78,8 @@ mod std_only {
         const FLAGS: c_uint = ffi::SECP256K1_START_SIGN;
         const DESCRIPTION: &'static str = "signing only";
 
-        fn deallocate(ptr: *mut [u8]) {
-            let _ = unsafe { Box::from_raw(ptr) };
+        unsafe fn deallocate(ptr: *mut [u8]) {
+            let _ = Box::from_raw(ptr);
         }
     }
 
@@ -87,8 +87,8 @@ mod std_only {
         const FLAGS: c_uint = ffi::SECP256K1_START_VERIFY;
         const DESCRIPTION: &'static str = "verification only";
 
-        fn deallocate(ptr: *mut [u8]) {
-            let _ = unsafe { Box::from_raw(ptr) };
+        unsafe fn deallocate(ptr: *mut [u8]) {
+            let _ = Box::from_raw(ptr);
         }
     }
 
@@ -96,8 +96,8 @@ mod std_only {
         const FLAGS: c_uint = VerifyOnly::FLAGS | SignOnly::FLAGS;
         const DESCRIPTION: &'static str = "all capabilities";
 
-        fn deallocate(ptr: *mut [u8]) {
-            let _ = unsafe { Box::from_raw(ptr) };
+        unsafe fn deallocate(ptr: *mut [u8]) {
+            let _ = Box::from_raw(ptr);
         }
     }
 
@@ -152,7 +152,6 @@ mod std_only {
             }
         }
     }
-
 }
 
 impl<'buf> Signing for SignOnlyPreallocated<'buf> {}
@@ -165,7 +164,7 @@ unsafe impl<'buf> Context for SignOnlyPreallocated<'buf> {
     const FLAGS: c_uint = ffi::SECP256K1_START_SIGN;
     const DESCRIPTION: &'static str = "signing only";
 
-    fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut [u8]) {
         // Allocated by the user
     }
 }
@@ -174,7 +173,7 @@ unsafe impl<'buf> Context for VerifyOnlyPreallocated<'buf> {
     const FLAGS: c_uint = ffi::SECP256K1_START_VERIFY;
     const DESCRIPTION: &'static str = "verification only";
 
-    fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut [u8]) {
         // Allocated by the user
     }
 }
@@ -183,7 +182,7 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
     const FLAGS: c_uint = SignOnlyPreallocated::FLAGS | VerifyOnlyPreallocated::FLAGS;
     const DESCRIPTION: &'static str = "all capabilities";
 
-    fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut [u8]) {
         // Allocated by the user
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,8 +571,10 @@ impl<C: Context> Eq for Secp256k1<C> { }
 
 impl<C: Context> Drop for Secp256k1<C> {
     fn drop(&mut self) {
-        unsafe { ffi::secp256k1_context_preallocated_destroy(self.ctx) };
-        C::deallocate(self.buf);
+        unsafe {
+            ffi::secp256k1_context_preallocated_destroy(self.ctx);
+            C::deallocate(self.buf);
+        }
     }
 }
 


### PR DESCRIPTION
Hi,
I wanted to make a PR to a make the `Context`[1] trait unimplementable, but then I realized that the `Context::deallocate()` function isn't marked as an unsafe function but it can de-reference and free a raw pointer.
this means that a user using only safe code can violate rust's memory guarantees which is obviously not a good thing.

besides that, I found out that there's a trick used in rust's libstd to make traits unimplementable: https://github.com/rust-lang/rfcs/issues/2822
So I used that trick here to make all of `Contex`,`Signing`, `Verification` unimplementable outside of this library.

[1] https://docs.rs/secp256k1/0.16.0/secp256k1/trait.Context.html