### PR TITLE
Run more tests in wasm

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -168,6 +168,9 @@ mod tests {
     use super::SharedSecret;
     use super::super::Secp256k1;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
     #[test]
     fn ecdh() {
         let s = Secp256k1::signing_only();

--- a/src/key.rs
+++ b/src/key.rs
@@ -429,6 +429,9 @@ mod test {
     use std::iter;
     use std::str::FromStr;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
     macro_rules! hex {
         ($hex:expr) => ({
             let mut result = vec![0; $hex.len() / 2];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ pub use secp256k1_sys as ffi;
 #[cfg(all(test, feature = "serde"))] extern crate serde_test;
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 #[cfg(any(test, feature = "std"))] extern crate core;
+#[cfg(all(test, target_arch = "wasm32"))] extern crate wasm_bindgen_test;
 
 use core::{fmt, ptr, str};
 
@@ -770,6 +771,9 @@ mod tests {
     use ffi::{self, types::AlignedType};
     use context::*;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
     macro_rules! hex {
         ($hex:expr) => ({
             let mut result = vec![0; $hex.len() / 2];
@@ -831,6 +835,7 @@ mod tests {
         drop(ctx_full);drop(ctx_sign);drop(ctx_vrfy);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     #[should_panic]
     fn test_panic_raw_ctx() {
@@ -1123,33 +1128,6 @@ mod tests {
         // Check usage as self
         let sig = SECP256K1.sign(&msg, &sk);
         assert!(SECP256K1.verify(&msg, &sig, &pk).is_ok());
-    }
-
-    // For WASM, just run through our general tests in this file all at once.
-    #[cfg(target_arch = "wasm32")]
-    extern crate wasm_bindgen_test;
-    #[cfg(target_arch = "wasm32")]
-    use self::wasm_bindgen_test::*;
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen_test]
-    fn stuff() {
-        test_manual_create_destroy();
-        test_raw_ctx();
-        // Note that, sadly, WASM doesn't currently properly unwind panics, so use of the library
-        // via unsafe primitives may cause abort() instead of catch-able panics.
-        /*assert!(std::panic::catch_unwind(|| {
-            test_panic_raw_ctx();
-        }).is_err());*/
-        test_preallocation();
-        capabilities();
-        signature_serialize_roundtrip();
-        signature_display();
-        signature_lax_der();
-        sign_and_verify();
-        sign_and_verify_extreme();
-        sign_and_verify_fail();
-        test_bad_slice();
-        test_low_s();
     }
 
     #[cfg(feature = "bitcoin_hashes")]

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -199,6 +199,9 @@ mod tests {
     use super::super::{Secp256k1, Message};
     use super::super::Error::{IncorrectSignature, InvalidSignature};
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
     #[test]
     fn capabilities() {
         let sign = Secp256k1::signing_only();

--- a/src/schnorrsig.rs
+++ b/src/schnorrsig.rs
@@ -500,6 +500,9 @@ mod tests {
     use std::iter;
     use std::str::FromStr;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
     macro_rules! hex_32 {
         ($hex:expr) => {{
             let mut result = [0; 32];


### PR DESCRIPTION
Instead of repeating ourselves in defining one big test for the wasm
target, we can override the `test` attribute with the `wasm-bindgen-test`
one and therefore automatically run all (supported) tests in wasm.

Unfortunately, wasm doesn't support catching panics yet which means we
have to disable the `test_panic_raw_ctx` test.