### PR TITLE
Making sure everything is aligned correctly. Succeeder of #141

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -53,6 +53,7 @@ use core::intrinsics;
 use core::panic::PanicInfo;
 
 use secp256k1::ecdh::SharedSecret;
+use secp256k1::ffi::types::AlignedType;
 use secp256k1::rand::{self, RngCore};
 use secp256k1::serde::Serialize;
 use secp256k1::*;
@@ -82,7 +83,7 @@ impl RngCore for FakeRng {
 
 #[start]
 fn start(_argc: isize, _argv: *const *const u8) -> isize {
-    let mut buf = [0u8; 600_000];
+    let mut buf = [AlignedType::zeroed(); 37_000];
     let size = Secp256k1::preallocate_size();
     unsafe { libc::printf("needed size: %d\n\0".as_ptr() as _, size) };
 
@@ -161,5 +162,5 @@ fn panic(info: &PanicInfo) -> ! {
     let mut buf = Print::new();
     write(&mut buf, *msg).unwrap();
     buf.print();
-    unsafe { intrinsics::abort() }
+    intrinsics::abort()
 }

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -21,6 +21,9 @@ features = [ "recovery", "endomorphism", "lowmemory" ]
 [build-dependencies]
 cc = "1.0.28"
 
+[dev-dependencies]
+libc = "0.2"
+
 [features]
 default = ["std"]
 recovery = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,6 @@
 use core::marker::PhantomData;
-use core::mem::ManuallyDrop;
-use ptr;
-use ffi::{self, CPtr};
+use core::mem::{self, ManuallyDrop};
+use ffi::{self, CPtr, types::AlignedType};
 use ffi::types::{c_uint, c_void};
 use Error;
 use Secp256k1;
@@ -50,7 +49,7 @@ pub unsafe trait Context : private::Sealed {
     /// A constant description of the context.
     const DESCRIPTION: &'static str;
     /// A function to deallocate the memory when the context is dropped.
-    unsafe fn deallocate(ptr: *mut [u8]);
+    unsafe fn deallocate(ptr: *mut u8, size: usize);
 }
 
 /// Marker trait for indicating that an instance of `Secp256k1` can be used for signing.
@@ -93,6 +92,8 @@ mod std_only {
     impl private::Sealed for VerifyOnly {}
 
     use super::*;
+    use std::alloc;
+    const ALIGN_TO: usize = mem::align_of::<AlignedType>();
 
     /// Represents the set of capabilities needed for signing.
     pub enum SignOnly {}
@@ -113,8 +114,9 @@ mod std_only {
         const FLAGS: c_uint = ffi::SECP256K1_START_SIGN;
         const DESCRIPTION: &'static str = "signing only";
 
-        unsafe fn deallocate(ptr: *mut [u8]) {
-            let _ = Box::from_raw(ptr);
+        unsafe fn deallocate(ptr: *mut u8, size: usize) {
+            let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
+            alloc::dealloc(ptr, layout);
         }
     }
 
@@ -122,8 +124,9 @@ mod std_only {
         const FLAGS: c_uint = ffi::SECP256K1_START_VERIFY;
         const DESCRIPTION: &'static str = "verification only";
 
-        unsafe fn deallocate(ptr: *mut [u8]) {
-            let _ = Box::from_raw(ptr);
+        unsafe fn deallocate(ptr: *mut u8, size: usize) {
+            let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
+            alloc::dealloc(ptr, layout);
         }
     }
 
@@ -131,8 +134,9 @@ mod std_only {
         const FLAGS: c_uint = VerifyOnly::FLAGS | SignOnly::FLAGS;
         const DESCRIPTION: &'static str = "all capabilities";
 
-        unsafe fn deallocate(ptr: *mut [u8]) {
-            let _ = Box::from_raw(ptr);
+        unsafe fn deallocate(ptr: *mut u8, size: usize) {
+            let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
+            alloc::dealloc(ptr, layout);
         }
     }
 
@@ -142,12 +146,13 @@ mod std_only {
             #[cfg(target_arch = "wasm32")]
             ffi::types::sanity_checks_for_wasm();
 
-            let buf = vec![0u8; Self::preallocate_size_gen()].into_boxed_slice();
-            let ptr = Box::into_raw(buf);
+            let size = unsafe { ffi::secp256k1_context_preallocated_size(C::FLAGS) };
+            let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
+            let ptr = unsafe {alloc::alloc(layout)};
             Secp256k1 {
                 ctx: unsafe { ffi::secp256k1_context_preallocated_create(ptr as *mut c_void, C::FLAGS) },
                 phantom: PhantomData,
-                buf: ptr,
+                size,
             }
         }
     }
@@ -181,12 +186,13 @@ mod std_only {
 
     impl<C: Context> Clone for Secp256k1<C> {
         fn clone(&self) -> Secp256k1<C> {
-            let clone_size = unsafe {ffi::secp256k1_context_preallocated_clone_size(self.ctx)};
-            let ptr_buf = Box::into_raw(vec![0u8; clone_size].into_boxed_slice());
+            let size = unsafe {ffi::secp256k1_context_preallocated_clone_size(self.ctx as _)};
+            let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
+            let ptr = unsafe {alloc::alloc(layout)};
             Secp256k1 {
-                ctx: unsafe { ffi::secp256k1_context_preallocated_clone(self.ctx, ptr_buf as *mut c_void) },
+                ctx: unsafe { ffi::secp256k1_context_preallocated_clone(self.ctx, ptr as *mut c_void) },
                 phantom: PhantomData,
-                buf: ptr_buf,
+                size,
             }
         }
     }
@@ -202,7 +208,7 @@ unsafe impl<'buf> Context for SignOnlyPreallocated<'buf> {
     const FLAGS: c_uint = ffi::SECP256K1_START_SIGN;
     const DESCRIPTION: &'static str = "signing only";
 
-    unsafe fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut u8, _size: usize) {
         // Allocated by the user
     }
 }
@@ -211,7 +217,7 @@ unsafe impl<'buf> Context for VerifyOnlyPreallocated<'buf> {
     const FLAGS: c_uint = ffi::SECP256K1_START_VERIFY;
     const DESCRIPTION: &'static str = "verification only";
 
-    unsafe fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut u8, _size: usize) {
         // Allocated by the user
     }
 }
@@ -220,7 +226,7 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
     const FLAGS: c_uint = SignOnlyPreallocated::FLAGS | VerifyOnlyPreallocated::FLAGS;
     const DESCRIPTION: &'static str = "all capabilities";
 
-    unsafe fn deallocate(_ptr: *mut [u8]) {
+    unsafe fn deallocate(_ptr: *mut u8, _size: usize) {
         // Allocated by the user
     }
 }
@@ -241,7 +247,7 @@ impl<'buf, C: Context + 'buf> Secp256k1<C> {
                     C::FLAGS)
             },
             phantom: PhantomData,
-            buf: buf as *mut [u8],
+            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
         })
     }
 }
