### PR TITLE
Replace dangerous cargo features with rustc flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,6 @@ endomorphism = ["secp256k1-sys/endomorphism"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std", "rand-std"]
 
-# Use this feature to not compile the bundled libsecp256k1 C symbols,
-# but use external ones. Use this only if you know what you are doing!
-external-symbols = ["secp256k1-sys/external-symbols"]
-
 # Do not use this feature! HAZMAT. (meant for Fuzzing only. this is *BROKEN CRYPTOGRAPHY*)
 fuzztarget = ["secp256k1-sys/fuzztarget"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ endomorphism = ["secp256k1-sys/endomorphism"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std", "rand-std"]
 
-# Do not use this feature! HAZMAT. (meant for Fuzzing only. this is *BROKEN CRYPTOGRAPHY*)
-fuzztarget = ["secp256k1-sys/fuzztarget"]
-
 [dependencies]
 secp256k1-sys = { version = "0.3.1", default-features = false, path = "./secp256k1-sys" }
 bitcoin_hashes = { version = "0.9", optional = true }

--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ before_script:
     cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose;
     fi
 ```
+
+## Fuzzing
+
+If you want to fuzz this library, or any library which depends on it, you will
+probably want to disable the actual cryptography, since fuzzers are unable to
+forge signatures and therefore won't test many interesting codepaths. To instead
+use a trivially-broken but fuzzer-accessible signature scheme, compile with
+`--cfg=rust_secp_fuzz` in your `RUSTFLAGS` variable.
+

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -31,8 +31,8 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     done
 
     # Other combos 
-    cargo test --no-run --verbose --features="fuzztarget"
-    cargo test --no-run --verbose --features="fuzztarget recovery"
+    RUSTFLAGS='--cfg=rust_secp_fuzz' cargo test --no-run --verbose
+    RUSTFLAGS='--cfg=rust_secp_fuzz' cargo test --no-run --verbose --features="recovery"
     cargo test --verbose --features="rand rand-std"
     cargo test --verbose --features="rand serde"
 

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -31,9 +31,5 @@ endomorphism = []
 lowmemory = []
 std = []
 
-# Use this feature to not compile the bundled libsecp256k1 C symbols,
-# but use external ones. Use this only if you know what you are doing!
-external-symbols = []
-
 # Do not use this feature! HAZMAT. (meant for Fuzzing only. this is *BROKEN CRYPTOGRAPHY*)
 fuzztarget = []

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -31,5 +31,3 @@ endomorphism = []
 lowmemory = []
 std = []
 
-# Do not use this feature! HAZMAT. (meant for Fuzzing only. this is *BROKEN CRYPTOGRAPHY*)
-fuzztarget = []

--- a/secp256k1-sys/README.md
+++ b/secp256k1-sys/README.md
@@ -29,6 +29,7 @@ $ ./vendor-libsecp.sh depend <version-code> <rev>
 
 ## Linking to external symbols
 
-For the more exotic use cases, this crate can be used with existing libsecp256k1
-symbols by using the `external-symbols` feature. How to setup rustc to link
-against those existing symbols is left as an exercise to the reader.
+If you want to compile this library without using the bundled symbols (which may
+be required for integration into other build systems), you can do so by adding
+`--cfg=rust_secp_no_symbol_renaming'` to your `RUSTFLAGS` variable.
+

--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -26,11 +26,6 @@ extern crate cc;
 use std::env;
 
 fn main() {
-    if cfg!(feature = "external-symbols") {
-        println!("cargo:rustc-link-lib=static=secp256k1");
-        return;
-    }
-
     // Actual build
     let mut base_config = cc::Build::new();
     base_config.include("depend/secp256k1/")

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -26,6 +26,9 @@
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
+#[cfg(rust_secp_fuzz)]
+const THIS_UNUSED_CONSTANT_IS_YOUR_WARNING_THAT_ALL_THE_CRYPTO_IN_THIS_LIB_IS_DISABLED_FOR_FUZZING: usize = 0;
+
 #[macro_use]
 mod macros;
 pub mod types;

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -93,7 +93,7 @@ pub type SchnorrNonceFn = unsafe extern "C" fn(
 #[derive(Clone, Debug)]
 #[repr(C)] pub struct Context(c_int);
 
-#[cfg(feature = "fuzztarget")]
+#[cfg(rust_secp_fuzz)]
 impl Context {
     pub fn flags(&self) -> u32 {
         self.0 as u32
@@ -260,7 +260,7 @@ impl hash::Hash for KeyPair {
     }
 }
 
-#[cfg(not(feature = "fuzztarget"))]
+#[cfg(not(rust_secp_fuzz))]
 extern "C" {
     /// Default ECDH hash function
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdh_hash_function_default")]
@@ -674,7 +674,7 @@ impl<T> CPtr for [T] {
 
 
 
-#[cfg(feature = "fuzztarget")]
+#[cfg(rust_secp_fuzz)]
 mod fuzz_dummy {
     extern crate std;
     use self::std::{ptr, mem};
@@ -1156,7 +1156,8 @@ mod fuzz_dummy {
         unimplemented!();
     }
 }
-#[cfg(feature = "fuzztarget")]
+
+#[cfg(rust_secp_fuzz)]
 pub use self::fuzz_dummy::*;
 
 

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -263,91 +263,91 @@ impl hash::Hash for KeyPair {
 #[cfg(not(feature = "fuzztarget"))]
 extern "C" {
     /// Default ECDH hash function
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdh_hash_function_default")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdh_hash_function_default")]
     pub static secp256k1_ecdh_hash_function_default: EcdhHashFn;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_nonce_function_rfc6979")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_nonce_function_rfc6979")]
     pub static secp256k1_nonce_function_rfc6979: NonceFn;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_nonce_function_default")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_nonce_function_default")]
     pub static secp256k1_nonce_function_default: NonceFn;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_context_no_precomp")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_context_no_precomp")]
     pub static secp256k1_context_no_precomp: *const Context;
 
     // Contexts
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_context_preallocated_size")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_context_preallocated_size")]
     pub fn secp256k1_context_preallocated_size(flags: c_uint) -> size_t;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_context_preallocated_create")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_context_preallocated_create")]
     pub fn secp256k1_context_preallocated_create(prealloc: *mut c_void, flags: c_uint) -> *mut Context;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_context_preallocated_destroy")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_context_preallocated_destroy")]
     pub fn secp256k1_context_preallocated_destroy(cx: *mut Context);
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_context_preallocated_clone_size")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_context_preallocated_clone_size")]
     pub fn secp256k1_context_preallocated_clone_size(cx: *const Context) -> size_t;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_context_preallocated_clone")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_context_preallocated_clone")]
     pub fn secp256k1_context_preallocated_clone(cx: *const Context, prealloc: *mut c_void) -> *mut Context;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_context_randomize")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_context_randomize")]
     pub fn secp256k1_context_randomize(cx: *mut Context,
                                        seed32: *const c_uchar)
                                        -> c_int;
 
     // Pubkeys
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_parse")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_parse")]
     pub fn secp256k1_ec_pubkey_parse(cx: *const Context, pk: *mut PublicKey,
                                      input: *const c_uchar, in_len: size_t)
                                      -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_serialize")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_serialize")]
     pub fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *mut c_uchar,
                                          out_len: *mut size_t, pk: *const PublicKey,
                                          compressed: c_uint)
                                          -> c_int;
 
     // Signatures
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_parse_der")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_parse_der")]
     pub fn secp256k1_ecdsa_signature_parse_der(cx: *const Context, sig: *mut Signature,
                                                input: *const c_uchar, in_len: size_t)
                                                -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_parse_compact")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_parse_compact")]
     pub fn secp256k1_ecdsa_signature_parse_compact(cx: *const Context, sig: *mut Signature,
                                                    input64: *const c_uchar)
                                                    -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_parse_der_lax")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_parse_der_lax")]
     pub fn ecdsa_signature_parse_der_lax(cx: *const Context, sig: *mut Signature,
                                          input: *const c_uchar, in_len: size_t)
                                          -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_serialize_der")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_serialize_der")]
     pub fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *mut c_uchar,
                                                    out_len: *mut size_t, sig: *const Signature)
                                                    -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_serialize_compact")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_serialize_compact")]
     pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *mut c_uchar,
                                                        sig: *const Signature)
                                                        -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_normalize")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_signature_normalize")]
     pub fn secp256k1_ecdsa_signature_normalize(cx: *const Context, out_sig: *mut Signature,
                                                in_sig: *const Signature)
                                                -> c_int;
 
     // ECDSA
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_verify")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_verify")]
     pub fn secp256k1_ecdsa_verify(cx: *const Context,
                                   sig: *const Signature,
                                   msg32: *const c_uchar,
                                   pk: *const PublicKey)
                                   -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_sign")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_sign")]
     pub fn secp256k1_ecdsa_sign(cx: *const Context,
                                 sig: *mut Signature,
                                 msg32: *const c_uchar,
@@ -357,11 +357,11 @@ extern "C" {
                                 -> c_int;
 
     // EC
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_seckey_verify")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_seckey_verify")]
     pub fn secp256k1_ec_seckey_verify(cx: *const Context,
                                       sk: *const c_uchar) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_create")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_create")]
     pub fn secp256k1_ec_pubkey_create(cx: *const Context, pk: *mut PublicKey,
                                       sk: *const c_uchar) -> c_int;
 
