### PR TITLE
Fix a C compiler warning because of redefinition of SECP256K1_BUILD

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -32,7 +32,6 @@ fn main() {
                .include("depend/secp256k1/include")
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
-               .define("SECP256K1_BUILD", Some("1"))
                .define("SECP256K1_API", Some(""))
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))
@@ -42,7 +41,7 @@ fn main() {
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
                .define("USE_SCALAR_INV_BUILTIN", Some("1"));
-    
+
     if cfg!(feature = "lowmemory") {
         base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
     } else {


### PR DESCRIPTION
The warning:
```
warning: depend/secp256k1/src/secp256k1.c:7:9: warning: 'SECP256K1_BUILD' macro redefined [-Wmacro-redefined]
warning: #define SECP256K1_BUILD
warning:         ^
warning: <command line>:1:9: note: previous definition is here
warning: #define SECP256K1_BUILD 1
warning:         ^
warning: 1 warning generated.
```

The flag was first added in: https://github.com/rust-bitcoin/rust-secp256k1/pull/35 But it is no longer needed since: https://github.com/bitcoin-core/secp256k1/pull/928