### PR TITLE
Improving safety of handling secret keys in different forms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std", "rand-std", "global-context-less-secure"]
 global-context-less-secure = []
+serde-secrets = ["serde", "std"]
 
 [dependencies]
 secp256k1-sys = { version = "0.4.1", default-features = false, path = "./secp256k1-sys" }

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-FEATURES="bitcoin_hashes global-context lowmemory rand rand-std recovery serde"
+FEATURES="bitcoin_hashes global-context lowmemory rand rand-std recovery serde serde-secrets"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -224,6 +224,12 @@ pub struct KeyPair([c_uchar; 96]);
 impl_array_newtype!(KeyPair, c_uchar, 96);
 impl_raw_debug!(KeyPair);
 
+impl Drop for KeyPair {
+    fn drop(&mut self) {
+        self.0.copy_from_slice(&[0u8; 96]);
+    }
+}
+
 impl KeyPair {
     /// Creates an "uninitialized" FFI keypair which is zeroed out
     ///

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -99,6 +99,7 @@ pub type SchnorrNonceFn = Option<unsafe extern "C" fn(
 
 /// Library-internal representation of a Secp256k1 public key
 #[repr(C)]
+#[derive(Copy)]
 pub struct PublicKey([c_uchar; 64]);
 impl_array_newtype!(PublicKey, c_uchar, 64);
 impl_raw_debug!(PublicKey);
@@ -141,6 +142,7 @@ impl hash::Hash for PublicKey {
 
 /// Library-internal representation of a Secp256k1 signature
 #[repr(C)]
+#[derive(Copy)]
 pub struct Signature([c_uchar; 64]);
 impl_array_newtype!(Signature, c_uchar, 64);
 impl_raw_debug!(Signature);
@@ -176,6 +178,7 @@ impl Signature {
 }
 
 #[repr(C)]
+#[derive(Copy)]
 pub struct XOnlyPublicKey([c_uchar; 64]);
 impl_array_newtype!(XOnlyPublicKey, c_uchar, 64);
 impl_raw_debug!(XOnlyPublicKey);

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -68,8 +68,6 @@ macro_rules! impl_array_newtype {
             pub fn is_empty(&self) -> bool { false }
         }
 
-        impl Copy for $thing {}
-
         impl Clone for $thing {
             #[inline]
             fn clone(&self) -> $thing {
@@ -167,7 +165,7 @@ macro_rules! impl_raw_debug {
     ($thing:ident) => {
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                for i in self[..].iter().cloned() {
+                for i in &self[..] {
                     write!(f, "{:02x}", i)?;
                 }
                 Ok(())

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -20,6 +20,7 @@ use {Context, Signature, NonceFn, PublicKey};
 
 /// Library-internal representation of a Secp256k1 signature + recovery ID
 #[repr(C)]
+#[derive(Copy)]
 pub struct RecoverableSignature([c_uchar; 65]);
 impl_array_newtype!(RecoverableSignature, c_uchar, 65);
 impl_raw_debug!(RecoverableSignature);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use core::marker::PhantomData;
-use core::mem::{self, ManuallyDrop};
+use core::mem::ManuallyDrop;
 use ffi::{self, CPtr, types::AlignedType};
 use ffi::types::{c_uint, c_void};
 use Error;
@@ -105,7 +105,7 @@ mod alloc_only {
     impl private::Sealed for VerifyOnly {}
 
     use super::*;
-    const ALIGN_TO: usize = mem::align_of::<AlignedType>();
+    const ALIGN_TO: usize = ::core::mem::align_of::<AlignedType>();
 
     /// Represents the set of capabilities needed for signing.
     pub enum SignOnly {}

--- a/src/key.rs
+++ b/src/key.rs
@@ -29,7 +29,7 @@ use ffi::{self, CPtr};
 /// Secret 256-bit key used as `x` in an ECDSA signature
 pub struct SecretKey(pub(crate) [u8; constants::SECRET_KEY_SIZE]);
 impl_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE);
-impl_pretty_debug!(SecretKey);
+impl_safe_debug!(SecretKey);
 
 impl fmt::LowerHex for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -675,8 +675,15 @@ mod test {
         let s = Secp256k1::new();
         let (sk, _) = s.generate_keypair(&mut DumbRng(0));
 
+        #[cfg(all(feature = "bitcoin_hashes", not(fuzzing)))]
         assert_eq!(&format!("{:?}", sk),
-                   "SecretKey(0100000000000000020000000000000003000000000000000400000000000000)");
+                   "SecretKey(#73e200e2...29d234a4)");
+        #[cfg(all(not(feature = "bitcoin_hashes"), feature = "std"))]
+        assert_eq!(&format!("{:?}", sk),
+                   "SecretKey(#a463cd1b7ffe86b0)");
+        #[allow(deprecated)] {
+        assert_eq!(sk.format_secret_key(),
+                   "0100000000000000020000000000000003000000000000000400000000000000"); };
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -29,7 +29,7 @@ use ffi::{self, CPtr};
 /// Secret 256-bit key used as `x` in an ECDSA signature
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SecretKey(pub(crate) [u8; constants::SECRET_KEY_SIZE]);
-impl_safe_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE);
+impl_ptr_newtype!(SecretKey, u8);
 impl_safe_debug!(SecretKey);
 
 impl str::FromStr for SecretKey {

--- a/src/key.rs
+++ b/src/key.rs
@@ -32,6 +32,12 @@ pub struct SecretKey(pub(crate) [u8; constants::SECRET_KEY_SIZE]);
 impl_ptr_newtype!(SecretKey, u8);
 impl_safe_debug!(SecretKey);
 
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        self.0.copy_from_slice(&[0u8; constants::SECRET_KEY_SIZE]);
+    }
+}
+
 impl str::FromStr for SecretKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<SecretKey, Error> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -32,21 +32,6 @@ pub struct SecretKey(pub(crate) [u8; constants::SECRET_KEY_SIZE]);
 impl_safe_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE);
 impl_safe_debug!(SecretKey);
 
-impl fmt::LowerHex for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for ch in &self.0[..] {
-            write!(f, "{:02x}", *ch)?;
-        }
-        Ok(())
-    }
-}
-
-impl fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::LowerHex::fmt(self, f)
-    }
-}
-
 impl str::FromStr for SecretKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<SecretKey, Error> {
@@ -219,7 +204,8 @@ impl SecretKey {
 impl ::serde::Serialize for SecretKey {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         if s.is_human_readable() {
-            s.collect_str(self)
+            #[allow(deprecated)]
+            s.serialize_str(&self.format_secret_key())
         } else {
             s.serialize_bytes(&self.0[..])
         }
@@ -706,10 +692,11 @@ mod test {
         #[cfg(fuzzing)]
         let pk = PublicKey::from_slice(&[0x02, 0x18, 0x84, 0x57, 0x81, 0xf6, 0x31, 0xc4, 0x8f, 0x1c, 0x97, 0x09, 0xe2, 0x30, 0x92, 0x06, 0x7d, 0x06, 0x83, 0x7f, 0x30, 0xaa, 0x0c, 0xd0, 0x54, 0x4a, 0xc8, 0x87, 0xfe, 0x91, 0xdd, 0xd1, 0x66]).expect("pk");
 
+        #[allow(deprecated)] {
         assert_eq!(
-            sk.to_string(),
+            sk.format_secret_key(),
             "01010101010101010001020304050607ffff0000ffff00006363636363636363"
-        );
+        ) };
         assert_eq!(
             SecretKey::from_str("01010101010101010001020304050607ffff0000ffff00006363636363636363").unwrap(),
             sk

--- a/src/key.rs
+++ b/src/key.rs
@@ -200,7 +200,7 @@ impl SecretKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "serde-secrets"))]
 impl ::serde::Serialize for SecretKey {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         if s.is_human_readable() {
@@ -930,7 +930,7 @@ mod test {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn test_serde() {
+    fn test_serde_pk() {
         use serde_test::{Configure, Token, assert_tokens};
         static SK_BYTES: [u8; 32] = [
             1, 1, 1, 1, 1, 1, 1, 1,
@@ -938,9 +938,6 @@ mod test {
             0xff, 0xff, 0, 0, 0xff, 0xff, 0, 0,
             99, 99, 99, 99, 99, 99, 99, 99
         ];
-        static SK_STR: &'static str = "\
-            01010101010101010001020304050607ffff0000ffff00006363636363636363\
-        ";
         static PK_BYTES: [u8; 33] = [
             0x02,
             0x18, 0x84, 0x57, 0x81, 0xf6, 0x31, 0xc4, 0x8f,
@@ -962,14 +959,6 @@ mod test {
         #[cfg(fuzzing)]
         let pk = PublicKey::from_slice(&PK_BYTES).expect("pk");
 
-        assert_tokens(&sk.clone().compact(), &[Token::BorrowedBytes(&SK_BYTES[..])]);
-        assert_tokens(&sk.clone().compact(), &[Token::Bytes(&SK_BYTES)]);
-        assert_tokens(&sk.clone().compact(), &[Token::ByteBuf(&SK_BYTES)]);
-
-        assert_tokens(&sk.clone().readable(), &[Token::BorrowedStr(SK_STR)]);
-        assert_tokens(&sk.clone().readable(), &[Token::Str(SK_STR)]);
-        assert_tokens(&sk.clone().readable(), &[Token::String(SK_STR)]);
-
         assert_tokens(&pk.compact(), &[Token::BorrowedBytes(&PK_BYTES[..])]);
         assert_tokens(&pk.compact(), &[Token::Bytes(&PK_BYTES)]);
         assert_tokens(&pk.compact(), &[Token::ByteBuf(&PK_BYTES)]);
@@ -977,6 +966,30 @@ mod test {
         assert_tokens(&pk.readable(), &[Token::BorrowedStr(PK_STR)]);
         assert_tokens(&pk.readable(), &[Token::Str(PK_STR)]);
         assert_tokens(&pk.readable(), &[Token::String(PK_STR)]);
+    }
 
+    #[cfg(all(feature = "serde", feature = "serde-secrets"))]
+    #[test]
+    fn test_serde_sk() {
+        use serde_test::{Configure, Token, assert_tokens};
+        static SK_BYTES: [u8; 32] = [
+            1, 1, 1, 1, 1, 1, 1, 1,
+            0, 1, 2, 3, 4, 5, 6, 7,
+            0xff, 0xff, 0, 0, 0xff, 0xff, 0, 0,
+            99, 99, 99, 99, 99, 99, 99, 99
+        ];
+        static SK_STR: &'static str = "\
+            01010101010101010001020304050607ffff0000ffff00006363636363636363\
+        ";
+
+        let sk = SecretKey::from_slice(&SK_BYTES).unwrap();
+
+        assert_tokens(&sk.clone().compact(), &[Token::BorrowedBytes(&SK_BYTES[..])]);
+        assert_tokens(&sk.clone().compact(), &[Token::Bytes(&SK_BYTES)]);
+        assert_tokens(&sk.clone().compact(), &[Token::ByteBuf(&SK_BYTES)]);
+
+        assert_tokens(&sk.clone().readable(), &[Token::BorrowedStr(SK_STR)]);
+        assert_tokens(&sk.clone().readable(), &[Token::Str(SK_STR)]);
+        assert_tokens(&sk.clone().readable(), &[Token::String(SK_STR)]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,7 +795,7 @@ impl<C: Verification> Secp256k1<C> {
     /// which OpenSSL would verify but not libsecp256k1, or vice-versa. Requires a
     /// verify-capable context.
     ///
-    /// ```rust
+    /// ```
     /// # #[cfg(feature="rand")] {
     /// # use secp256k1::rand::rngs::OsRng;
     /// # use secp256k1::{Secp256k1, Message, Error};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -995,7 +995,7 @@ mod tests {
         assert!(full.verify(&msg, &sig, &pk).is_ok());
 
         // Check that we can produce keys from slices with no precomputation
-        let (pk_slice, sk_slice) = (&pk.serialize(), &sk[..]);
+        let (pk_slice, sk_slice) = (&pk.serialize(), &sk.0[..]);
         let new_pk = PublicKey::from_slice(pk_slice).unwrap();
         let new_sk = SecretKey::from_slice(sk_slice).unwrap();
         assert_eq!(sk, new_sk);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,6 +458,7 @@ impl<'de> ::serde::Deserialize<'de> for Signature {
 }
 
 /// A (hashed) message input to an ECDSA signature
+#[derive(Copy)]
 pub struct Message([u8; constants::MESSAGE_SIZE]);
 impl_array_newtype!(Message, u8, constants::MESSAGE_SIZE);
 impl_pretty_debug!(Message);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,10 +18,80 @@ macro_rules! impl_pretty_debug {
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 write!(f, "{}(", stringify!($thing))?;
-                for i in self[..].iter().cloned() {
+                for i in &self[..] {
                     write!(f, "{:02x}", i)?;
                 }
-                write!(f, ")")
+                f.write_str(")")
+            }
+        }
+     }
+}
+
+macro_rules! impl_safe_debug {
+    ($thing:ident) => {
+        #[cfg(feature = "bitcoin_hashes")]
+        impl ::core::fmt::Debug for $thing {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                use ::bitcoin_hashes::{Hash, sha256};
+                write!(f, "{}(#", stringify!($thing))?;
+                let hash = sha256::Hash::hash(&self.0[..]);
+                for i in &hash[..4] {
+                    write!(f, "{:02x}", i)?;
+                }
+                f.write_str("...")?;
+                for i in &hash[28..] {
+                    write!(f, "{:02x}", i)?;
+                }
+                f.write_str(")")
+            }
+        }
+
+        #[cfg(all(not(feature = "bitcoin_hashes"), feature = "std"))]
+        impl ::core::fmt::Debug for $thing {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                use ::core::hash::Hasher;
+                let mut hasher = ::std::collections::hash_map::DefaultHasher::new();
+
+                hasher.write(&self.0[..]);
+                let hash = hasher.finish();
+
+                write!(f, "{}(#{:016x})", stringify!($thing), hash)
+            }
+        }
+
+        impl $thing {
+            /// Formats the explicit byte value of the secret key kept inside the type as a
+            /// little-endian hexadecimal string using the provided formatter.
+            ///
+            /// This is the only method that outputs the actual secret key value, and, thus,
+            /// should be used with extreme precaution.
+            #[deprecated(
+                note = "Caution: you are explicitly outputting secret key value! This can be done
+                only in debug environment and that's why always considered as ``deprecated''"
+            )]
+            pub fn fmt_secret_key(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                for i in &self.0[..] {
+                    write!(f, "{:02x}", i)?;
+                }
+                Ok(())
+            }
+
+            /// Formats the explicit byte value of the secret key kept inside the type as a
+            /// little-endian hexadecimal string.
+            ///
+            /// This is the only method that outputs the actual secret key value, and, thus,
+            /// should be used with extreme precaution.
+            #[deprecated(
+                note = "Caution: you are explicitly outputting secret key value! This can be done
+                only in debug environment and that's why always considered as ``deprecated''"
+            )]
+            #[cfg(feature = "std")]
+            pub fn format_secret_key(&self) -> String {
+                let mut s = Vec::with_capacity(self.0.len() * 2);
+                for i in &self.0[..] {
+                    s.push(format!("{:02x}", i));
+                }
+                s.join("")
             }
         }
      }

--- a/src/schnorrsig.rs
+++ b/src/schnorrsig.rs
@@ -76,8 +76,9 @@ impl str::FromStr for Signature {
 }
 
 /// Opaque data structure that holds a keypair consisting of a secret and a public key.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
 pub struct KeyPair(ffi::KeyPair);
+impl_safe_debug!(KeyPair);
 
 /// A Schnorr public key, used for verification of Schnorr signatures
 #[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]

--- a/src/schnorrsig.rs
+++ b/src/schnorrsig.rs
@@ -16,6 +16,7 @@ use {Message, Signing, Verification};
 use SecretKey;
 
 /// Represents a Schnorr signature.
+#[derive(Copy)]
 pub struct Signature([u8; constants::SCHNORRSIG_SIGNATURE_SIZE]);
 impl_array_newtype!(Signature, u8, constants::SCHNORRSIG_SIGNATURE_SIZE);
 impl_pretty_debug!(Signature);


### PR DESCRIPTION
This PR tries to improve safety in working with data types containing secret key related information (`SecretKey`, `ffi::KeyPair`, `KeyPair`). In particular, it
- zeroes inner representations on drop operations
- prohibits copy
- removes explicit hex display, lower hex and debug representation
- prints debug information as a (partial) hash of the secret key data, either SHA256 (if `bitcoin_hashes` feature is used) or using rust default hasher (if the feature is not used, but either `alloc` or `std` is present)
- introduced special functions for disclosing secret hex in hexadecimal form, marked as deprecated (so compiler will always generate a warning)
- introduces "serde-secret" feature required to do a serde serialization of secret-key related types
- removes `AsRef<[u8]>` and index access methods to secret key values

Closes #226 and provides alternative to #262 without introducing `zeroize` dependency