### PR TITLE
Allow all-zero messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,10 +454,6 @@ impl Message {
     /// Converts a `MESSAGE_SIZE`-byte slice to a message object
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<Message, Error> {
-        if data == [0; constants::MESSAGE_SIZE] {
-            return Err(Error::InvalidMessage);
-        }
-
         match data.len() {
             constants::MESSAGE_SIZE => {
                 let mut ret = [0; constants::MESSAGE_SIZE];
@@ -1007,10 +1003,7 @@ mod tests {
                    Err(InvalidMessage));
         assert_eq!(Message::from_slice(&[0; constants::MESSAGE_SIZE + 1]),
                    Err(InvalidMessage));
-        assert_eq!(
-            Message::from_slice(&[0; constants::MESSAGE_SIZE]),
-            Err(InvalidMessage)
-        );
+        assert!(Message::from_slice(&[0; constants::MESSAGE_SIZE]).is_ok());
         assert!(Message::from_slice(&[1; constants::MESSAGE_SIZE]).is_ok());
     }
 


### PR DESCRIPTION
In Ethereum's `ecrecover` precompile, we need to operate on the raw preimage/message. The message is user input and can be all-zero. However, the current `Message` struct treats all-zero message as `InvalidMessage`. This breaks some of our use cases.

cc https://github.com/openethereum/openethereum/issues/11603