### PR TITLE
Small modernization after MSRV bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - if [ ${TRAVIS_RUST_VERSION} == "stable" -a "$TRAVIS_OS_NAME" = "linux" ]; then
     clang --version &&
     CARGO_TARGET_DIR=wasm cargo install --verbose --force wasm-pack &&
-    sed -i 's/\[lib\]/[lib]\ncrate-type = ["cdylib", "rlib"]/' Cargo.toml &&
+    printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml &&
     CC=clang-9 wasm-pack build &&
     CC=clang-9 wasm-pack test --node;
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "secp256k1"
 version = "0.19.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
@@ -16,10 +15,6 @@ autoexamples = false # Remove when edition 2018 https://github.com/rust-lang/car
 # Should make docs.rs show all functions, even those behind non-default features
 [package.metadata.docs.rs]
 features = [ "rand", "rand-std", "serde", "recovery", "endomorphism" ]
-
-[lib]
-name = "secp256k1"
-path = "src/lib.rs"
 
 [features]
 unstable = ["recovery", "rand-std"]
@@ -40,6 +35,10 @@ fuzztarget = ["secp256k1-sys/fuzztarget"]
 
 [dependencies]
 secp256k1-sys = { version = "0.3.0", default-features = false, path = "./secp256k1-sys" }
+bitcoin_hashes = { version = "0.9", optional = true }
+rand = { version = "0.6", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+
 
 [dev-dependencies]
 rand = "0.6"
@@ -51,19 +50,6 @@ bitcoin_hashes = "0.9"
 wasm-bindgen-test = "0.3"
 rand = { version = "0.6", features = ["wasm-bindgen"] }
 
-[dependencies.bitcoin_hashes]
-version = "0.9"
-optional = true
-
-[dependencies.rand]
-version = "0.6"
-optional = true
-default-features = false
-
-[dependencies.serde]
-version = "1.0"
-optional = true
-default-features = false
 
 [[example]]
 name = "sign_verify_recovery"

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -21,10 +21,6 @@ features = [ "recovery", "endomorphism", "lowmemory" ]
 [build-dependencies]
 cc = "1.0.28"
 
-[lib]
-name = "secp256k1_sys"
-path = "src/lib.rs"
-
 [features]
 default = ["std"]
 recovery = []

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -16,16 +16,13 @@
 //! Direct bindings to the underlying C library functions. These should
 //! not be needed for most users.
 
-#![crate_type = "lib"]
-#![crate_type = "rlib"]
-#![crate_type = "dylib"]
-#![crate_name = "secp256k1_sys"]
+// Coding conventions
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
 
-#![cfg_attr(all(not(test), not(fuzztarget), not(feature = "std")), no_std)]
-#![cfg_attr(feature = "dev", allow(unstable_features))]
-#![cfg_attr(feature = "dev", feature(plugin))]
-#![cfg_attr(feature = "dev", plugin(clippy))]
-
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
@@ -467,7 +464,7 @@ mod fuzz_dummy {
     use self::std::{ptr, mem};
     use self::std::boxed::Box;
     use types::*;
-    use ::{Signature, Context, NonceFn, EcdhHashFn, PublicKey,
+    use {Signature, Context, NonceFn, EcdhHashFn, PublicKey,
         SECP256K1_START_NONE, SECP256K1_START_VERIFY, SECP256K1_START_SIGN,
         SECP256K1_SER_COMPRESSED, SECP256K1_SER_UNCOMPRESSED};
 

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -94,9 +94,6 @@ impl_raw_debug!(PublicKey);
 impl PublicKey {
     /// Create a new (zeroed) public key usable for the FFI interface
     pub fn new() -> PublicKey { PublicKey([0; 64]) }
-    /// Create a new (uninitialized) public key usable for the FFI interface
-    #[deprecated(since = "0.15.3", note = "Please use the new function instead")]
-    pub unsafe fn blank() -> PublicKey { PublicKey::new() }
 }
 
 impl Default for PublicKey {
@@ -120,9 +117,6 @@ impl_raw_debug!(Signature);
 impl Signature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> Signature { Signature([0; 64]) }
-    /// Create a new (uninitialized) signature usable for the FFI interface
-    #[deprecated(since = "0.15.3", note = "Please use the new function instead")]
-    pub unsafe fn blank() -> Signature { Signature::new() }
 }
 
 impl Default for Signature {

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -130,7 +130,7 @@ macro_rules! impl_array_newtype {
                 &dat[..]
             }
         }
-        impl ::CPtr for $thing {
+        impl $crate::CPtr for $thing {
             type Target = $ty;
             fn as_c_ptr(&self) -> *const Self::Target {
                 if self.is_empty() {

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -28,9 +28,6 @@ impl_raw_debug!(RecoverableSignature);
 impl RecoverableSignature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> RecoverableSignature { RecoverableSignature([0; 65]) }
-    /// Create a new (uninitialized) signature usable for the FFI interface
-    #[deprecated(since = "0.15.3", note = "Please use the new function instead")]
-    pub unsafe fn blank() -> RecoverableSignature { RecoverableSignature::new() }
 }
 
 impl Default for RecoverableSignature {

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,7 +14,7 @@ pub use self::std_only::*;
 pub mod global {
     use std::ops::Deref;
     use std::sync::Once;
-    use ::{Secp256k1, All};
+    use {Secp256k1, All};
 
     /// Proxy struct for global `SECP256K1` context
     pub struct GlobalContext {


### PR DESCRIPTION
Now that we bumped the MSRV to 1.29 I went over the code and did a little cleanup, most of it could have done a while ago but some only after this bump(the inclusive range usage)

I also deleted the deprecated `blank()` functions which were deprecated ~17 months ago and 4 releases.
