### PR TITLE
Fix typos in the external-symbols feature(bug)

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -63,7 +63,6 @@ fn main() {
     } else {
         base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
     }
-    #[cfg(not(feature = "dont_replace_c_symbols"))]
     base_config.define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
     #[cfg(feature = "endomorphism")]
     base_config.define("USE_ENDOMORPHISM", Some("1"));

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -295,7 +295,7 @@ extern "C" {
 // Returns: a newly created context object.
 //  In:      flags: which parts of the context to initialize.
 #[no_mangle]
-#[cfg(all(feature = "std", not(feature = "external_symbols")))]
+#[cfg(all(feature = "std", not(feature = "external-symbols")))]
 pub unsafe extern "C" fn rustsecp256k1_v0_1_1_context_create(flags: c_uint) -> *mut Context {
     use std::mem;
     assert!(mem::align_of::<usize>() >= mem::align_of::<u8>());
@@ -312,7 +312,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_1_1_context_create(flags: c_uint) -> *
     secp256k1_context_preallocated_create(ptr as *mut c_void, flags)
 }
 
-#[cfg(all(feature = "std", not(feature = "external_symbols")))]
+#[cfg(all(feature = "std", not(feature = "external-symbols")))]
 pub unsafe fn secp256k1_context_create(flags: c_uint) -> *mut Context {
     rustsecp256k1_v0_1_1_context_create(flags)
 }
@@ -324,7 +324,7 @@ pub unsafe fn secp256k1_context_create(flags: c_uint) -> *mut Context {
 /// The pointer shouldn't be used after passing to this function, consider it as passing it to `free()`.
 ///
 #[no_mangle]
-#[cfg(all(feature = "std", not(feature = "external_symbols")))]
+#[cfg(all(feature = "std", not(feature = "external-symbols")))]
 pub unsafe extern "C" fn rustsecp256k1_v0_1_1_context_destroy(ctx: *mut Context) {
     secp256k1_context_preallocated_destroy(ctx);
     let ctx: *mut usize = ctx as *mut usize;
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_1_1_context_destroy(ctx: *mut Context)
     let _ = Box::from_raw(slice as *mut [usize]);
 }
 
-#[cfg(all(feature = "std", not(feature = "external_symbols")))]
+#[cfg(all(feature = "std", not(feature = "external-symbols")))]
 pub unsafe fn secp256k1_context_destroy(ctx: *mut Context) {
     rustsecp256k1_v0_1_1_context_destroy(ctx)
 }
@@ -360,7 +360,7 @@ pub unsafe fn secp256k1_context_destroy(ctx: *mut Context) {
 /// See also secp256k1_default_error_callback_fn.
 ///
 #[no_mangle]
-#[cfg(not(feature = "external_symbols"))]
+#[cfg(not(feature = "external-symbols"))]
 pub unsafe extern "C" fn rustsecp256k1_v0_1_1_default_illegal_callback_fn(message: *const c_char, _data: *mut c_void) {
     use core::str;
     let msg_slice = slice::from_raw_parts(message as *const u8, strlen(message));
@@ -383,7 +383,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_1_1_default_illegal_callback_fn(messag
 /// See also secp256k1_default_illegal_callback_fn.
 ///
 #[no_mangle]
-#[cfg(not(feature = "external_symbols"))]
+#[cfg(not(feature = "external-symbols"))]
 pub unsafe extern "C" fn rustsecp256k1_v0_1_1_default_error_callback_fn(message: *const c_char, _data: *mut c_void) {
     use core::str;
     let msg_slice = slice::from_raw_parts(message as *const u8, strlen(message));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,6 @@ mod tests {
 
 
     #[test]
-    #[cfg(not(feature = "dont_replace_c_symbols"))]
     fn test_manual_create_destroy() {
         let ctx_full = unsafe { ffi::secp256k1_context_create(AllPreallocated::FLAGS) };
         let ctx_sign = unsafe { ffi::secp256k1_context_create(SignOnlyPreallocated::FLAGS) };


### PR DESCRIPTION
Hi,
This was introduced in https://github.com/rust-bitcoin/rust-secp256k1/pull/169

There was a typo in some of the feature gates from `external-symbols` to `external_symbols`.
it wasn't caught because it was either not `pub extern "C"` (like `secp256k1_context_create`) or prefixed with the `rustsecp256k1_v0_1_1_*` which made it not collide with other symbols.

Second thing is we still have some leftovers from the `dont_replace_c_symbols` feature (https://github.com/rust-bitcoin/rust-secp256k1/pull/177) which we no longer support since #169 was merged and prefixed all the symbols so they're not really easily usable in C/C++ code anyway.
this feature isn't in our Cargo.toml anyway so these are no-ops anyway now.