### PR TITLE
Manually test that panicking from C will abort the process

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -78,6 +78,9 @@ if [ "$DO_ASAN" = true ]; then
     cargo run --release --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified Successfully"
 fi
 
+# Test if panic in C code aborts the process (either with a real panic or with SIGILL)
+cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at '\[libsecp256k1\]"
+
 # Bench
 if [ "$DO_BENCH" = true ]; then
     cargo bench --all --features="unstable"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,14 +938,12 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    #[should_panic]
-    fn test_panic_raw_ctx() {
+    #[ignore] // Panicking from C may trap (SIGILL) intentionally, so we test this manually.
+    fn test_panic_raw_ctx_should_terminate_abnormally() {
         let ctx_vrfy = Secp256k1::verification_only();
         let raw_ctx_verify_as_full = unsafe {Secp256k1::from_raw_all(ctx_vrfy.ctx)};
-        let (sk, _) = raw_ctx_verify_as_full.generate_keypair(&mut thread_rng());
-        let msg = Message::from_slice(&[2u8; 32]).unwrap();
-        // Try signing
-        raw_ctx_verify_as_full.sign(&msg, &sk);
+        // Generating a key pair in verify context will panic (ARG_CHECK).
+        raw_ctx_verify_as_full.generate_keypair(&mut thread_rng());
     }
 
     #[test]


### PR DESCRIPTION
Panicking from C is not UB in newer rust versions and will reliably
trigger an abort (without unwinding). In older rust versions, it is
technically UB but empirically it seems to "just work" (and what should
it realistically do except crashing, which is what we intent).

Since there's potentially no unwinding, we can't test this behavior
using [should_panic]. This PR will check the exit code instead in our
CI tests.

Fixes #228. This is an alternative to #288.