### PR TITLE
Clear clippy warnings

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -43,6 +43,7 @@ pub const SECP256K1_START_VERIFY: c_uint = 1 | (1 << 8);
 /// Flag for context to enable signing precomputation
 pub const SECP256K1_START_SIGN: c_uint = 1 | (1 << 9);
 /// Flag for keys to indicate uncompressed serialization format
+#[allow(unused_parens)]
 pub const SECP256K1_SER_UNCOMPRESSED: c_uint = (1 << 1);
 /// Flag for keys to indicate compressed serialization format
 pub const SECP256K1_SER_COMPRESSED: c_uint = (1 << 1) | (1 << 8);

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -630,7 +630,8 @@ pub unsafe extern "C" fn rustsecp256k1_v0_3_1_default_error_callback_fn(message:
     panic!("[libsecp256k1] internal consistency check failed {}", msg);
 }
 
-
+#[no_mangle]
+#[cfg(not(feature = "external-symbols"))]
 unsafe fn strlen(mut str_ptr: *const c_char) -> usize {
     let mut ctr = 0;
     while *str_ptr != '\0' as c_char {
@@ -1161,11 +1162,13 @@ pub use self::fuzz_dummy::*;
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::CString;
-    use super::strlen;
-
+    #[no_mangle]
+    #[cfg(not(feature = "external-symbols"))]
     #[test]
     fn test_strlen() {
+        use std::ffi::CString;
+        use super::strlen;
+
         let orig = "test strlen \t \n";
         let test = CString::new(orig).unwrap();
 

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -35,19 +35,21 @@ macro_rules! impl_array_newtype {
             }
 
             #[inline]
-            /// Gets a reference to the underlying array
-            pub fn as_ref(&self) -> &[$ty; $len] {
-                let &$thing(ref dat) = self;
-                dat
-            }
-
-            #[inline]
             /// Returns the length of the object as an array
             pub fn len(&self) -> usize { $len }
 
             #[inline]
             /// Returns whether the object as an array is empty
             pub fn is_empty(&self) -> bool { false }
+        }
+
+        impl AsRef<[$ty; $len]> for $thing {
+            #[inline]
+            /// Gets a reference to the underlying array
+            fn as_ref(&self) -> &[$ty; $len] {
+                let &$thing(ref dat) = self;
+                dat
+            }
         }
 
         impl PartialEq for $thing {

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -40,6 +40,7 @@ impl AlignedType {
     }
 }
 
+#[cfg(all(feature = "std", not(feature = "external-symbols")))]
 pub(crate) const ALIGN_TO: usize = mem::align_of::<AlignedType>();
 
 


### PR DESCRIPTION
Checking this repo with `cargo clippy --all-features --all-targets` produces a bunch of warnings. 

This PR clears all the warnings except for the safety documentation warnings.