### PR TITLE
More standard derives for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ impl<T: ThirtyTwoByteHash> From<T> for Message {
 }
 
 /// An ECDSA error
-#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub enum Error {
     /// Signature failed verification
     IncorrectSignature,


### PR DESCRIPTION
According to the discussion in https://github.com/rust-bitcoin/rust-bitcoin/issues/555

This PR is required for further work on error types derives in rust-bitcoin