### PR TITLE
Add negate support

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -243,6 +243,14 @@ extern "C" {
 //TODO secp256k1_ec_privkey_export
 //TODO secp256k1_ec_privkey_import
 
+    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_1_1_ec_privkey_negate")]
+    pub fn secp256k1_ec_privkey_negate(cx: *const Context,
+                                       sk: *mut c_uchar) -> c_int;
+
+    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_1_1_ec_pubkey_negate")]
+    pub fn secp256k1_ec_pubkey_negate(cx: *const Context,
+                                      pk: *mut PublicKey) -> c_int;
+
     #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_1_1_ec_privkey_tweak_add")]
     pub fn secp256k1_ec_privkey_tweak_add(cx: *const Context,
                                           sk: *mut c_uchar,

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -702,6 +702,20 @@ mod fuzz_dummy {
 //TODO secp256k1_ec_privkey_export
 //TODO secp256k1_ec_privkey_import
 
+    pub unsafe fn secp256k1_ec_privkey_negate(cx: *const Context,
+                                              sk: *mut c_uchar) -> c_int {
+        assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
+        if secp256k1_ec_seckey_verify(cx, sk) != 1 { return 0; }
+        1
+    }
+
+    pub unsafe fn secp256k1_ec_pubkey_negate(cx: *const Context,
+                                             pk: *mut PublicKey) -> c_int {
+        assert!(!cx.is_null() && (*cx).0 as u32 & !(SECP256K1_START_NONE | SECP256K1_START_VERIFY | SECP256K1_START_SIGN) == 0);
+        if test_pk_validate(cx, pk) != 1 { return 0; }
+        1
+    }
+
     /// Copies the first 16 bytes of tweak into the last 16 bytes of sk
     pub unsafe fn secp256k1_ec_privkey_tweak_add(cx: *const Context,
                                                  sk: *mut c_uchar,

--- a/src/key.rs
+++ b/src/key.rs
@@ -149,6 +149,19 @@ impl SecretKey {
     }
 
     #[inline]
+    /// Negates one secret key.
+    pub fn negate_assign(
+        &mut self
+    ) {
+        unsafe {
+            ffi::secp256k1_ec_privkey_negate(
+                ffi::secp256k1_context_no_precomp,
+                self.as_mut_c_ptr()
+            );
+        }
+    }
+
+    #[inline]
     /// Adds one secret key to another, modulo the curve order. WIll
     /// return an error if the resulting key would be invalid or if
     /// the tweak was not a 32-byte length slice.
@@ -289,6 +302,22 @@ impl PublicKey {
             debug_assert_eq!(ret_len, ret.len());
         }
         ret
+    }
+
+    #[inline]
+    /// Negates the pk to the pk `self` in place
+    /// Will return an error if the pk would be invalid.
+    pub fn negate_assign<C: Verification>(
+        &mut self,
+        secp: &Secp256k1<C>
+    ) -> Result<(), Error> {
+        unsafe {
+            if ffi::secp256k1_ec_pubkey_negate(secp.ctx, &mut self.0 as *mut _) == 1 {
+                Ok(())
+            } else {
+                Err(Error::InvalidPublicKey)
+            }
+        }
     }
 
     #[inline]
@@ -750,6 +779,27 @@ mod test {
         assert!(sk2.mul_assign(&sk1[..]).is_ok());
         assert!(pk2.mul_assign(&s, &sk1[..]).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk2), pk2);
+    }
+
+    #[test]
+    fn test_negation() {
+        let s = Secp256k1::new();
+
+        let (mut sk, mut pk) = s.generate_keypair(&mut thread_rng());
+
+        let original_sk = sk;
+        let original_pk = pk;
+
+        assert_eq!(PublicKey::from_secret_key(&s, &sk), pk);
+        sk.negate_assign();
+        assert!(pk.negate_assign(&s).is_ok());
+        assert_ne!(original_sk, sk);
+        assert_ne!(original_pk, pk);
+        sk.negate_assign();
+        assert!(pk.negate_assign(&s).is_ok());
+        assert_eq!(original_sk, sk);
+        assert_eq!(original_pk, pk);
+        assert_eq!(PublicKey::from_secret_key(&s, &sk), pk);
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -154,10 +154,11 @@ impl SecretKey {
         &mut self
     ) {
         unsafe {
-            ffi::secp256k1_ec_privkey_negate(
+            let res = ffi::secp256k1_ec_privkey_negate(
                 ffi::secp256k1_context_no_precomp,
                 self.as_mut_c_ptr()
             );
+            debug_assert_eq!(res, 1);
         }
     }
 
@@ -310,13 +311,10 @@ impl PublicKey {
     pub fn negate_assign<C: Verification>(
         &mut self,
         secp: &Secp256k1<C>
-    ) -> Result<(), Error> {
+    ) {
         unsafe {
-            if ffi::secp256k1_ec_pubkey_negate(secp.ctx, &mut self.0 as *mut _) == 1 {
-                Ok(())
-            } else {
-                Err(Error::InvalidPublicKey)
-            }
+            let res = ffi::secp256k1_ec_pubkey_negate(secp.ctx, &mut self.0 as *mut _);
+            debug_assert_eq!(res, 1);
         }
     }
 
@@ -792,11 +790,11 @@ mod test {
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk), pk);
         sk.negate_assign();
-        assert!(pk.negate_assign(&s).is_ok());
+        pk.negate_assign(&s);
         assert_ne!(original_sk, sk);
         assert_ne!(original_pk, pk);
         sk.negate_assign();
-        assert!(pk.negate_assign(&s).is_ok());
+        pk.negate_assign(&s);
         assert_eq!(original_sk, sk);
         assert_eq!(original_pk, pk);
         assert_eq!(PublicKey::from_secret_key(&s, &sk), pk);


### PR DESCRIPTION
Hi, I added negate interfaces for Rust.

`secp256k1.h` has the interfaces, but the rust side doesn't have. 
Could you take in the changes into this crate?