### PR TITLE
Rename `rust_secp_fuzz` config flag to `fuzzing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.20.0"
+version = "0.20.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/README.md
+++ b/README.md
@@ -42,5 +42,7 @@ If you want to fuzz this library, or any library which depends on it, you will
 probably want to disable the actual cryptography, since fuzzers are unable to
 forge signatures and therefore won't test many interesting codepaths. To instead
 use a trivially-broken but fuzzer-accessible signature scheme, compile with
-`--cfg=rust_secp_fuzz` in your `RUSTFLAGS` variable.
+`--cfg=fuzzing` in your `RUSTFLAGS` variable.
+
+Note that `cargo hfuzz` sets this config flag automatically.
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -34,14 +34,14 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     done
 
     # Other combos 
-    RUSTFLAGS='--cfg=rust_secp_fuzz' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all
-    RUSTFLAGS='--cfg=rust_secp_fuzz' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all --features="$FEATURES"
+    RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all
+    RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all --features="$FEATURES"
     cargo test --all --features="rand rand-std"
     cargo test --all --features="rand serde"
 
     if [ "$DO_BENCH" = true ]; then  # proxy for us having a nightly compiler
         cargo test --all --all-features
-        RUSTFLAGS='--cfg=rust_secp_fuzz' RUSTDOCFLAGS='--cfg=rust_secp_fuzz' cargo test --all --all-features
+        RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS='--cfg=fuzzing' cargo test --all --all-features
     fi
 
     # Examples

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -26,7 +26,7 @@
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
-#[cfg(rust_secp_fuzz)]
+#[cfg(fuzzing)]
 const THIS_UNUSED_CONSTANT_IS_YOUR_WARNING_THAT_ALL_THE_CRYPTO_IN_THIS_LIB_IS_DISABLED_FOR_FUZZING: usize = 0;
 
 #[macro_use]
@@ -480,7 +480,7 @@ extern "C" {
     ) -> c_int;
 }
 
-#[cfg(not(rust_secp_fuzz))]
+#[cfg(not(fuzzing))]
 extern "C" {
     // ECDSA
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_ecdsa_verify")]
@@ -666,7 +666,7 @@ impl<T> CPtr for [T] {
     }
 }
 
-#[cfg(rust_secp_fuzz)]
+#[cfg(fuzzing)]
 mod fuzz_dummy {
     use super::*;
 
@@ -755,7 +755,7 @@ mod fuzz_dummy {
     }
 }
 
-#[cfg(rust_secp_fuzz)]
+#[cfg(fuzzing)]
 pub use self::fuzz_dummy::*;
 
 #[cfg(test)]

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -52,7 +52,7 @@ extern "C" {
                                                          -> c_int;
 }
 
-#[cfg(not(rust_secp_fuzz))]
+#[cfg(not(fuzzing))]
 extern "C" {
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_ecdsa_sign_recoverable")]
     pub fn secp256k1_ecdsa_sign_recoverable(cx: *const Context,
@@ -72,7 +72,7 @@ extern "C" {
 }
 
 
-#[cfg(rust_secp_fuzz)]
+#[cfg(fuzzing)]
 mod fuzz_dummy {
     use super::*;
     use std::slice;
@@ -146,6 +146,6 @@ mod fuzz_dummy {
         1
     }
 }
-#[cfg(rust_secp_fuzz)]
+#[cfg(fuzzing)]
 pub use self::fuzz_dummy::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@
 //!     0xc9, 0x42, 0x8f, 0xca, 0x69, 0xc1, 0x32, 0xa2,
 //! ]).expect("compact signatures are 64 bytes; DER signatures are 68-72 bytes");
 //!
-//! # #[cfg(not(rust_secp_fuzz))]
+//! # #[cfg(not(fuzzing))]
 //! assert!(secp.verify(&message, &sig, &public_key).is_ok());
 //! ```
 //!
@@ -744,7 +744,7 @@ impl<C: Signing> Secp256k1<C> {
                     entropy_p = extra_entropy.as_ptr() as *const ffi::types::c_void;
 
                     // When fuzzing, these checks will usually spinloop forever, so just short-circuit them.
-                    #[cfg(rust_secp_fuzz)]
+                    #[cfg(fuzzing)]
                     return Signature::from(ret);
                 }
             }
