### PR TITLE
Bump -sys version to 0.1.2

### DIFF
--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-sys"
-version = "0.1.1"
+version = "0.1.2"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>" ]


### PR DESCRIPTION
I accidentally bumped the "main" crate on https://github.com/rust-bitcoin/rust-secp256k1/pull/191 when I should've bumped only the `-sys` one