### PR TITLE
Missing return c_int in NonceFn

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -63,7 +63,7 @@ pub type NonceFn = unsafe extern "C" fn(nonce32: *mut c_uchar,
                                         algo16: *const c_uchar,
                                         data: *mut c_void,
                                         attempt: c_uint,
-);
+) -> c_int;
 
 /// Hash function to use to post-process an ECDH point to get
 /// a shared secret.
@@ -490,13 +490,6 @@ mod fuzz_dummy {
         assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
         1
     }
-
-    // TODO secp256k1_context_set_illegal_callback
-    // TODO secp256k1_context_set_error_callback
-    // (Actually, I don't really want these exposed; if either of these
-    // are ever triggered it indicates a bug in rust-secp256k1, since
-    // one goal is to use Rust's type system to eliminate all possible
-    // bad inputs.)
 
     // Pubkeys
     /// Parse 33/65 byte pubkey into PublicKey, losing compressed information


### PR DESCRIPTION
https://github.com/rust-bitcoin/rust-secp256k1/blob/master/secp256k1-sys/depend/secp256k1/include/secp256k1.h#L100

Just like https://github.com/rust-bitcoin/rust-secp256k1/issues/160

Also removed the TODO set_callback comments that were missed here: https://github.com/rust-bitcoin/rust-secp256k1/pull/143 (https://github.com/rust-bitcoin/rust-secp256k1/blob/255d1ddd6042862b2f232418e55754da37452b2c/src/ffi.rs#L413)