### PR TITLE
Add MemorySanitizer and AddressSanitizer to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,19 @@ script:
   - cargo run --example generate_keys --features=rand
   - if [ ${TRAVIS_RUST_VERSION} == "stable" ]; then cargo doc --verbose --features="rand,serde,recovery,endomorphism"; fi
   - if [ ${TRAVIS_RUST_VERSION} == "nightly" ]; then cargo test --verbose --benches --features=unstable; fi
-  - if [ ${TRAVIS_RUST_VERSION} == "nightly" -a "$TRAVIS_OS_NAME" = "linux" ]; then
-    cd no_std_test &&
-    cargo run --release | grep -q "Verified Successfully";
+  - |
+    if [ ${TRAVIS_RUST_VERSION} == "nightly" -a "$TRAVIS_OS_NAME" = "linux" ]; then
+    cargo clean
+    rustup component add rust-src
+    CC='clang -fsanitize=address -fno-omit-frame-pointer'                                        \
+    RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \
+    ASAN_OPTIONS='detect_leaks=1 detect_invalid_pointer_pairs=1 detect_stack_use_after_return=1' \
+    cargo test --lib --verbose --features="rand-std serde recovery bitcoin_hashes" -Zbuild-std --target x86_64-unknown-linux-gnu &&
+    cargo clean &&
+    CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
+    RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
+    cargo test --lib --verbose --features="rand-std serde recovery bitcoin_hashes" -Zbuild-std --target x86_64-unknown-linux-gnu &&
+    cd no_std_test && cargo run --release | grep -q "Verified Successfully"
     fi
   - if [ ${TRAVIS_RUST_VERSION} == "stable" -a "$TRAVIS_OS_NAME" = "linux" ]; then
     clang --version &&


### PR DESCRIPTION
Run all the tests under MemorySanitizer + AddressSanitizer, combined with rebuilding libstd with them :)
It seems to be fast enough(nightly run with this is ~6:45m overall), so why not do it. 

Example of errors it can find:
1. Not allocating enough memory for the context: 
code change: https://github.com/rust-bitcoin/rust-secp256k1/compare/9dfb329ff145...0bbe50d7185f
result: https://travis-ci.org/github/rust-bitcoin/rust-secp256k1/jobs/722098237#L1730

2. Uninitialized reads (shouldn't be a problem for us):
code change: https://github.com/rust-bitcoin/rust-secp256k1/compare/0bbe50d7185f...23382d63fe1b
result: https://travis-ci.org/github/rust-bitcoin/rust-secp256k1/jobs/722098767#L1756