### PR TITLE
Define ECMULT_GEN_PREC_BITS

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -52,12 +52,13 @@ fn main() {
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
                .define("SECP256K1_BUILD", Some("1"))
+               .define("ENABLE_MODULE_ECDH", Some("1"))
+               .define("ECMULT_GEN_PREC_BITS", Some("4"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
-               .define("USE_SCALAR_INV_BUILTIN", Some("1"))
-               .define("ENABLE_MODULE_ECDH", Some("1"));
-
+               .define("USE_SCALAR_INV_BUILTIN", Some("1"));
+    
     if cfg!(feature = "lowmemory") {
         base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
     } else {


### PR DESCRIPTION
This is configurable in upstream now.

Fixes #214.

So far, this just sets it to `4`. It's tempting to set it to `2` when `lowmemory` is enabled
but `lowmemory` is about RAM and not about binary size. This is better addressed by
a resolution of #193.