### PR TITLE
Add feature zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ secp256k1-sys = { version = "0.4.0", default-features = false, path = "./secp256
 bitcoin_hashes = { version = "0.9", optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
-
+zeroize = { version = "1.2", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.6"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ before_script:
     fi
 ```
 
+## Zeroize
+
+Zeroizing secrets is supported using the `zeroize` feature. Enabling this
+feature changes the MSRV to 1.44 (see https://docs.rs/zeroize/1.2.0/zeroize/).
+
+The aim of the `zeroize` feature is to allow users of this library to reduce the
+number of copies of secrets in memory (by wrapping our types, implementing
+`Zeroize` and implementing `Drop` (i.e. derive `Zeroize`). Our aim is not to
+guarantee that there are no copies left un-zeroed in memory. Internally we
+absolutely do leave secrets on the stack.
+
+> I think even zeroing some out the copies is better than none, because every
+> copy makes a Heartbleed-like attack a little easier.
+
 ## Fuzzing
 
 If you want to fuzz this library, or any library which depends on it, you will

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -83,6 +83,14 @@ macro_rules! impl_array_newtype {
             }
         }
 
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $thing {
+            fn zeroize(&mut self) {
+                let &mut $thing(ref mut dat) = self;
+                dat.zeroize()
+            }
+        }
+
         impl ::core::ops::Index<usize> for $thing {
             type Output = $ty;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -850,4 +850,20 @@ mod test {
         assert_tokens(&pk.compact(), &[Token::BorrowedBytes(&PK_BYTES[..])]);
         assert_tokens(&pk.readable(), &[Token::BorrowedStr(PK_STR)]);
     }
+
+    #[cfg(feature = "zeroize")]
+    #[test]
+    fn zeroize_secret_key() {
+        use zeroize::Zeroize;
+
+        let mut sk = SecretKey::new(&mut thread_rng());
+        sk.zeroize();
+
+        let ptr = &sk.0[0];
+
+        for _ in 0..32 {
+            assert_eq!(*ptr, 0x00);
+        }
+    }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub use secp256k1_sys as ffi;
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 #[cfg(any(test, feature = "std"))] extern crate core;
 #[cfg(all(test, target_arch = "wasm32"))] extern crate wasm_bindgen_test;
+#[cfg(feature = "zeroize")] extern crate zeroize;
 
 use core::{fmt, ptr, str};
 


### PR DESCRIPTION
It is useful for downstream users to be able to zeroize secrets. Doing so is supported by the `zeroize` library. 

Add feature `zeroize` which, if enabled, implements `Zeroize` for all our types that use `impl_array_newtype` (includes `SecretKey` and `KeyPair`).

On purpose we do _not_ implement `Drop` and we still implement `Copy`. This is so as to not negatively effect users of the library (see link below from when this was attempted previously). This means that stack variables are not zerozied and there may be additional copies made by the compiler.

Adds a section to the README explaining the aims of the `zeroize` feature, included here:

```
Zeroizing secrets is supported using the `zeroize` feature. Enabling this
feature changes the MSRV to 1.44 (see https://docs.rs/zeroize/1.2.0/zeroize/).

The aim of the `zeroize` feature is to allow users of this library to reduce the
number of copies of secrets in memory (by wrapping our types, implementing
`Zeroize` and implementing `Drop` (i.e. derive `Zeroize`). Our aim is not to
guarantee that there are no copies left un-zeroed in memory. Internally we
absolutely do leave secrets on the stack.

> I think even zeroing some out the copies is better than none, because every
> copy makes a Heartbleed-like attack a little easier.
```

@elichai this quote is from you in this PR's thread, I gave not attribution of the source of the quote. Pleases say so if you would like attribution (or if you would prefer not to be quoted).

Please note, PR introduces a new dependency on `zeroize v1.2` .
