### PR TITLE
Pass full public key to hash function instead of its coordinates

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -105,8 +105,13 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
 
     let _ = SharedSecret::new(&public_key, &secret_key);
     let mut x_arr = [0u8; 32];
-    let y_arr = SharedSecret::new_with_hash(&public_key, &secret_key, |x,y| {
-        x_arr = x;
+    let y_arr = SharedSecret::new_with_hash(&public_key, &secret_key, |pubkey| {
+        let xy = pubkey.serialize_uncompressed();
+        x_arr.copy_from_slice(&xy[1..33]);
+
+        let mut y = [0u8; 32];
+        y.copy_from_slice(&xy[33..]);
+
         y.into()
     });
     assert_ne!(x_arr, [0u8; 32]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 pub extern crate secp256k1_sys;
 pub use secp256k1_sys as ffi;
 
-#[cfg(feature = "bitcoin_hashes")] pub extern crate bitcoin_hashes;
+#[cfg(any(test, feature = "bitcoin_hashes"))] pub extern crate bitcoin_hashes;
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 #[cfg(any(test, feature = "rand"))] pub extern crate rand;
 #[cfg(any(test))] extern crate rand_core;


### PR DESCRIPTION
The `new_with_hash` constructor of `SharedSecret` passes a `null` hash
function to the underlying C code. This means what we are getting passed
is the literal result of the DH operation which is a PublicKey.

We can model this more closely by making the type of the closure an
actual PublicKey. As a nice side-effect, we can avoid copying the return
value.

The motivation for this change is usage within elements where the nonce of a confidential txout is a sha256 double hash of the compressed ECDH public key. That is easier if we get passed a public key directly instead of the coordinates.