### PR TITLE
Touch recovery module in no_std_test

### DIFF
--- a/no_std_test/Cargo.toml
+++ b/no_std_test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Elichai Turkel <elichai.turkel@gmail.com>"]
 
 [dependencies]
-secp256k1 = { path = "../", default-features = false, features = ["serde", "rand"] }
+secp256k1 = { path = "../", default-features = false, features = ["serde", "rand", "recovery"] }
 libc = { version = "0.2", default-features = false }
 serde_cbor = { version = "0.10", default-features = false } # A random serializer that supports no-std.
 


### PR DESCRIPTION
Adds some key functionality from the recovery module to the no_std_test.

Closes #301 