@@ -271,7 +277,7 @@ impl<'buf> Secp256k1<AllPreallocated<'buf>> {
         ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
-            buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
+            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
         })
     }
 }
@@ -303,7 +309,7 @@ impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
         ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
-            buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
+            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
         })
     }
 }
@@ -335,7 +341,7 @@ impl<'buf> Secp256k1<VerifyOnlyPreallocated<'buf>> {
         ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,
-            buf: ptr::null_mut::<[u8;0]>() as *mut [u8] ,
+            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
         })
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -233,7 +233,7 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
 
 impl<'buf, C: Context + 'buf> Secp256k1<C> {
     /// Lets you create a context with preallocated buffer in a generic manner(sign/verify/all)
-    pub fn preallocated_gen_new(buf: &'buf mut [u8]) -> Result<Secp256k1<C>, Error> {
+    pub fn preallocated_gen_new(buf: &'buf mut [AlignedType]) -> Result<Secp256k1<C>, Error> {
         #[cfg(target_arch = "wasm32")]
         ffi::types::sanity_checks_for_wasm();
 
@@ -254,7 +254,7 @@ impl<'buf, C: Context + 'buf> Secp256k1<C> {
 
 impl<'buf> Secp256k1<AllPreallocated<'buf>> {
     /// Creates a new Secp256k1 context with all capabilities
-    pub fn preallocated_new(buf: &'buf mut [u8]) -> Result<Secp256k1<AllPreallocated<'buf>>, Error> {
+    pub fn preallocated_new(buf: &'buf mut [AlignedType]) -> Result<Secp256k1<AllPreallocated<'buf>>, Error> {
         Secp256k1::preallocated_gen_new(buf)
     }
     /// Uses the ffi `secp256k1_context_preallocated_size` to check the memory size needed for a context
@@ -284,7 +284,7 @@ impl<'buf> Secp256k1<AllPreallocated<'buf>> {
 
 impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
     /// Creates a new Secp256k1 context that can only be used for signing
-    pub fn preallocated_signing_only(buf: &'buf mut [u8]) -> Result<Secp256k1<SignOnlyPreallocated<'buf>>, Error> {
+    pub fn preallocated_signing_only(buf: &'buf mut [AlignedType]) -> Result<Secp256k1<SignOnlyPreallocated<'buf>>, Error> {
         Secp256k1::preallocated_gen_new(buf)
     }
 
@@ -316,7 +316,7 @@ impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
 
 impl<'buf> Secp256k1<VerifyOnlyPreallocated<'buf>> {
     /// Creates a new Secp256k1 context that can only be used for verification
-    pub fn preallocated_verification_only(buf: &'buf mut [u8]) -> Result<Secp256k1<VerifyOnlyPreallocated<'buf>>, Error> {
+    pub fn preallocated_verification_only(buf: &'buf mut [AlignedType]) -> Result<Secp256k1<VerifyOnlyPreallocated<'buf>>, Error> {
         Secp256k1::preallocated_gen_new(buf)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,7 +558,7 @@ impl std::error::Error for Error {}
 pub struct Secp256k1<C: Context> {
     ctx: *mut ffi::Context,
     phantom: PhantomData<C>,
-    buf: *mut [u8],
+    size: usize,
 }
 
 // The underlying secp context does not contain any references to memory it does not own
@@ -607,7 +607,7 @@ impl<C: Context> Drop for Secp256k1<C> {
     fn drop(&mut self) {
         unsafe {
             ffi::secp256k1_context_preallocated_destroy(self.ctx);
-            C::deallocate(self.buf);
+            C::deallocate(self.ctx as _, self.size);
         }
     }
 }
@@ -781,10 +781,10 @@ mod tests {
         let ctx_sign = unsafe { ffi::secp256k1_context_create(SignOnlyPreallocated::FLAGS) };
         let ctx_vrfy = unsafe { ffi::secp256k1_context_create(VerifyOnlyPreallocated::FLAGS) };
 
-        let buf: *mut [u8] = &mut [0u8;0] as _;
-        let full: Secp256k1<AllPreallocated> = Secp256k1{ctx: ctx_full, phantom: PhantomData, buf};
-        let sign: Secp256k1<SignOnlyPreallocated> = Secp256k1{ctx: ctx_sign, phantom: PhantomData, buf};
-        let vrfy: Secp256k1<VerifyOnlyPreallocated> = Secp256k1{ctx: ctx_vrfy, phantom: PhantomData, buf};
+        let size = 0;
+        let full: Secp256k1<AllPreallocated> = Secp256k1{ctx: ctx_full, phantom: PhantomData, size};
+        let sign: Secp256k1<SignOnlyPreallocated> = Secp256k1{ctx: ctx_sign, phantom: PhantomData, size};
+        let vrfy: Secp256k1<VerifyOnlyPreallocated> = Secp256k1{ctx: ctx_vrfy, phantom: PhantomData, size};
 
         let (sk, pk) = full.generate_keypair(&mut thread_rng());
         let msg = Message::from_slice(&[2u8; 32]).unwrap();


### PR DESCRIPTION
### Introduction

libsecp256k1 expects thing to be "suitably aligned to hold an object of any type"[0] which is the same jargon C89 uses for malloc:

> The pointer returned if the allocation succeeds is suitably aligned so that it may be assigned to a pointer to any type of object and then used to access such an object or an array of such objects in the space allocated(until the space is explicitly  deallocated). [1]


which translated to C11 jargon means "suitably aligned for any fundamental type" :
>  The pointer returned if the allocation succeeds is suitably aligned so that it may be assigned to a pointer to any type of object with a fundamental alignment requirement and then used to access such an object or an array of such objects in the space allocated (until the space is explicitly deallocated).  [2]

Which is:
> A fundamental alignment is represented by an alignment less than or equal to the greatest alignment supported by the implementation in all contexts, which is equal to alignof(max_align_t). [3]


Rust holds a table of all these alignments for the supported platforms: https://github.com/rust-lang/rust/blob/2c31b45ae878b821975c4ebd94cc1e49f6073fd0/library/std/src/sys_common/alloc.rs
And rust-lang/libc implements `max_align_t` directly: https://docs.rs/libc/0.2.76/libc/struct.max_align_t.html

So I took the bigger alignment any rust architecture supports and used that as our default alignment, and also added a test that it is bigger than `max_align_t` (we could also test that in the build.rs if we really want).


### Implementation
Use [alloc()](https://doc.rust-lang.org/std/alloc/fn.alloc.html) and [dealloc()](https://doc.rust-lang.org/std/alloc/fn.dealloc.html) whenever we allocate, with `16` as alignment.
And use `#[repr(align(16))] struct AlignType([u8; 16])` for the preallocated buffer API. 

### Alternatives
* #234 - Here the preallocated API is the same, but the regular API uses `Vec<AlignType>` for allocations.
* #235 - Here the regular API is the same, but the preallocated API is made `unsafe` with s.t. the caller now needs to make sure he upholds the invariants

Closes #138
[0] https://github.com/bitcoin-core/secp256k1/blob/670cdd3f8be25f81472b2d16dcd228b0d24a5c45/include/secp256k1_preallocated.h#L42
[1] http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf 7.20.3
[2] http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1548.pdf 7.22.3
[3] http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1548.pdf 6.2.8p2