@@ -369,64 +369,64 @@ extern "C" {
 //TODO secp256k1_ec_privkey_import
 
     #[deprecated(since = "0.2.0",note = "Please use the secp256k1_ec_seckey_tweak_add function instead")]
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_privkey_negate")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_privkey_negate")]
     pub fn secp256k1_ec_privkey_negate(cx: *const Context,
                                        sk: *mut c_uchar) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_privkey_negate")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_privkey_negate")]
     pub fn secp256k1_ec_seckey_negate(cx: *const Context,
                                       sk: *mut c_uchar) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_negate")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_negate")]
     pub fn secp256k1_ec_pubkey_negate(cx: *const Context,
                                       pk: *mut PublicKey) -> c_int;
 
     #[deprecated(since = "0.2.0",note = "Please use the secp256k1_ec_seckey_tweak_add function instead")]
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_privkey_tweak_add")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_privkey_tweak_add")]
     pub fn secp256k1_ec_privkey_tweak_add(cx: *const Context,
                                           sk: *mut c_uchar,
                                           tweak: *const c_uchar)
                                           -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_seckey_tweak_add")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_seckey_tweak_add")]
     pub fn secp256k1_ec_seckey_tweak_add(cx: *const Context,
                                         sk: *mut c_uchar,
                                         tweak: *const c_uchar)
                                         -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_tweak_add")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_tweak_add")]
     pub fn secp256k1_ec_pubkey_tweak_add(cx: *const Context,
                                          pk: *mut PublicKey,
                                          tweak: *const c_uchar)
                                          -> c_int;
 
     #[deprecated(since = "0.2.0",note = "Please use the secp256k1_ec_seckey_tweak_mul function instead")]
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_privkey_tweak_mul")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_privkey_tweak_mul")]
     pub fn secp256k1_ec_privkey_tweak_mul(cx: *const Context,
                                           sk: *mut c_uchar,
                                           tweak: *const c_uchar)
                                           -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_seckey_tweak_mul")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_seckey_tweak_mul")]
     pub fn secp256k1_ec_seckey_tweak_mul(cx: *const Context,
                                         sk: *mut c_uchar,
                                         tweak: *const c_uchar)
                                         -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_tweak_mul")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_tweak_mul")]
     pub fn secp256k1_ec_pubkey_tweak_mul(cx: *const Context,
                                          pk: *mut PublicKey,
                                          tweak: *const c_uchar)
                                          -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_combine")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ec_pubkey_combine")]
     pub fn secp256k1_ec_pubkey_combine(cx: *const Context,
                                        out: *mut PublicKey,
                                        ins: *const *const PublicKey,
                                        n: c_int)
                                        -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdh")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdh")]
     pub fn secp256k1_ecdh(
         cx: *const Context,
         output: *mut c_uchar,
@@ -438,10 +438,10 @@ extern "C" {
 
 
     // Schnorr Signatures
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_nonce_function_bip340")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_nonce_function_bip340")]
     pub static secp256k1_nonce_function_bip340: SchnorrNonceFn;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_schnorrsig_sign")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_schnorrsig_sign")]
     pub fn secp256k1_schnorrsig_sign(
         cx: *const Context,
         sig: *mut c_uchar,
@@ -451,7 +451,7 @@ extern "C" {
         noncedata: *const c_void
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_schnorrsig_verify")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_schnorrsig_verify")]
     pub fn secp256k1_schnorrsig_verify(
         cx: *const Context,
         sig64: *const c_uchar,
@@ -461,28 +461,28 @@ extern "C" {
 
     // Extra keys
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_keypair_create")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_keypair_create")]
     pub fn secp256k1_keypair_create(
         cx: *const Context,
         keypair: *mut KeyPair,
         seckey: *const c_uchar,
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_parse")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_parse")]
     pub fn secp256k1_xonly_pubkey_parse(
         cx: *const Context,
         pubkey: *mut XOnlyPublicKey,
         input32: *const c_uchar,
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_serialize")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_serialize")]
     pub fn secp256k1_xonly_pubkey_serialize(
         cx: *const Context,
         output32: *mut c_uchar,
         pubkey: *const XOnlyPublicKey,
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_from_pubkey")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_from_pubkey")]
     pub fn secp256k1_xonly_pubkey_from_pubkey(
         cx: *const Context,
         xonly_pubkey: *mut XOnlyPublicKey,
@@ -490,7 +490,7 @@ extern "C" {
         pubkey: *const PublicKey,
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_tweak_add")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_tweak_add")]
     pub fn secp256k1_xonly_pubkey_tweak_add(
         cx: *const Context,
         output_pubkey: *mut PublicKey,
@@ -498,7 +498,7 @@ extern "C" {
         tweak32: *const c_uchar,
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_keypair_xonly_pub")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_keypair_xonly_pub")]
     pub fn secp256k1_keypair_xonly_pub(
         cx: *const Context,
         pubkey: *mut XOnlyPublicKey,
@@ -506,14 +506,14 @@ extern "C" {
         keypair: *const KeyPair
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_keypair_xonly_tweak_add")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_keypair_xonly_tweak_add")]
     pub fn secp256k1_keypair_xonly_tweak_add(
         cx: *const Context,
         keypair: *mut KeyPair,
         tweak32: *const c_uchar,
     ) -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_tweak_add_check")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_xonly_pubkey_tweak_add_check")]
     pub fn secp256k1_xonly_pubkey_tweak_add_check(
         cx: *const Context,
         tweaked_pubkey32: *const c_uchar,
@@ -533,7 +533,7 @@ extern "C" {
 // Returns: a newly created context object.
 //  In:      flags: which parts of the context to initialize.
 #[no_mangle]
-#[cfg(all(feature = "std", not(feature = "external-symbols")))]
+#[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
 pub unsafe extern "C" fn rustsecp256k1_v0_3_1_context_create(flags: c_uint) -> *mut Context {
     use core::mem;
     use std::alloc;
@@ -552,7 +552,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_3_1_context_create(flags: c_uint) -> *
     secp256k1_context_preallocated_create(ptr, flags)
 }
 
-#[cfg(all(feature = "std", not(feature = "external-symbols")))]
+#[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
 pub unsafe fn secp256k1_context_create(flags: c_uint) -> *mut Context {
     rustsecp256k1_v0_3_1_context_create(flags)
 }
@@ -564,7 +564,7 @@ pub unsafe fn secp256k1_context_create(flags: c_uint) -> *mut Context {
 /// The pointer shouldn't be used after passing to this function, consider it as passing it to `free()`.
 ///
 #[no_mangle]
-#[cfg(all(feature = "std", not(feature = "external-symbols")))]
+#[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
 pub unsafe extern "C" fn rustsecp256k1_v0_3_1_context_destroy(ctx: *mut Context) {
     use std::alloc;
     secp256k1_context_preallocated_destroy(ctx);
@@ -574,7 +574,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_3_1_context_destroy(ctx: *mut Context)
     alloc::dealloc(ptr, layout);
 }
 
-#[cfg(all(feature = "std", not(feature = "external-symbols")))]
+#[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
 pub unsafe fn secp256k1_context_destroy(ctx: *mut Context) {
     rustsecp256k1_v0_3_1_context_destroy(ctx)
 }
@@ -599,7 +599,7 @@ pub unsafe fn secp256k1_context_destroy(ctx: *mut Context) {
 /// See also secp256k1_default_error_callback_fn.
 ///
 #[no_mangle]
-#[cfg(not(feature = "external-symbols"))]
+#[cfg(not(rust_secp_no_symbol_renaming))]
 pub unsafe extern "C" fn rustsecp256k1_v0_3_1_default_illegal_callback_fn(message: *const c_char, _data: *mut c_void) {
     use core::str;
     let msg_slice = slice::from_raw_parts(message as *const u8, strlen(message));
@@ -622,7 +622,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_3_1_default_illegal_callback_fn(messag
 /// See also secp256k1_default_illegal_callback_fn.
 ///
 #[no_mangle]
-#[cfg(not(feature = "external-symbols"))]
+#[cfg(not(rust_secp_no_symbol_renaming))]
 pub unsafe extern "C" fn rustsecp256k1_v0_3_1_default_error_callback_fn(message: *const c_char, _data: *mut c_void) {
     use core::str;
     let msg_slice = slice::from_raw_parts(message as *const u8, strlen(message));
@@ -631,7 +631,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_3_1_default_error_callback_fn(message:
 }
 
 #[no_mangle]
-#[cfg(not(feature = "external-symbols"))]
+#[cfg(not(rust_secp_no_symbol_renaming))]
 unsafe fn strlen(mut str_ptr: *const c_char) -> usize {
     let mut ctr = 0;
     while *str_ptr != '\0' as c_char {
@@ -689,11 +689,11 @@ mod fuzz_dummy {
     pub static secp256k1_context_no_precomp: &Context = &Context(0);
 
     extern "C" {
-        #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdh_hash_function_default")]
+        #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdh_hash_function_default")]
         pub static secp256k1_ecdh_hash_function_default: EcdhHashFn;
-        #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_nonce_function_rfc6979")]
+        #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_nonce_function_rfc6979")]
         pub static secp256k1_nonce_function_rfc6979: NonceFn;
-        #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_nonce_function_bip340")]
+        #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_nonce_function_bip340")]
         pub static secp256k1_nonce_function_bip340: SchnorrNonceFn;
     }
 
@@ -1163,7 +1163,7 @@ pub use self::fuzz_dummy::*;
 #[cfg(test)]
 mod tests {
     #[no_mangle]
-    #[cfg(not(feature = "external-symbols"))]
+    #[cfg(not(rust_secp_no_symbol_renaming))]
     #[test]
     fn test_strlen() {
         use std::ffi::CString;

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -38,21 +38,21 @@ impl Default for RecoverableSignature {
 
 #[cfg(not(feature = "fuzztarget"))]
 extern "C" {
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_recoverable_signature_parse_compact")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_recoverable_signature_parse_compact")]
     pub fn secp256k1_ecdsa_recoverable_signature_parse_compact(cx: *const Context, sig: *mut RecoverableSignature,
                                                                input64: *const c_uchar, recid: c_int)
                                                                -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_recoverable_signature_serialize_compact")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_recoverable_signature_serialize_compact")]
     pub fn secp256k1_ecdsa_recoverable_signature_serialize_compact(cx: *const Context, output64: *mut c_uchar,
                                                                    recid: *mut c_int, sig: *const RecoverableSignature)
                                                                    -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_recoverable_signature_convert")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_recoverable_signature_convert")]
     pub fn secp256k1_ecdsa_recoverable_signature_convert(cx: *const Context, sig: *mut Signature,
                                                          input: *const RecoverableSignature)
                                                          -> c_int;
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_sign_recoverable")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_sign_recoverable")]
     pub fn secp256k1_ecdsa_sign_recoverable(cx: *const Context,
                                             sig: *mut RecoverableSignature,
                                             msg32: *const c_uchar,
@@ -61,7 +61,7 @@ extern "C" {
                                             noncedata: *const c_void)
                                             -> c_int;
 
-    #[cfg_attr(not(feature = "external-symbols"), link_name = "rustsecp256k1_v0_3_1_ecdsa_recover")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_recover")]
     pub fn secp256k1_ecdsa_recover(cx: *const Context,
                                    pk: *mut PublicKey,
                                    sig: *const RecoverableSignature,

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -16,7 +16,7 @@
 //! # FFI of the recovery module
 
 use ::types::*;
-#[cfg(not(feature = "fuzztarget"))]
+#[cfg(not(rust_secp_fuzz))]
 use ::{Context, Signature, NonceFn, PublicKey};
 
 /// Library-internal representation of a Secp256k1 signature + recovery ID
@@ -36,7 +36,7 @@ impl Default for RecoverableSignature {
     }
 }
 
-#[cfg(not(feature = "fuzztarget"))]
+#[cfg(not(rust_secp_fuzz))]
 extern "C" {
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_3_1_ecdsa_recoverable_signature_parse_compact")]
     pub fn secp256k1_ecdsa_recoverable_signature_parse_compact(cx: *const Context, sig: *mut RecoverableSignature,
@@ -70,7 +70,7 @@ extern "C" {
 }
 
 
-#[cfg(feature = "fuzztarget")]
+#[cfg(rust_secp_fuzz)]
 mod fuzz_dummy {
     extern crate std;
     use self::std::ptr;
@@ -126,6 +126,6 @@ mod fuzz_dummy {
         unimplemented!();
     }
 }
-#[cfg(feature = "fuzztarget")]
+#[cfg(rust_secp_fuzz)]
 pub use self::fuzz_dummy::*;
 

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -40,7 +40,7 @@ impl AlignedType {
     }
 }
 
-#[cfg(all(feature = "std", not(feature = "external-symbols")))]
+#[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
 pub(crate) const ALIGN_TO: usize = mem::align_of::<AlignedType>();
 
 


### PR DESCRIPTION
cc @TheBlueMatt 

For Core integration you now need to add `--cfg=rust_secp_no_symbol_renaming` to your rustc flags rather than `--cfg=features=external-symbols`.

For fuzzing you need to add `--cfg=rust_secp_fuzz` rather than `--cfg=features=fuzztarget`. Our downstream fuzzing scripts will need to be adjusted.