### PR TITLE
[Alternative] Making sure everything is aligned correctly

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -56,6 +56,7 @@ use secp256k1::ecdh::SharedSecret;
 use secp256k1::rand::{self, RngCore};
 use secp256k1::serde::Serialize;
 use secp256k1::*;
+use secp256k1::ffi::types::AlignedType;
 
 use serde_cbor::de;
 use serde_cbor::ser::SliceWrite;
@@ -82,7 +83,7 @@ impl RngCore for FakeRng {
 
 #[start]
 fn start(_argc: isize, _argv: *const *const u8) -> isize {
-    let mut buf = [0u8; 600_000];
+    let mut buf = [AlignedType::zeroed(); 37_000];
     let size = Secp256k1::preallocate_size();
     unsafe { libc::printf("needed size: %d\n\0".as_ptr() as _, size) };
 
@@ -161,5 +162,5 @@ fn panic(info: &PanicInfo) -> ! {
     let mut buf = Print::new();
     write(&mut buf, *msg).unwrap();
     buf.print();
-    unsafe { intrinsics::abort() }
+    intrinsics::abort()
 }

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -21,6 +21,9 @@ features = [ "recovery", "endomorphism", "lowmemory" ]
 [build-dependencies]
 cc = "1.0.28"
 
+[dev-dependencies]
+libc = "0.2"
+
 [lib]
 name = "secp256k1_sys"
 path = "src/lib.rs"

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -324,19 +324,21 @@ extern "C" {
 #[no_mangle]
 #[cfg(all(feature = "std", not(feature = "external-symbols")))]
 pub unsafe extern "C" fn rustsecp256k1_v0_2_0_context_create(flags: c_uint) -> *mut Context {
-    use std::mem;
-    assert!(mem::align_of::<usize>() >= mem::align_of::<u8>());
-    assert_eq!(mem::size_of::<usize>(), mem::size_of::<&usize>());
+    use core::mem;
+    use std::alloc;
+    assert!(ALIGN_TO >= mem::align_of::<usize>());
+    assert!(ALIGN_TO >= mem::align_of::<&usize>());
+    assert!(ALIGN_TO >= mem::size_of::<usize>());
 
-    let word_size = mem::size_of::<usize>();
-    let n_words = (secp256k1_context_preallocated_size(flags) + word_size - 1) / word_size;
-
-    let buf = vec![0usize; n_words + 1].into_boxed_slice();
-    let ptr = Box::into_raw(buf) as *mut usize;
-    ::core::ptr::write(ptr, n_words);
-    let ptr: *mut usize = ptr.offset(1);
-
-    secp256k1_context_preallocated_create(ptr as *mut c_void, flags)
+    // We need to allocate `ALIGN_TO` more bytes in order to write the amount of bytes back.
+    let bytes = secp256k1_context_preallocated_size(flags) + ALIGN_TO;
+    let layout = alloc::Layout::from_size_align(bytes, ALIGN_TO).unwrap();
+    let ptr = alloc::alloc(layout);
+    (ptr as *mut usize).write(bytes);
+    // We must offset a whole ALIGN_TO in order to preserve the same alignment
+    // this means we "lose" ALIGN_TO-size_of(usize) for padding.
+    let ptr = ptr.add(ALIGN_TO) as *mut c_void;
+    secp256k1_context_preallocated_create(ptr, flags)
 }
 
 #[cfg(all(feature = "std", not(feature = "external-symbols")))]
@@ -353,13 +355,12 @@ pub unsafe fn secp256k1_context_create(flags: c_uint) -> *mut Context {
 #[no_mangle]
 #[cfg(all(feature = "std", not(feature = "external-symbols")))]
 pub unsafe extern "C" fn rustsecp256k1_v0_2_0_context_destroy(ctx: *mut Context) {
+    use std::alloc;
     secp256k1_context_preallocated_destroy(ctx);
-    let ctx: *mut usize = ctx as *mut usize;
-
-    let n_words_ptr: *mut usize = ctx.offset(-1);
-    let n_words: usize = ::core::ptr::read(n_words_ptr);
-    let slice: &mut [usize] = slice::from_raw_parts_mut(n_words_ptr , n_words+1);
-    let _ = Box::from_raw(slice as *mut [usize]);
+    let ptr = (ctx as *mut u8).sub(ALIGN_TO);
+    let bytes = (ptr as *mut usize).read();
+    let layout = alloc::Layout::from_size_align(bytes, ALIGN_TO).unwrap();
+    alloc::dealloc(ptr, layout);
 }
 
 #[cfg(all(feature = "std", not(feature = "external-symbols")))]

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types)]
-use core::fmt;
+use core::{fmt, mem};
 
 pub type c_int = i32;
 pub type c_uchar = u8;
@@ -26,11 +26,30 @@ impl fmt::Debug for c_void {
     }
 }
 
+/// A type that is as aligned as the biggest alignment for fundamental types in C
+/// since C11 that means as aligned as `max_align_t` is.
+/// the exact size/alignment is unspecified.
+// 16 matches is as big as the biggest alignment in any arch that rust supports https://github.com/rust-lang/rust/blob/2c31b45ae878b821975c4ebd94cc1e49f6073fd0/library/std/src/sys_common/alloc.rs
+#[repr(align(16))]
+#[derive(Default, Copy, Clone)]
+pub struct AlignedType([u8; 16]);
+
+impl AlignedType {
+    pub fn zeroed() -> Self {
+        AlignedType([0u8; 16])
+    }
+}
+
+pub(crate) const ALIGN_TO: usize = mem::align_of::<AlignedType>();
+
+
 #[cfg(test)]
 mod tests {
+    extern crate libc;
     use std::os::raw;
+    use std::mem;
     use std::any::TypeId;
-    use types;
+    use {types, AlignedType};
 
     #[test]
     fn verify_types() {
@@ -38,6 +57,8 @@ mod tests {
         assert_eq!(TypeId::of::<types::c_uchar>(), TypeId::of::<raw::c_uchar>());
         assert_eq!(TypeId::of::<types::c_uint>(), TypeId::of::<raw::c_uint>());
         assert_eq!(TypeId::of::<types::c_char>(), TypeId::of::<raw::c_char>());
+
+        assert!(mem::align_of::<AlignedType>() >= mem::align_of::<self::libc::max_align_t>());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub use secp256k1_sys as ffi;
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 #[cfg(any(test, feature = "std"))] extern crate core;
 
-use core::{fmt, ptr, str};
+use core::{fmt, str, ptr::{self, NonNull}};
 
 #[macro_use]
 mod macros;
@@ -584,7 +584,7 @@ impl std::error::Error for Error {
 pub struct Secp256k1<C: Context> {
     ctx: *mut ffi::Context,
     phantom: PhantomData<C>,
-    buf: *mut [u8],
+    buf: NonNull<[u8]>,
 }
 
 // The underlying secp context does not contain any references to memory it does not own
@@ -789,6 +789,7 @@ mod tests {
     use rand::{RngCore, thread_rng};
     use std::str::FromStr;
     use std::marker::PhantomData;
+    use core::ptr::NonNull;
 
     use key::{SecretKey, PublicKey};
     use super::from_hex;
@@ -813,7 +814,7 @@ mod tests {
         let ctx_sign = unsafe { ffi::secp256k1_context_create(SignOnlyPreallocated::FLAGS) };
         let ctx_vrfy = unsafe { ffi::secp256k1_context_create(VerifyOnlyPreallocated::FLAGS) };
 
-        let buf: *mut [u8] = &mut [0u8;0] as _;
+        let buf = NonNull::<[u8; 0]>::dangling() as _;
         let full: Secp256k1<AllPreallocated> = Secp256k1{ctx: ctx_full, phantom: PhantomData, buf};
         let sign: Secp256k1<SignOnlyPreallocated> = Secp256k1{ctx: ctx_sign, phantom: PhantomData, buf};
         let vrfy: Secp256k1<VerifyOnlyPreallocated> = Secp256k1{ctx: ctx_vrfy, phantom: PhantomData, buf};


### PR DESCRIPTION
Alternative for  #233

this uses vecs/box with `AlignType` for the regular API.
the preallocated API is the same as in #233