### PR TITLE
Fix fuzztarget symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ script:
   - cargo build --verbose --no-default-features --features="rand"
   - cargo build --verbose --no-default-features --features="rand serde recovery endomorphism"
   - cargo build --verbose --no-default-features --features="fuzztarget recovery"
-  - cargo build --verbose --features=fuzztarget
   - cargo build --verbose --features=rand
+  - cargo test --no-run --features=fuzztarget
   - cargo test --verbose --features=rand
   - cargo test --verbose --features="rand rand-std"
   - cargo test --verbose --features="rand serde"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+# 0.17.2
+- Fix linking in the `fuzztarget` feature.
+
 # 0.17.1
 
 - Correctly prefix the secp256k1-sys links field in Cargo.toml.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "secp256k1"
-version = "0.17.1"
+version = "0.17.2"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -444,10 +444,14 @@ mod fuzz_dummy {
         SECP256K1_START_NONE, SECP256K1_START_VERIFY, SECP256K1_START_SIGN,
         SECP256K1_SER_COMPRESSED, SECP256K1_SER_UNCOMPRESSED};
 
+    #[allow(non_upper_case_globals)]
+    pub static secp256k1_context_no_precomp: &Context = &Context(0);
+
     extern "C" {
+        #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_1_1_ecdh_hash_function_default")]
         pub static secp256k1_ecdh_hash_function_default: EcdhHashFn;
+        #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_1_1_nonce_function_rfc6979")]
         pub static secp256k1_nonce_function_rfc6979: NonceFn;
-        pub static secp256k1_context_no_precomp: *const Context;
     }
 
     // Contexts


### PR DESCRIPTION
This is why https://github.com/rust-bitcoin/rust-bitcoin/pull/380 tests fail.

I fixed the linking but changed 1 logic thing.
I replaced `secp256k1_context_no_precomp` from being linked to the actual `secp256k1_context` to just be a pointer to a local instance of our Context.
I did it for 2 reasons:
1. Maybe we can skip even compiling libsecp for the fuzztarget one day.
2. Avoid a theoretical UB, i.e. our `Context` struct doesn't match `secp256k1_context`. it's meant to be used just as an Opaque pointer. but the `fuzztarget` actually dereferences that pointer and access the `c_uint` parameter in there. which might correspond  to some padding in `secp256k1_context` -> access uninitialized values.

I wanted to also replace the 2 function pointers with `null` but apparently rust doesn't allow null function pointers https://rust-lang.github.io/unsafe-code-guidelines/layout/function-pointers.html