@@ -1108,12 +1108,12 @@ mod tests {
             if compact[0] < 0x80 {
                 assert_eq!(sig, low_r_sig);
             } else {
-                #[cfg(not(rust_secp_fuzz))]  // mocked sig generation doesn't produce low-R sigs
+                #[cfg(not(fuzzing))]  // mocked sig generation doesn't produce low-R sigs
                 assert_ne!(sig, low_r_sig);
             }
-            #[cfg(not(rust_secp_fuzz))]  // mocked sig generation doesn't produce low-R sigs
+            #[cfg(not(fuzzing))]  // mocked sig generation doesn't produce low-R sigs
             assert!(super::compact_sig_has_zero_first_bit(&low_r_sig.0));
-            #[cfg(not(rust_secp_fuzz))]  // mocked sig generation doesn't produce low-R sigs
+            #[cfg(not(fuzzing))]  // mocked sig generation doesn't produce low-R sigs
             assert!(super::der_length_check(&grind_r_sig.0, 70));
          }
     }
@@ -1186,7 +1186,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(rust_secp_fuzz))]  // fixed sig vectors can't work with fuzz-sigs
+    #[cfg(not(fuzzing))]  // fixed sig vectors can't work with fuzz-sigs
     fn test_low_s() {
         // nb this is a transaction on testnet
         // txid 8ccc87b72d766ab3128f03176bb1c98293f2d1f85ebfaf07b82cc81ea6891fa9
@@ -1208,7 +1208,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(rust_secp_fuzz))]  // fuzz-sigs have fixed size/format
+    #[cfg(not(fuzzing))]  // fuzz-sigs have fixed size/format
     fn test_low_r() {
         let secp = Secp256k1::new();
         let msg = hex!("887d04bb1cf1b1554f1b268dfe62d13064ca67ae45348d50d1392ce2d13418ac");
@@ -1223,7 +1223,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(rust_secp_fuzz))]  // fuzz-sigs have fixed size/format
+    #[cfg(not(fuzzing))]  // fuzz-sigs have fixed size/format
     fn test_grind_r() {
         let secp = Secp256k1::new();
         let msg = hex!("ef2d5b9a7c61865a95941d0f04285420560df7e9d76890ac1b8867b12ce43167");
@@ -1237,7 +1237,7 @@ mod tests {
     }
 
     #[cfg(feature = "serde")]
-    #[cfg(not(rust_secp_fuzz))]  // fixed sig vectors can't work with fuzz-sigs
+    #[cfg(not(fuzzing))]  // fixed sig vectors can't work with fuzz-sigs
     #[test]
     fn test_signature_serde() {
         use serde_test::{Configure, Token, assert_tokens};

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -235,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(rust_secp_fuzz))]  // fixed sig vectors can't work with fuzz-sigs
+    #[cfg(not(fuzzing))]  // fixed sig vectors can't work with fuzz-sigs
     fn sign() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());

--- a/src/schnorrsig.rs
+++ b/src/schnorrsig.rs
@@ -561,7 +561,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(rust_secp_fuzz))]  // fixed sig vectors can't work with fuzz-sigs
+    #[cfg(not(fuzzing))]  // fixed sig vectors can't work with fuzz-sigs
     fn test_schnorrsig_sign() {
         let secp = Secp256k1::new();
 
@@ -583,7 +583,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(rust_secp_fuzz))]  // fixed sig vectors can't work with fuzz-sigs
+    #[cfg(not(fuzzing))]  // fixed sig vectors can't work with fuzz-sigs
     fn test_schnorrsig_verify() {
         let secp = Secp256k1::new();
 
@@ -722,7 +722,7 @@ mod tests {
     }
 
     #[cfg(feature = "serde")]
-    #[cfg(not(rust_secp_fuzz))]  // fixed sig vectors can't work with fuzz-sigs
+    #[cfg(not(fuzzing))]  // fixed sig vectors can't work with fuzz-sigs
     #[test]
     fn test_signature_serde() {
         use serde_test::{assert_tokens, Configure, Token};


### PR DESCRIPTION
This matches what `cargo hfuzz` sets, meaning that there are no downstream changes needed to support this.

See https://github.com/rust-fuzz/honggfuzz-rs/blob/master/README.md