### PR TITLE
New alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ features = [ "rand", "rand-std", "serde", "recovery" ]
 unstable = ["recovery", "rand-std"]
 default = ["std"]
 std = ["secp256k1-sys/std"]
+# allow use of Secp256k1::new and related API that requires an allocator
+alloc = []
 rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -76,6 +76,7 @@ if [ "$DO_ASAN" = true ]; then
     RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
     cargo test --lib --all --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu &&
     cargo run --release --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified Successfully"
+    cargo run --release --features=alloc --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified alloc Successfully"
 fi
 
 # Test if panic in C code aborts the process (either with a real panic or with SIGILL)

--- a/no_std_test/Cargo.toml
+++ b/no_std_test/Cargo.toml
@@ -3,7 +3,11 @@ name = "no_std_test"
 version = "0.1.0"
 authors = ["Elichai Turkel <elichai.turkel@gmail.com>"]
 
+[features]
+alloc = ["secp256k1/alloc", "wee_alloc"]
+
 [dependencies]
+wee_alloc = { version = "0.4.5", optional = true }
 secp256k1 = { path = "../", default-features = false, features = ["serde", "rand", "recovery"] }
 libc = { version = "0.2", default-features = false }
 serde_cbor = { version = "0.10", default-features = false } # A random serializer that supports no-std.

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,8 +5,8 @@ use ffi::types::{c_uint, c_void};
 use Error;
 use Secp256k1;
 
-#[cfg(feature = "std")]
-pub use self::std_only::*;
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub use self::alloc_only::*;
 
 #[cfg(feature = "global-context-less-secure")]
 /// Module implementing a singleton pattern for a global `Secp256k1` context
@@ -93,14 +93,18 @@ mod private {
     impl<'buf> Sealed for SignOnlyPreallocated<'buf> {}
 }
 
-#[cfg(feature = "std")]
-mod std_only {
+#[cfg(any(feature = "std", feature = "alloc"))]
+mod alloc_only {
+    #[cfg(feature = "std")]
+    use std::alloc;
+    #[cfg(not(feature = "std"))]
+    use alloc::alloc;
+
     impl private::Sealed for SignOnly {}
     impl private::Sealed for All {}
     impl private::Sealed for VerifyOnly {}
 
     use super::*;
-    use std::alloc;
     const ALIGN_TO: usize = mem::align_of::<AlignedType>();
 
     /// Represents the set of capabilities needed for signing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub use secp256k1_sys as ffi;
 #[cfg(any(test, feature = "rand"))] use rand::Rng;
 #[cfg(any(test, feature = "std"))] extern crate core;
 #[cfg(all(test, target_arch = "wasm32"))] extern crate wasm_bindgen_test;
+#[cfg(feature = "alloc")] extern crate alloc;
 
 use core::{fmt, ptr, str};
 


### PR DESCRIPTION
Allows use of `Secp256k1::new` and related API, if an allocator is available