### PR TITLE
Add a global-context-less-secure feature which skips randomization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ std = ["secp256k1-sys/std"]
 rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
-global-context = ["std", "rand-std"]
+global-context = ["std", "rand-std", "global-context-less-secure"]
+global-context-less-secure = []
 
 [dependencies]
 secp256k1-sys = { version = "0.4.0", default-features = false, path = "./secp256k1-sys" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ use core::ops::Deref;
 use core::mem;
 use ffi::{CPtr, types::AlignedType};
 
-#[cfg(feature = "global-context")]
+#[cfg(feature = "global-context-less-secure")]
 pub use context::global::SECP256K1;
 
 #[cfg(feature = "bitcoin_hashes")]
@@ -1269,7 +1269,7 @@ mod tests {
 
     }
 
-    #[cfg(feature = "global-context")]
+    #[cfg(feature = "global-context-less-secure")]
     #[test]
     fn test_global_context() {
         use super::SECP256K1;


### PR DESCRIPTION
This is useful for us downstream as we wish to target WASM with a
global context, and using rand in such a build doesn't seem like a
safe idea.