### PR TITLE
Fix broken benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "secp256k1"
 path = "src/lib.rs"
 
 [features]
-unstable = []
+unstable = ["recovery", "rand-std"]
 default = ["std"]
 std = ["secp256k1-sys/std"]
 rand-std = ["rand/std"]

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -14,13 +14,13 @@
 
 //! # secp256k1 no-std test.
 //! This binary is a short smallest rust code to produce a working binary *without libstd*.
-//! This gives us 2 things: 
+//! This gives us 2 things:
 //!     1. Test that the parts of the code that should work in a no-std enviroment actually work.
 //!     2. Test that we don't accidentally import libstd into `secp256k1`.
-//! 
+//!
 //! The first is tested using the following command `cargo run --release | grep -q "Verified Successfully"`.
 //! (Making sure that it successfully printed that. i.e. it didn't abort before that).
-//! 
+//!
 //! The second is tested by the fact that it compiles. if we accidentally link against libstd we should see the following error:
 //! `error[E0152]: duplicate lang item found`.
 //! Example:
@@ -33,11 +33,11 @@
 //!    |
 //!    = note: first defined in crate `panic_unwind` (which `std` depends on).
 //! ```
-//! 
-//! Notes: 
+//!
+//! Notes:
 //!     * Requires `panic=abort` and `--release` to not depend on libunwind(which is provided usually by libstd) https://github.com/rust-lang/rust/issues/47493
 //!     * Requires linking with `libc` for calling `printf`.
-//!     
+//!
 
 #![feature(lang_items)]
 #![feature(start)]
@@ -52,10 +52,10 @@ use core::fmt::{self, write, Write};
 use core::intrinsics;
 use core::panic::PanicInfo;
 
+use secp256k1::ecdh::SharedSecret;
 use secp256k1::rand::{self, RngCore};
 use secp256k1::serde::Serialize;
 use secp256k1::*;
-use secp256k1::ecdh::SharedSecret;
 
 use serde_cbor::de;
 use serde_cbor::ser::SliceWrite;
@@ -111,23 +111,10 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     })}.unwrap();
     assert_ne!(x_arr, [0u8; 32]);
     assert_ne!(&y_arr[..], &[0u8; 32][..]);
-    
 
     unsafe { libc::printf("Verified Successfully!\n\0".as_ptr() as _) };
     0
 }
-
-// These functions are used by the compiler, but not
-// for a bare-bones hello world. These are normally
-// provided by libstd.
-#[lang = "eh_personality"]
-#[no_mangle]
-pub extern "C" fn rust_eh_personality() {}
-
-// This function may be needed based on the compilation target.
-#[lang = "eh_unwind_resume"]
-#[no_mangle]
-pub extern "C" fn rust_eh_unwind_resume() {}
 
 const MAX_PRINT: usize = 511;
 struct Print {

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -304,7 +304,6 @@ mod benches {
         let s = Secp256k1::signing_only();
         let (sk, pk) = s.generate_keypair(&mut thread_rng());
 
-        let s = Secp256k1::new();
         bh.iter( || {
             let res = SharedSecret::new(&pk, &sk);
             black_box(res);

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -363,6 +363,10 @@ mod tests {
 
 #[cfg(all(test, feature = "unstable"))]
 mod benches {
+    use rand::{thread_rng, RngCore};
+    use test::{Bencher, black_box};
+    use super::{Message, Secp256k1};
+
     #[bench]
     pub fn bench_recover(bh: &mut Bencher) {
         let s = Secp256k1::new();


### PR DESCRIPTION
Currently the benchmarks in recovery weren't compiling.
I fixed and made travis compile them too.

I experimented with switching to criterion which looks pretty cool (works on stable, produces html plots, remembers last results to show you improvements/regressions etc.)
But dev-dependencies aren't allowed to be optional so this will break the tests on 1.22.0
https://github.com/rust-lang/cargo/issues/1596

(We could add it to the regular dependencies though, like @TheBlueMatt is doing with mutagen https://github.com/rust-bitcoin/rust-lightning/pull/453/files#r368478034 )