### PR TITLE
Add an optional global, static context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,9 @@ script:
   - cargo test --verbose --features="rand rand-std"
   - cargo test --verbose --features="rand serde"
   - cargo test --verbose --features="rand serde recovery endomorphism"
+  - if [ ${TRAVIS_RUST_VERSION} != "1.22.0" ]; then
+    cargo test --verbose --features global-context;
+    fi
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --verbose --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 endomorphism = ["secp256k1-sys/endomorphism"]
 lowmemory = ["secp256k1-sys/lowmemory"]
-global-context = []
+global-context = ["std", "rand"]
 
 # Use this feature to not compile the bundled libsecp256k1 C symbols,
 # but use external ones. Use this only if you know what you are doing!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 endomorphism = ["secp256k1-sys/endomorphism"]
 lowmemory = ["secp256k1-sys/lowmemory"]
+global-context = []
 
 # Use this feature to not compile the bundled libsecp256k1 C symbols,
 # but use external ones. Use this only if you know what you are doing!

--- a/src/context.rs
+++ b/src/context.rs
@@ -31,7 +31,9 @@ pub mod global {
             static ONCE: Once = Once::new();
             static mut CONTEXT: Option<Secp256k1<All>> = None;
             ONCE.call_once(|| unsafe {
-                CONTEXT = Some(Secp256k1::new());
+                let mut ctx = Secp256k1::new();
+                ctx.randomize(&mut rand::thread_rng());
+                CONTEXT = Some(ctx);
             });
             unsafe { CONTEXT.as_ref().unwrap() }
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,36 @@ use Secp256k1;
 #[cfg(feature = "std")]
 pub use self::std_only::*;
 
+#[cfg(feature = "global-context")]
+/// Module implementing a singleton pattern for a global `Secp256k1` context
+pub mod global {
+    use std::ops::Deref;
+    use std::sync::Once;
+    use ::{Secp256k1, All};
+
+    /// Proxy struct for global `SECP256K1` context
+    pub struct GlobalContext {
+        __private: (),
+    }
+
+    /// A global, static context to avoid repeatedly creating contexts where one can't be passed
+    pub static SECP256K1: &GlobalContext = &GlobalContext { __private: () };
+
+    impl Deref for GlobalContext {
+        type Target = Secp256k1<All>;
+
+        fn deref(&self) -> &Self::Target {
+            static ONCE: Once = Once::new();
+            static mut CONTEXT: Option<Secp256k1<All>> = None;
+            ONCE.call_once(|| unsafe {
+                CONTEXT = Some(Secp256k1::new());
+            });
+            unsafe { CONTEXT.as_ref().unwrap() }
+        }
+    }
+}
+
+
 /// A trait for all kinds of Context's that Lets you define the exact flags and a function to deallocate memory.
 /// It shouldn't be possible to implement this for types outside this crate.
 pub unsafe trait Context : private::Sealed {


### PR DESCRIPTION
Add an optional global, static context to avoid creating new ones over and over again when there's no option to pass a context. According to my understanding the context is immutable, doesn't do any locking internally and is basically just a bunch of lookup-tables.

As this might not be useful for everyone, introduces a dependency and would bump the minimum rust version to 1.27.2 I hid the functionality behind the new `global-context` feature. While these limitations are a bit annoying I still think this crate is the right place for something like that (instead of a bunch of other crates doing the same, leading to a bunch of redundant, static contexts).