### PR TITLE
global-context depends on rand-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 endomorphism = ["secp256k1-sys/endomorphism"]
 lowmemory = ["secp256k1-sys/lowmemory"]
-global-context = ["std", "rand"]
+global-context = ["std", "rand-std"]
 
 # Use this feature to not compile the bundled libsecp256k1 C symbols,
 # but use external ones. Use this only if you know what you are doing!


### PR DESCRIPTION
Uses `thread_rng` which is only available with `rand/std` / `rand-std` enabled.