### PR TITLE
More clippy

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -61,6 +61,11 @@ impl SharedSecret {
         self.len
     }
 
+    /// True if the underlying data buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
     /// Set the length of the object.
     pub(crate) fn set_len(&mut self, len: usize) {
         debug_assert!(len <= self.data.len());

--- a/src/key.rs
+++ b/src/key.rs
@@ -762,13 +762,13 @@ mod test {
         let s = Secp256k1::new();
         let mut set = HashSet::new();
         const COUNT : usize = 1024;
-        let count = (0..COUNT).map(|_| {
+        for _ in 0..COUNT {
             let (_, pk) = s.generate_keypair(&mut thread_rng());
             let hash = hash(&pk);
             assert!(!set.contains(&hash));
             set.insert(hash);
-        }).count();
-        assert_eq!(count, COUNT);
+        };
+        assert_eq!(set.len(), COUNT);
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -796,7 +796,7 @@ mod test {
         let pk1 = PublicKey::from_slice(
             &hex!("0241cc121c419921942add6db6482fb36243faf83317c866d2a28d8c6d7089f7ba"),
         ).unwrap();
-        let pk2 = pk1.clone();
+        let pk2 = pk1;
         let pk3 = PublicKey::from_slice(
             &hex!("02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443"),
         ).unwrap();

--- a/src/key.rs
+++ b/src/key.rs
@@ -512,7 +512,8 @@ mod test {
                 self.0 -= 1;
             }
             fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-                Ok(self.fill_bytes(dest))
+                self.fill_bytes(dest);
+                Ok(())
             }
         }
 

--- a/src/schnorrsig.rs
+++ b/src/schnorrsig.rs
@@ -384,7 +384,7 @@ impl<C: Signing> Secp256k1<C> {
         msg: &Message,
         keypair: &KeyPair,
         nonce_data: *const ffi::types::c_void,
-    ) -> Result<Signature, Error> {
+    ) -> Signature {
         unsafe {
             let mut sig = [0u8; constants::SCHNORRSIG_SIGNATURE_SIZE];
             assert_eq!(
@@ -399,7 +399,7 @@ impl<C: Signing> Secp256k1<C> {
                 )
             );
 
-            Ok(Signature(sig))
+            Signature(sig)
         }
     }
 
@@ -407,7 +407,7 @@ impl<C: Signing> Secp256k1<C> {
     /// generator to generate the auxiliary random data.
     /// Requires compilation with "rand-std" feature.
     #[cfg(any(test, feature = "rand-std"))]
-    pub fn schnorrsig_sign(&self, msg: &Message, keypair: &KeyPair) -> Result<Signature, Error> {
+    pub fn schnorrsig_sign(&self, msg: &Message, keypair: &KeyPair) -> Signature {
         let mut rng = thread_rng();
         self.schnorrsig_sign_with_rng(msg, keypair, &mut rng)
     }
@@ -417,7 +417,7 @@ impl<C: Signing> Secp256k1<C> {
         &self,
         msg: &Message,
         keypair: &KeyPair,
-    ) -> Result<Signature, Error> {
+    ) -> Signature {
         self.schnorrsig_sign_helper(msg, keypair, ptr::null())
     }
 
@@ -427,7 +427,7 @@ impl<C: Signing> Secp256k1<C> {
         msg: &Message,
         keypair: &KeyPair,
         aux_rand: &[u8; 32],
-    ) -> Result<Signature, Error> {
+    ) -> Signature {
         self.schnorrsig_sign_helper(
             msg,
             keypair,
@@ -444,7 +444,7 @@ impl<C: Signing> Secp256k1<C> {
         msg: &Message,
         keypair: &KeyPair,
         rng: &mut R,
-    ) -> Result<Signature, Error> {
+    ) -> Signature {
         let mut aux = [0u8; 32];
         rng.fill_bytes(&mut aux);
         self.schnorrsig_sign_helper(msg, keypair, aux.as_c_ptr() as *const ffi::types::c_void)
@@ -533,7 +533,6 @@ mod tests {
             let mut aux_rand = [0; 32];
             rng.fill_bytes(&mut aux_rand);
             secp.schnorrsig_sign_with_aux_rand(msg, seckey, &aux_rand)
-                .unwrap()
         })
     }
 
@@ -541,21 +540,20 @@ mod tests {
     fn test_schnorrsig_sign_with_rng_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, mut rng| {
             secp.schnorrsig_sign_with_rng(msg, seckey, &mut rng)
-                .unwrap()
         })
     }
 
     #[test]
     fn test_schnorrsig_sign_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, _| {
-            secp.schnorrsig_sign(msg, seckey).unwrap()
+            secp.schnorrsig_sign(msg, seckey)
         })
     }
 
     #[test]
     fn test_schnorrsig_sign_no_aux_rand_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, _| {
-            secp.schnorrsig_sign_no_aux_rand(msg, seckey).unwrap()
+            secp.schnorrsig_sign_no_aux_rand(msg, seckey)
         })
     }
 
@@ -575,8 +573,7 @@ mod tests {
         let expected_sig = Signature::from_str("6470FD1303DDA4FDA717B9837153C24A6EAB377183FC438F939E0ED2B620E9EE5077C4A8B8DCA28963D772A94F5F0DDF598E1C47C137F91933274C7C3EDADCE8").unwrap();
 
         let sig = secp
-            .schnorrsig_sign_with_aux_rand(&msg, &sk, &aux_rand)
-            .unwrap();
+            .schnorrsig_sign_with_aux_rand(&msg, &sk, &aux_rand);
 
         assert_eq!(expected_sig, sig);
     }
@@ -730,8 +727,7 @@ mod tests {
         let keypair = KeyPair::from_seckey_slice(&s, &[2; 32]).unwrap();
         let aux = [3; 32];
         let sig = s
-            .schnorrsig_sign_with_aux_rand(&msg, &keypair, &aux)
-            .unwrap();
+            .schnorrsig_sign_with_aux_rand(&msg, &keypair, &aux);
         static SIG_BYTES: [u8; constants::SCHNORRSIG_SIGNATURE_SIZE] = [
             0x14, 0xd0, 0xbf, 0x1a, 0x89, 0x53, 0x50, 0x6f, 0xb4, 0x60, 0xf5, 0x8b, 0xe1, 0x41,
             0xaf, 0x76, 0x7f, 0xd1, 0x12, 0x53, 0x5f, 0xb3, 0x92, 0x2e, 0xf2, 0x17, 0x30, 0x8e,

--- a/src/schnorrsig.rs
+++ b/src/schnorrsig.rs
@@ -185,11 +185,11 @@ impl KeyPair {
                 tweak.as_c_ptr(),
             );
 
-            return if err == 1 {
+            if err == 1 {
                 Ok(())
             } else {
                 Err(Error::InvalidTweak)
-            };
+            }
         }
     }
 }
@@ -465,11 +465,11 @@ impl<C: Signing> Secp256k1<C> {
                 pubkey.as_c_ptr(),
             );
 
-            return if ret == 1 {
+            if ret == 1 {
                 Ok(())
             } else {
                 Err(Error::InvalidSignature)
-            };
+            }
         }
     }
 


### PR DESCRIPTION
We recently merged some work that introduced a bunch of clippy warnings. Lets keep clippy quiet and clean them up. Is there a reason we don't have CI catching these?

Patches are all trivial except the last two, particularly I just blindly followed clippy for the last one, I've not encountered `ManuallyDrop` before.