### PR TITLE
Use CARGO_CFG_TARGET_ARCH instead TARGET in build.rs

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -51,10 +51,9 @@ fn main() {
     #[cfg(feature = "recovery")]
     base_config.define("ENABLE_MODULE_RECOVERY", Some("1"));
 
-    match &env::var("TARGET").unwrap() as &str {
-        "wasm32-unknown-unknown"|"wasm32-wasi" =>
-            { base_config.include("wasm-sysroot"); },
-        _ => {},
+    // Header files. WASM only.
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "wasm32" {
+        base_config.include("wasm-sysroot");
     }
 
     // secp256k1


### PR DESCRIPTION
In code for wasm detection `target_arch` is used. I think to use `CARGO_CFG_TARGET_ARCH` instead `TARGET` in the build file will be more correct.