### PR TITLE
Reduce the size of precomputed signing table for lowmemory

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -36,15 +36,16 @@ fn main() {
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))
                .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))
-               .define("ECMULT_GEN_PREC_BITS", Some("4"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
                .define("USE_SCALAR_INV_BUILTIN", Some("1"));
 
     if cfg!(feature = "lowmemory") {
-        base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
+        base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume negligible memory
+        base_config.define("ECMULT_GEN_PREC_BITS", Some("2"));
     } else {
+        base_config.define("ECMULT_GEN_PREC_BITS", Some("4"));
         base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
     }
     base_config.define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));


### PR DESCRIPTION
Reduce the size of precomputed signing table (ECMULT_GEN_PREC_BITS) for `lowmemory` feature

in rust-bitcoin embedded test secp preallocate_size become `33472` from `66240`