### PR TITLE
Add ecdh, extrakeys, schnorrsig features to secp256k1-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std", "rand-std"]
 
 [dependencies]
-secp256k1-sys = { version = "0.4.0", default-features = false, path = "./secp256k1-sys" }
+secp256k1-sys = { version = "0.4.0", default-features = false, features = ["ecdh"], path = "./secp256k1-sys" }
 bitcoin_hashes = { version = "0.9", optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std", "rand-std"]
 
 [dependencies]
-secp256k1-sys = { version = "0.4.0", default-features = false, features = ["ecdh"], path = "./secp256k1-sys" }
+secp256k1-sys = { version = "0.4.0", default-features = false, features = ["ecdh", "schnorrsig"], path = "./secp256k1-sys" }
 bitcoin_hashes = { version = "0.9", optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -25,9 +25,10 @@ cc = "1.0.28"
 libc = "0.2"
 
 [features]
-default = ["std", "ecdh", "schnorrsig"]
+default = ["std", "ecdh", "extrakeys", "schnorrsig"]
 std = []
 lowmemory = []
 ecdh = []
+extrakeys = []
 recovery = []
-schnorrsig = []
+schnorrsig = ["extrakeys"]

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2"
 
 [features]
 default = ["std"]
-recovery = []
-lowmemory = []
 std = []
-
+lowmemory = []
+ecdh = []
+recovery = []

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -25,8 +25,9 @@ cc = "1.0.28"
 libc = "0.2"
 
 [features]
-default = ["std"]
+default = ["std", "ecdh", "schnorrsig"]
 std = []
 lowmemory = []
 ecdh = []
 recovery = []
+schnorrsig = []

--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -33,7 +33,6 @@ fn main() {
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
                .define("SECP256K1_BUILD", Some("1"))
-               .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))
                .define("ECMULT_GEN_PREC_BITS", Some("4"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
                .define("USE_NUM_NONE", Some("1"))
@@ -49,6 +48,9 @@ fn main() {
 
     #[cfg(feature = "ecdh")]
     base_config.define("ENABLE_MODULE_ECDH", Some("1"));
+
+    #[cfg(feature = "extrakeys")]
+    base_config.define("ENABLE_MODULE_EXTRAKEYS", Some("1"));
 
     #[cfg(feature = "recovery")]
     base_config.define("ENABLE_MODULE_RECOVERY", Some("1"));

--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -33,7 +33,6 @@ fn main() {
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
                .define("SECP256K1_BUILD", Some("1"))
-               .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))
                .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))
                .define("ECMULT_GEN_PREC_BITS", Some("4"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
@@ -53,6 +52,9 @@ fn main() {
 
     #[cfg(feature = "recovery")]
     base_config.define("ENABLE_MODULE_RECOVERY", Some("1"));
+
+    #[cfg(feature = "schnorrsig")]
+    base_config.define("ENABLE_MODULE_SCHNORRSIG", Some("1"));
 
     match &env::var("TARGET").unwrap() as &str {
         "wasm32-unknown-unknown"|"wasm32-wasi" =>

--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -33,21 +33,24 @@ fn main() {
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
                .define("SECP256K1_BUILD", Some("1"))
-               .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))
                .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))
                .define("ECMULT_GEN_PREC_BITS", Some("4"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
-               .define("USE_SCALAR_INV_BUILTIN", Some("1"));
+               .define("USE_SCALAR_INV_BUILTIN", Some("1"))
+               .define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
     
     if cfg!(feature = "lowmemory") {
         base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
     } else {
         base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
     }
-    base_config.define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
+
+    #[cfg(feature = "ecdh")]
+    base_config.define("ENABLE_MODULE_ECDH", Some("1"));
+
     #[cfg(feature = "recovery")]
     base_config.define("ENABLE_MODULE_RECOVERY", Some("1"));
 

--- a/secp256k1-sys/src/ecdh.rs
+++ b/secp256k1-sys/src/ecdh.rs
@@ -1,0 +1,45 @@
+// Bitcoin secp256k1 bindings
+// Written in 2014 by
+//   Dawid Ciężarkiewicz
+//   Andrew Poelstra
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # FFI of the ecdh module
+
+use ::types::*;
+use {Context, PublicKey};
+
+/// Hash function to use to post-process an ECDH point to get
+/// a shared secret.
+pub type EcdhHashFn = Option<unsafe extern "C" fn(
+    output: *mut c_uchar,
+    x: *const c_uchar,
+    y: *const c_uchar,
+    data: *mut c_void,
+) -> c_int>;
+
+extern "C" {
+    /// Default ECDH hash function
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_ecdh_hash_function_default")]
+    pub static secp256k1_ecdh_hash_function_default: EcdhHashFn;
+
+    #[cfg(feature = "ecdh")]
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_ecdh")]
+    pub fn secp256k1_ecdh(
+        cx: *const Context,
+        output: *mut c_uchar,
+        pubkey: *const PublicKey,
+        seckey: *const c_uchar,
+        hashfp: EcdhHashFn,
+        data: *mut c_void,
+    ) -> c_int;
+}

--- a/secp256k1-sys/src/extrakeys.rs
+++ b/secp256k1-sys/src/extrakeys.rs
@@ -1,0 +1,166 @@
+// Bitcoin secp256k1 bindings
+// Written in 2014 by
+//   Dawid Ciężarkiewicz
+//   Andrew Poelstra
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # FFI of the extrakeys module
+
+use ::types::*;
+use {Context, PublicKey};
+
+use core::hash;
+
+#[repr(C)]
+pub struct XOnlyPublicKey([c_uchar; 64]);
+impl_array_newtype!(XOnlyPublicKey, c_uchar, 64);
+impl_raw_debug!(XOnlyPublicKey);
+
+impl XOnlyPublicKey {
+    /// Creates an "uninitialized" FFI x-only public key which is zeroed out
+    ///
+    /// If you pass this to any FFI functions, except as an out-pointer,
+    /// the result is likely to be an assertation failure and process
+    /// termination.
+    pub unsafe fn new() -> Self {
+        Self::from_array_unchecked([0; 64])
+    }
+
+    /// Create a new x-only public key usable for the FFI interface from raw bytes
+    ///
+    /// Does not check the validity of the underlying representation. If it is
+    /// invalid the result may be assertation failures (and process aborts) from
+    /// the underlying library. You should not use this method except with data
+    /// that you obtained from the FFI interface of the same version of this
+    /// library.
+    pub unsafe fn from_array_unchecked(data: [c_uchar; 64]) -> Self {
+        XOnlyPublicKey(data)
+    }
+
+    /// Returns the underlying FFI opaque representation of the x-only public key
+    ///
+    /// You should not use this unless you really know what you are doing. It is
+    /// essentially only useful for extending the FFI interface itself.
+    pub fn underlying_bytes(self) -> [c_uchar; 64] {
+        self.0
+    }
+}
+
+impl hash::Hash for XOnlyPublicKey {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.0)
+    }
+}
+
+#[repr(C)]
+pub struct KeyPair([c_uchar; 96]);
+impl_array_newtype!(KeyPair, c_uchar, 96);
+impl_raw_debug!(KeyPair);
+
+impl KeyPair {
+    /// Creates an "uninitialized" FFI keypair which is zeroed out
+    ///
+    /// If you pass this to any FFI functions, except as an out-pointer,
+    /// the result is likely to be an assertation failure and process
+    /// termination.
+    pub unsafe fn new() -> Self {
+        Self::from_array_unchecked([0; 96])
+    }
+
+    /// Create a new keypair usable for the FFI interface from raw bytes
+    ///
+    /// Does not check the validity of the underlying representation. If it is
+    /// invalid the result may be assertation failures (and process aborts) from
+    /// the underlying library. You should not use this method except with data
+    /// that you obtained from the FFI interface of the same version of this
+    /// library.
+    pub unsafe fn from_array_unchecked(data: [c_uchar; 96]) -> Self {
+        KeyPair(data)
+    }
+
+    /// Returns the underlying FFI opaque representation of the x-only public key
+    ///
+    /// You should not use this unless you really know what you are doing. It is
+    /// essentially only useful for extending the FFI interface itself.
+    pub fn underlying_bytes(self) -> [c_uchar; 96] {
+        self.0
+    }
+}
+
+impl hash::Hash for KeyPair {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.0)
+    }
+}
+
+extern "C" {
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_keypair_create")]
+    pub fn secp256k1_keypair_create(
+        cx: *const Context,
+        keypair: *mut KeyPair,
+        seckey: *const c_uchar,
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_parse")]
+    pub fn secp256k1_xonly_pubkey_parse(
+        cx: *const Context,
+        pubkey: *mut XOnlyPublicKey,
+        input32: *const c_uchar,
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_serialize")]
+    pub fn secp256k1_xonly_pubkey_serialize(
+        cx: *const Context,
+        output32: *mut c_uchar,
+        pubkey: *const XOnlyPublicKey,
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_from_pubkey")]
+    pub fn secp256k1_xonly_pubkey_from_pubkey(
+        cx: *const Context,
+        xonly_pubkey: *mut XOnlyPublicKey,
+        pk_parity: *mut c_int,
+        pubkey: *const PublicKey,
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_tweak_add")]
+    pub fn secp256k1_xonly_pubkey_tweak_add(
+        cx: *const Context,
+        output_pubkey: *mut PublicKey,
+        internal_pubkey: *const XOnlyPublicKey,
+        tweak32: *const c_uchar,
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_keypair_xonly_pub")]
+    pub fn secp256k1_keypair_xonly_pub(
+        cx: *const Context,
+        pubkey: *mut XOnlyPublicKey,
+        pk_parity: *mut c_int,
+        keypair: *const KeyPair
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_keypair_xonly_tweak_add")]
+    pub fn secp256k1_keypair_xonly_tweak_add(
+        cx: *const Context,
+        keypair: *mut KeyPair,
+        tweak32: *const c_uchar,
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_tweak_add_check")]
+    pub fn secp256k1_xonly_pubkey_tweak_add_check(
+        cx: *const Context,
+        tweaked_pubkey32: *const c_uchar,
+        tweaked_pubkey_parity: c_int,
+        internal_pubkey: *const XOnlyPublicKey,
+        tweak32: *const c_uchar,
+    ) -> c_int;
+}

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -38,6 +38,11 @@ mod ecdh;
 #[cfg(feature = "ecdh")]
 pub use ecdh::*;
 
+#[cfg(feature = "extrakeys")]
+pub(crate) mod extrakeys;
+#[cfg(feature = "extrakeys")]
+pub use extrakeys::*;
+
 #[cfg(feature = "recovery")]
 pub mod recovery;
 
@@ -159,88 +164,6 @@ impl Signature {
     /// essentially only useful for extending the FFI interface itself.
     pub fn underlying_bytes(self) -> [c_uchar; 64] {
         self.0
-    }
-}
-
-#[repr(C)]
-pub struct XOnlyPublicKey([c_uchar; 64]);
-impl_array_newtype!(XOnlyPublicKey, c_uchar, 64);
-impl_raw_debug!(XOnlyPublicKey);
-
-impl XOnlyPublicKey {
-    /// Creates an "uninitialized" FFI x-only public key which is zeroed out
-    ///
-    /// If you pass this to any FFI functions, except as an out-pointer,
-    /// the result is likely to be an assertation failure and process
-    /// termination.
-    pub unsafe fn new() -> Self {
-        Self::from_array_unchecked([0; 64])
-    }
-
-    /// Create a new x-only public key usable for the FFI interface from raw bytes
-    ///
-    /// Does not check the validity of the underlying representation. If it is
-    /// invalid the result may be assertation failures (and process aborts) from
-    /// the underlying library. You should not use this method except with data
-    /// that you obtained from the FFI interface of the same version of this
-    /// library.
-    pub unsafe fn from_array_unchecked(data: [c_uchar; 64]) -> Self {
-        XOnlyPublicKey(data)
-    }
-
-    /// Returns the underlying FFI opaque representation of the x-only public key
-    ///
-    /// You should not use this unless you really know what you are doing. It is
-    /// essentially only useful for extending the FFI interface itself.
-    pub fn underlying_bytes(self) -> [c_uchar; 64] {
-        self.0
-    }
-}
-
-impl hash::Hash for XOnlyPublicKey {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.0)
-    }
-}
-
-#[repr(C)]
-pub struct KeyPair([c_uchar; 96]);
-impl_array_newtype!(KeyPair, c_uchar, 96);
-impl_raw_debug!(KeyPair);
-
-impl KeyPair {
-    /// Creates an "uninitialized" FFI keypair which is zeroed out
-    ///
-    /// If you pass this to any FFI functions, except as an out-pointer,
-    /// the result is likely to be an assertation failure and process
-    /// termination.
-    pub unsafe fn new() -> Self {
-        Self::from_array_unchecked([0; 96])
-    }
-
-    /// Create a new keypair usable for the FFI interface from raw bytes
-    ///
-    /// Does not check the validity of the underlying representation. If it is
-    /// invalid the result may be assertation failures (and process aborts) from
-    /// the underlying library. You should not use this method except with data
-    /// that you obtained from the FFI interface of the same version of this
-    /// library.
-    pub unsafe fn from_array_unchecked(data: [c_uchar; 96]) -> Self {
-        KeyPair(data)
-    }
-
-    /// Returns the underlying FFI opaque representation of the x-only public key
-    ///
-    /// You should not use this unless you really know what you are doing. It is
-    /// essentially only useful for extending the FFI interface itself.
-    pub fn underlying_bytes(self) -> [c_uchar; 96] {
-        self.0
-    }
-}
-
-impl hash::Hash for KeyPair {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.0)
     }
 }
 
@@ -386,68 +309,6 @@ extern "C" {
                                        ins: *const *const PublicKey,
                                        n: c_int)
                                        -> c_int;
-
-    // Extra keys
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_keypair_create")]
-    pub fn secp256k1_keypair_create(
-        cx: *const Context,
-        keypair: *mut KeyPair,
-        seckey: *const c_uchar,
-    ) -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_parse")]
-    pub fn secp256k1_xonly_pubkey_parse(
-        cx: *const Context,
-        pubkey: *mut XOnlyPublicKey,
-        input32: *const c_uchar,
-    ) -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_serialize")]
-    pub fn secp256k1_xonly_pubkey_serialize(
-        cx: *const Context,
-        output32: *mut c_uchar,
-        pubkey: *const XOnlyPublicKey,
-    ) -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_from_pubkey")]
-    pub fn secp256k1_xonly_pubkey_from_pubkey(
-        cx: *const Context,
-        xonly_pubkey: *mut XOnlyPublicKey,
-        pk_parity: *mut c_int,
-        pubkey: *const PublicKey,
-    ) -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_tweak_add")]
-    pub fn secp256k1_xonly_pubkey_tweak_add(
-        cx: *const Context,
-        output_pubkey: *mut PublicKey,
-        internal_pubkey: *const XOnlyPublicKey,
-        tweak32: *const c_uchar,
-    ) -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_keypair_xonly_pub")]
-    pub fn secp256k1_keypair_xonly_pub(
-        cx: *const Context,
-        pubkey: *mut XOnlyPublicKey,
-        pk_parity: *mut c_int,
-        keypair: *const KeyPair
-    ) -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_keypair_xonly_tweak_add")]
-    pub fn secp256k1_keypair_xonly_tweak_add(
-        cx: *const Context,
-        keypair: *mut KeyPair,
-        tweak32: *const c_uchar,
-    ) -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_xonly_pubkey_tweak_add_check")]
-    pub fn secp256k1_xonly_pubkey_tweak_add_check(
-        cx: *const Context,
-        tweaked_pubkey32: *const c_uchar,
-        tweaked_pubkey_parity: c_int,
-        internal_pubkey: *const XOnlyPublicKey,
-        tweak32: *const c_uchar,
-    ) -> c_int;
 }
 
 #[cfg(not(fuzzing))]

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -33,6 +33,11 @@ const THIS_UNUSED_CONSTANT_IS_YOUR_WARNING_THAT_ALL_THE_CRYPTO_IN_THIS_LIB_IS_DI
 mod macros;
 pub mod types;
 
+#[cfg(feature = "ecdh")]
+mod ecdh;
+#[cfg(feature = "ecdh")]
+pub use ecdh::*;
+
 #[cfg(feature = "recovery")]
 pub mod recovery;
 
@@ -65,15 +70,6 @@ pub type NonceFn = Option<unsafe extern "C" fn(
     algo16: *const c_uchar,
     data: *mut c_void,
     attempt: c_uint,
-) -> c_int>;
-
-/// Hash function to use to post-process an ECDH point to get
-/// a shared secret.
-pub type EcdhHashFn = Option<unsafe extern "C" fn(
-    output: *mut c_uchar,
-    x: *const c_uchar,
-    y: *const c_uchar,
-    data: *mut c_void,
 ) -> c_int>;
 
 ///  Same as secp256k1_nonce function with the exception of accepting an
@@ -258,10 +254,6 @@ impl hash::Hash for KeyPair {
 }
 
 extern "C" {
-    /// Default ECDH hash function
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_ecdh_hash_function_default")]
-    pub static secp256k1_ecdh_hash_function_default: EcdhHashFn;
-
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_nonce_function_rfc6979")]
     pub static secp256k1_nonce_function_rfc6979: NonceFn;
 
@@ -406,16 +398,6 @@ extern "C" {
                                        ins: *const *const PublicKey,
                                        n: c_int)
                                        -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_ecdh")]
-    pub fn secp256k1_ecdh(
-        cx: *const Context,
-        output: *mut c_uchar,
-        pubkey: *const PublicKey,
-        seckey: *const c_uchar,
-        hashfp: EcdhHashFn,
-        data: *mut c_void,
-    ) -> c_int;
 
     // Extra keys
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_keypair_create")]

--- a/secp256k1-sys/src/schnorrsig.rs
+++ b/secp256k1-sys/src/schnorrsig.rs
@@ -16,7 +16,8 @@
 //! # FFI of the schnorrsig module
 
 use ::types::*;
-use {Context, XOnlyPublicKey, KeyPair};
+use ::extrakeys::{XOnlyPublicKey, KeyPair};
+use Context;
 
 ///  Same as secp256k1_nonce function with the exception of accepting an
 ///  additional pubkey argument and not requiring an attempt argument. The pubkey

--- a/secp256k1-sys/src/schnorrsig.rs
+++ b/secp256k1-sys/src/schnorrsig.rs
@@ -1,0 +1,112 @@
+// Bitcoin secp256k1 bindings
+// Written in 2014 by
+//   Dawid Ciężarkiewicz
+//   Andrew Poelstra
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # FFI of the schnorrsig module
+
+use ::types::*;
+use {Context, XOnlyPublicKey, KeyPair};
+
+///  Same as secp256k1_nonce function with the exception of accepting an
+///  additional pubkey argument and not requiring an attempt argument. The pubkey
+///  argument can protect signature schemes with key-prefixed challenge hash
+///  inputs against reusing the nonce when signing with the wrong precomputed
+///  pubkey.
+pub type SchnorrNonceFn = Option<unsafe extern "C" fn(
+    nonce32: *mut c_uchar,
+    msg32: *const c_uchar,
+    key32: *const c_uchar,
+    xonly_pk32: *const c_uchar,
+    algo16: *const c_uchar,
+    data: *mut c_void,
+) -> c_int>;
+
+extern "C" {
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_nonce_function_bip340")]
+    pub static secp256k1_nonce_function_bip340: SchnorrNonceFn;
+}
+
+#[cfg(not(fuzzing))]
+extern "C" {
+    // Schnorr Signatures
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_schnorrsig_sign")]
+    pub fn secp256k1_schnorrsig_sign(
+        cx: *const Context,
+        sig: *mut c_uchar,
+        msg32: *const c_uchar,
+        keypair: *const KeyPair,
+        noncefp: SchnorrNonceFn,
+        noncedata: *const c_void
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_0_schnorrsig_verify")]
+    pub fn secp256k1_schnorrsig_verify(
+        cx: *const Context,
+        sig64: *const c_uchar,
+        msg32: *const c_uchar,
+        pubkey: *const XOnlyPublicKey,
+    ) -> c_int;
+}
+
+#[cfg(fuzzing)]
+mod fuzz_dummy {
+    use super::*;
+    use super::{secp256k1_xonly_pubkey_tweak_add, secp256k1_keypair_create};
+
+    /// Verifies that sig is msg32||pk[32..]
+    pub unsafe fn secp256k1_schnorrsig_verify(
+        cx: *const Context,
+        sig64: *const c_uchar,
+        msg32: *const c_uchar,
+        pubkey: *const XOnlyPublicKey,
+    ) -> c_int {
+        // Check context is built for verification
+        let mut new_pk = PublicKey::new();
+        let _ = secp256k1_xonly_pubkey_tweak_add(cx, &mut new_pk, pubkey, msg32);
+        // Actually verify
+        let sig_sl = slice::from_raw_parts(sig64 as *const u8, 64);
+        let msg_sl = slice::from_raw_parts(msg32 as *const u8, 32);
+        if &sig_sl[..32] == msg_sl && sig_sl[32..] == (*pubkey).0[..32] {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Sets sig to msg32||pk[..32]
+    pub unsafe fn secp256k1_schnorrsig_sign(
+        cx: *const Context,
+        sig64: *mut c_uchar,
+        msg32: *const c_uchar,
+        keypair: *const KeyPair,
+        noncefp: SchnorrNonceFn,
+        noncedata: *const c_void
+    ) -> c_int {
+        // Check context is built for signing
+        let mut new_kp = KeyPair::new();
+        if secp256k1_keypair_create(cx, &mut new_kp, (*keypair).0.as_ptr()) != 1 {
+            return 0;
+        }
+        assert_eq!(new_kp, *keypair);
+        // Sign
+        let sig_sl = slice::from_raw_parts_mut(sig64 as *mut u8, 64);
+        let msg_sl = slice::from_raw_parts(msg32 as *const u8, 32);
+        sig_sl[..32].copy_from_slice(msg_sl);
+        sig_sl[32..].copy_from_slice(&new_kp.0[32..64]);
+        1
+    }
+}
+
+#[cfg(fuzzing)]
+pub use self::fuzz_dummy::*;

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types)]
-use core::{fmt, mem};
+use core::fmt;
 
 pub type c_int = i32;
 pub type c_uchar = u8;
@@ -43,7 +43,7 @@ impl AlignedType {
 }
 
 #[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
-pub(crate) const ALIGN_TO: usize = mem::align_of::<AlignedType>();
+pub(crate) const ALIGN_TO: usize = core::mem::align_of::<AlignedType>();
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
I work WASM for [bitcoinjs/tiny-secp256k1](https://github.com/bitcoinjs/tiny-secp256k1/) and this package do not need `ecdh`, `extrakeys`, `schnorrsig` modules right now. Without them resulted WASM file less on ~48KB.