### PR TITLE
Reduce visibility on secp-sys symbols

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -33,6 +33,7 @@ fn main() {
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
                .define("SECP256K1_BUILD", Some("1"))
+               .define("SECP256K1_API", Some(""))
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))
                .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))


### PR DESCRIPTION
cc-rs builds C dependencies with reduced visibility to avoid
exporting the C symbols all the way out to any rust-built shared
libraries however we override it with SECP256K1_API. We should
avoid doing this, allowing LTO/DCE to do its work.

<strike>Note: THIS IS UNTESTED.</strike> https://github.com/rust-bitcoin/rust-secp256k1/pull/287#issuecomment-802223480