### PR TITLE
Replace `ThirtyTwoByteHash` trait impl for more generic `From`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ secp256k1-sys = { version = "0.1.1", default-features = false, path = "./secp256
 rand = "0.6"
 rand_core = "0.4"
 serde_test = "1.0"
-bitcoin_hashes = "0.7"
+bitcoin_hashes = { git = "https://github.com/thomaseizinger/bitcoin_hashes.git", branch = "impl-into" }
 
 [dependencies.rand]
 version = "0.6"

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -6,7 +6,7 @@ use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey, Signature, Sign
 
 fn verify<C: Verification>(secp: &Secp256k1<C>, msg: &[u8], sig: [u8; 64], pubkey: [u8; 33]) -> Result<bool, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from(msg);
     let sig = Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
@@ -15,7 +15,7 @@ fn verify<C: Verification>(secp: &Secp256k1<C>, msg: &[u8], sig: [u8; 64], pubke
 
 fn sign<C: Signing>(secp: &Secp256k1<C>, msg: &[u8], seckey: [u8; 32]) -> Result<Signature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from(msg);
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign(&msg, &seckey))
 }

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -8,7 +8,7 @@ use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verifi
 
 fn recover<C: Verification>(secp: &Secp256k1<C>,msg: &[u8],sig: [u8; 64],recovery_id: u8) -> Result<PublicKey, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from(msg);
     let id = RecoveryId::from_i32(recovery_id as i32)?;
     let sig = RecoverableSignature::from_compact(&sig, id)?;
 
@@ -17,7 +17,7 @@ fn recover<C: Verification>(secp: &Secp256k1<C>,msg: &[u8],sig: [u8; 64],recover
 
 fn sign_recovery<C: Signing>(secp: &Secp256k1<C>, msg: &[u8], seckey: [u8; 32]) -> Result<RecoverableSignature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from(msg);
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_recoverable(&msg, &seckey))
 }

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -167,7 +167,6 @@ mod tests {
     use rand::thread_rng;
     use super::SharedSecret;
     use super::super::Secp256k1;
-    use Error;
 
     #[test]
     fn ecdh() {

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -208,7 +208,7 @@ mod tests {
 
         let mut msg = [0u8; 32];
         thread_rng().fill_bytes(&mut msg);
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from(msg);
 
         // Try key generation
         let (sk, pk) = full.generate_keypair(&mut thread_rng());
@@ -240,7 +240,7 @@ mod tests {
                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
         let sk = SecretKey::from_slice(&one).unwrap();
-        let msg = Message::from_slice(&one).unwrap();
+        let msg = Message::from(one);
 
         let sig = s.sign_recoverable(&msg, &sk);
         assert_eq!(Ok(sig), RecoverableSignature::from_compact(&[
@@ -262,7 +262,7 @@ mod tests {
 
         let mut msg = [0u8; 32];
         thread_rng().fill_bytes(&mut msg);
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from(msg);
 
         let (sk, pk) = s.generate_keypair(&mut thread_rng());
 
@@ -271,7 +271,7 @@ mod tests {
 
         let mut msg = [0u8; 32];
         thread_rng().fill_bytes(&mut msg);
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from(msg);
         assert_eq!(s.verify(&msg, &sig, &pk), Err(IncorrectSignature));
 
         let recovered_key = s.recover(&msg, &sigr).unwrap();
@@ -285,7 +285,7 @@ mod tests {
 
         let mut msg = [0u8; 32];
         thread_rng().fill_bytes(&mut msg);
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from(msg);
 
         let (sk, pk) = s.generate_keypair(&mut thread_rng());
 
@@ -299,7 +299,7 @@ mod tests {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
 
-        let msg = Message::from_slice(&[0x55; 32]).unwrap();
+        let msg = Message::from([0x55; 32]);
 
         // Zero is not a valid sig
         let sig = RecoverableSignature::from_compact(&[0; 64], RecoveryId(0)).unwrap();
@@ -372,7 +372,7 @@ mod benches {
         let s = Secp256k1::new();
         let mut msg = [0u8; 32];
         thread_rng().fill_bytes(&mut msg);
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from(msg);
         let (sk, _) = s.generate_keypair(&mut thread_rng());
         let sig = s.sign_recoverable(&msg, &sk);
 


### PR DESCRIPTION
This patch replaces the `ThirtyTwoByteHash` trait with a more generic `From` impl that allows us to construct a message from any 32-byte array.

There is a companion PR for `bitcoin_hashes` that provides said impls which plays nicely together with this: https://github.com/rust-bitcoin/bitcoin_hashes/pull/81

Judging from the comment on the original `ThirtyTwoByteHash` trait, the idea of this trait was to make good use of the type system to prevent conversions that make semantically no sense.
Hence, in an ideal world, the bytes going into a message should always come from a hash function.

I would argue that this is unnecessarily restrictive and the more general `From` impl is more useful and allows for type interactions that are more pleasant to use (see the updated examples).

Also, in practice, we already allow users to construct a message from arbitrary bytes using the `from_slice` function. The downside of this function is that imposes a runtime error that in many cases "can never happen", yet we have to deal with in in the type system.