### PR TITLE
Add error type for combine keys + test and doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,10 +527,10 @@ pub enum Error {
     InvalidRecoveryId,
     /// Invalid tweak for add_*_assign or mul_*_assign
     InvalidTweak,
-    /// `tweak_add_check` failed on an xonly public key
-    TweakCheckFailed,
     /// Didn't pass enough memory to context creation with preallocated memory
     NotEnoughMemory,
+    /// Bad set of public keys
+    InvalidPublicKeySum,
 }
 
 impl Error {
@@ -543,8 +543,8 @@ impl Error {
             Error::InvalidSecretKey => "secp: malformed or out-of-range secret key",
             Error::InvalidRecoveryId => "secp: bad recovery id",
             Error::InvalidTweak => "secp: bad tweak",
-            Error::TweakCheckFailed => "secp: xonly_pubkey_tewak_add_check failed",
             Error::NotEnoughMemory => "secp: not enough memory allocated",
+            Error::InvalidPublicKeySum => "secp: the sum of public keys was invalid or the input vector lengths was less than 1",
         }
     }
 }


### PR DESCRIPTION
Trying to address the issues raised [here](https://github.com/rust-bitcoin/rust-secp256k1/pull/291#issuecomment-858397262):
* Add error type for combine_keys
* Add test with empty slice for combine_keys
* Document empty slice error condition for combine_keys

Deleted the `TweakCheckFailed` at the same time since it's not used but let me know if you'd prefer to have that in a separate commit/PR.

@real-or-random I was not sure if you wanted to change something in the fuzz_dummy module and I'm not so familiar with what it does so let me know if it does need a change.