### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### rust-secp256k1
 
-`rust-secp256k1` is a wrapper around ![libsecp256k1](https://github.com/bitcoin-core/secp256k1),
+`rust-secp256k1` is a wrapper around [libsecp256k1](https://github.com/bitcoin-core/secp256k1),
 a C library by Pieter Wuille for producing ECDSA signatures using the SECG curve
 `secp256k1`. This library
 * exposes type-safe Rust bindings for all `libsecp256k1` functions


### PR DESCRIPTION
Right now this link looks "broken" in the README

![image](https://user-images.githubusercontent.com/4335621/100288894-4f026680-2f3d-11eb-9272-af4702f1930f.png)

AFAICT the `![a](b)` style of markdown link is only used when `b` is an image and `a` is the alt description so I'm guessing this isn't intentional ...