### PR TITLE
Add Wasm build for MacOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,8 +43,6 @@ jobs:
             os: macos-latest
             cc: /usr/local/opt/llvm/bin/clang
             ar: /usr/local/opt/llvm/bin/llvm-ar
-        rust:
-          - stable
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Crate
@@ -53,7 +51,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           override: true
       - name: Building docs
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,11 +31,21 @@ jobs:
 
   wasm: 
     name: Stable - Docs / WebAssembly Build
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            cc: clang-12
+            ar: ar
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            cc: /usr/local/opt/llvm/bin/clang
+            ar: /usr/local/opt/llvm/bin/llvm-ar
         rust:
           - stable
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
@@ -52,6 +62,8 @@ jobs:
       - name: Running WASM build
         env:
           DO_WASM: true
+          CC: ${{ matrix.cc }}
+          AR: ${{ matrix.ar }}
         run: ./contrib/test.sh
 
   Tests:

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -60,8 +60,8 @@ if [ "$DO_WASM" = true ]; then
     clang --version &&
     CARGO_TARGET_DIR=wasm cargo install --force wasm-pack &&
     printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml &&
-    CC=clang-9 wasm-pack build &&
-    CC=clang-9 wasm-pack test --node;
+    wasm-pack build &&
+    wasm-pack test --node;
 fi
 
 # Address Sanitizer


### PR DESCRIPTION
This PR adds MacOS build to CI to ensure that the library also build on MacOS.

The library does not compile to wasm using the default clang setup on MacOS.
We are able to work around this by setting the environment variables CC and AR to use clang and llvm-ar provided by llvm.



//edit// outdated description below
Hi, 

we depend on this library in one of our projects and fail to compile it to wasm on MacOS. 
Do you have an idea what's going wrong?

I was able to reproduce it on CI (see below or here for more information here: https://github.com/bonomat/rust-secp256k1/pull/1/checks?check_run_id=1534192675):

```bash
    Compiling secp256k1 v0.19.0 (/Users/runner/work/rust-secp256k1/rust-secp256k1)
    Finished test [unoptimized + debuginfo] target(s) in 1.37s
     Running target/wasm32-unknown-unknown/debug/deps/secp256k1-3f31b356cd36a038.wasm
Set timeout to 20 seconds...
Executing bindgen...                              
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'env'
Require stack:
- /Users/runner/work/rust-secp256k1/rust-secp256k1/target/wasm32-unknown-unknown/wbg-tmp/wasm-bindgen-test.js
- /Users/runner/work/rust-secp256k1/rust-secp256k1/target/wasm32-unknown-unknown/wbg-tmp/run.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/Users/runner/work/rust-secp256k1/rust-secp256k1/target/wasm32-unknown-unknown/wbg-tmp/wasm-bindgen-test.js:3:18)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/runner/work/rust-secp256k1/rust-secp256k1/target/wasm32-unknown-unknown/wbg-tmp/wasm-bindgen-test.js',
    '/Users/runner/work/rust-secp256k1/rust-secp256k1/target/wasm32-unknown-unknown/wbg-tmp/run.js'
  ]
}
error: test failed, to rerun pass '--lib'
Error: Running Wasm tests with wasm-bindgen-test failed
Caused by: failed to execute `cargo test`: exited with exit code: 1
  full command: "cargo" "test" "--target" "wasm32-unknown-unknown"
```


