### PR TITLE
Use wasm sysroot for wasm32-wasi target as well

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -62,8 +62,10 @@ fn main() {
         }
     }
 
-    if env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
-        base_config.include("wasm-sysroot");
+    match &env::var("TARGET").unwrap() as &str {
+        "wasm32-unknown-unknown"|"wasm32-wasi" =>
+            { base_config.include("wasm-sysroot"); },
+        _ => {},
     }
 
     // secp256k1


### PR DESCRIPTION
wasm32-wasi is an officially-supported target. This lets us build on it.