### PR TITLE
Wrap Secp256k1 from raw context in a ManuallyDrop

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use ptr;
 use ffi::{self, CPtr};
 use ffi::types::{c_uint, c_void};
@@ -227,12 +228,12 @@ impl<'buf> Secp256k1<AllPreallocated<'buf>> {
     /// * The user must handle the freeing of the context(using the correct functions) by himself.
     /// * Violating these may lead to Undefined Behavior.
     ///
-    pub unsafe fn from_raw_all(raw_ctx: *mut ffi::Context) -> Secp256k1<AllPreallocated<'buf>> {
-        Secp256k1 {
+    pub unsafe fn from_raw_all(raw_ctx: *mut ffi::Context) -> ManuallyDrop<Secp256k1<AllPreallocated<'buf>>> {
+        ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
             buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
-        }
+        })
     }
 }
 
@@ -259,12 +260,12 @@ impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
     /// * The user must handle the freeing of the context(using the correct functions) by himself.
     /// * This list *is not* exhaustive, and any violation may lead to Undefined Behavior.,
     ///
-    pub unsafe fn from_raw_signining_only(raw_ctx: *mut ffi::Context) -> Secp256k1<SignOnlyPreallocated<'buf>> {
-        Secp256k1 {
+    pub unsafe fn from_raw_signining_only(raw_ctx: *mut ffi::Context) -> ManuallyDrop<Secp256k1<SignOnlyPreallocated<'buf>>> {
+        ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
             buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
-        }
+        })
     }
 }
 
@@ -291,11 +292,11 @@ impl<'buf> Secp256k1<VerifyOnlyPreallocated<'buf>> {
     /// * The user must handle the freeing of the context(using the correct functions) by himself.
     /// * This list *is not* exhaustive, and any violation may lead to Undefined Behavior.,
     ///
-    pub unsafe fn from_raw_verification_only(raw_ctx: *mut ffi::Context) -> Secp256k1<VerifyOnlyPreallocated<'buf>> {
-        Secp256k1 {
+    pub unsafe fn from_raw_verification_only(raw_ctx: *mut ffi::Context) -> ManuallyDrop<Secp256k1<VerifyOnlyPreallocated<'buf>>> {
+        ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
             buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
-        }
+        })
     }
 }


### PR DESCRIPTION
Fix a problem discovered by @apoelstra in #179.
Even though it didn't try to deallocate the buffer (it shouldn't) it still called `secp256k1_context_preallocated_destroy` which makes the Context unsuable in the eyes of libsecp256k1.
this function should only be called by the owner of the context.
so we return the context wrapped in a `ManuallyDrop` such that the use can do whatever he thinks should be done when dropped (or call `into_inner` to let our `Drop` impl call `secp256k1_context_preallocated_destroy`)