### PR TITLE
Add optional bitcoin_hashes feature to implement ThirtyTwoByteHash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
     cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose;
     fi
   - cargo build --verbose --no-default-features
+  - cargo build --verbose --no-default-features --features="bitcoin_hashes"
   - cargo build --verbose --no-default-features --features="serde"
   - cargo build --verbose --no-default-features --features="lowmemory"
   - cargo build --verbose --no-default-features --features="rand"
@@ -37,6 +38,7 @@ script:
   - cargo build --verbose --no-default-features --features="fuzztarget recovery"
   - cargo build --verbose --features=rand
   - cargo test --no-run --features=fuzztarget
+  - cargo test --verbose --features="bitcoin_hashes"
   - cargo test --verbose --features=rand
   - cargo test --verbose --features="rand rand-std"
   - cargo test --verbose --features="rand serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,10 @@ bitcoin_hashes = "0.7"
 wasm-bindgen-test = "0.3"
 rand = { version = "0.6", features = ["wasm-bindgen"] }
 
+[dependencies.bitcoin_hashes]
+version = "0.7"
+optional = true
+
 [dependencies.rand]
 version = "0.6"
 optional = true


### PR DESCRIPTION
This PR adds `bitcoin_hashes` as an optional dependency to implement the `ThirtyTwoByteHash` trait for the relevant hash types. It also adds a shortcut function `Message::from_hashed_data<H: Hash>(&[u8])`.