### PR TITLE
Schnorr adaptor signature helpers

### DIFF
--- a/secp256k1-sys/depend/secp256k1/include/secp256k1_schnorrsig.h
+++ b/secp256k1-sys/depend/secp256k1/include/secp256k1_schnorrsig.h
@@ -93,8 +93,8 @@ SECP256K1_API int rustsecp256k1_v0_4_1_schnorrsig_sign(
 
 /** Verify a Schnorr signature.
  *
- *  Returns: 1: correct signature
- *           0: incorrect signature
+ *  Returns: 1: successful recovery
+ *           0: failed recovery
  *  Args:    ctx: a secp256k1 context object, initialized for verification.
  *  In:    sig64: pointer to the 64-byte signature to verify (cannot be NULL)
  *         msg32: the 32-byte message being verified (cannot be NULL)
@@ -106,6 +106,21 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int rustsecp256k1_v0_4_1_schnorrsig_v
     const unsigned char *msg32,
     const rustsecp256k1_v0_4_1_xonly_pubkey *pubkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+
+/** Recover a secret key from a Schnorr signature and adaptor Schnorr signature.
+ *
+ *  Returns: 1: correct signature
+ *           0: incorrect signature
+ *  Args:
+ *  Out:        secret: pointer to a 32-byte array to store the recovered secret key (cannot be NULL)
+ *  In:          sig64: pointer to the 64-byte signature (cannot be NULL)
+ *       adaptor_sig64: pointer to the 64-byte adaptor signature (cannot be NULL)
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int rustsecp256k1_v0_4_1_schnorrsig_recover(
+   unsigned char *secret,
+   const unsigned char *sig64,
+   const unsigned char *adaptor_sig64
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 #ifdef __cplusplus
 }

--- a/secp256k1-sys/depend/secp256k1/include/secp256k1_schnorrsig.h
+++ b/secp256k1-sys/depend/secp256k1/include/secp256k1_schnorrsig.h
@@ -78,6 +78,8 @@ SECP256K1_API extern const rustsecp256k1_v0_4_1_nonce_function_hardened rustsecp
  *                function (can be NULL). If it is non-NULL and
  *                rustsecp256k1_v0_4_1_nonce_function_bip340 is used, then ndata must be a
  *                pointer to 32-byte auxiliary randomness as per BIP-340.
+ *       adaptor: pointer to adaptor secret key to create an adaptor signature by adding the key to the signature
+ *                (can be NULL)
  */
 SECP256K1_API int rustsecp256k1_v0_4_1_schnorrsig_sign(
     const rustsecp256k1_v0_4_1_context* ctx,
@@ -85,7 +87,8 @@ SECP256K1_API int rustsecp256k1_v0_4_1_schnorrsig_sign(
     const unsigned char *msg32,
     const rustsecp256k1_v0_4_1_keypair *keypair,
     rustsecp256k1_v0_4_1_nonce_function_hardened noncefp,
-    void *ndata
+    void *ndata,
+    const unsigned char *adaptor
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** Verify a Schnorr signature.

--- a/secp256k1-sys/depend/secp256k1/scr
+++ b/secp256k1-sys/depend/secp256k1/scr
@@ -1,0 +1,29 @@
+
+int rustsecp256k1_v0_4_1_schnorrsig_recover(unsigned char *secret, const unsigned char *sig64, const unsigned char *adaptor_sig64) {
+	rustsecp256k1_v0_4_1_scalar e;
+	rustsecp256k1_v0_4_1_scalar a;
+	int ret = 1;
+	int overflow;
+
+    VERIFY_CHECK(secret != NULL);
+    VERIFY_CHECK(sig64 != NULL);
+    VERIFY_CHECK(adaptor_sig64 != NULL);
+
+	rustsecp256k1_v0_4_1_scalar_set_be32(&e, sig64[32], &overflow);
+	ret &= !overflow;
+	rustsecp256k1_v0_4_1_scalar_set_be32(&a, adaptor_sig64[32], &overflow);
+	ret &= !overflow;
+	ret &= !rustsecp256k1_v0_4_1_scalar_is_zero(&e);
+	ret &= !rustsecp256k1_v0_4_1_scalar_is_zero(&a);
+
+	rustsecp256k1_v0_4_1_scalar_negate(&e, &e);
+	rustsecp256k1_v0_4_1_scalar_add(&a, &a, &e);
+	rustsecp256k1_v0_4_1_scalar_get_b32(secret, &a);
+
+	rustsecp256k1_v0_4_1_scalar_clear(&e);
+	rustsecp256k1_v0_4_1_scalar_clear(&a);
+    rustsecp256k1_v0_4_1_memczero(secret, 32, !ret);
+
+	return ret;
+}
+

--- a/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/main_impl.h
+++ b/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/main_impl.h
@@ -245,4 +245,32 @@ int rustsecp256k1_v0_4_1_schnorrsig_verify(const rustsecp256k1_v0_4_1_context* c
            rustsecp256k1_v0_4_1_fe_equal_var(&rx, &r.x);
 }
 
+int rustsecp256k1_v0_4_1_schnorrsig_recover(unsigned char *secret, const unsigned char *sig64, const unsigned char *adaptor_sig64) {
+    rustsecp256k1_v0_4_1_scalar e;
+    rustsecp256k1_v0_4_1_scalar a;
+    int ret = 1;
+    int overflow;
+
+    VERIFY_CHECK(secret != NULL);
+    VERIFY_CHECK(sig64 != NULL);
+    VERIFY_CHECK(adaptor_sig64 != NULL);
+
+    rustsecp256k1_v0_4_1_scalar_set_b32(&e, &sig64[32], &overflow);
+    ret &= !overflow;
+    rustsecp256k1_v0_4_1_scalar_set_b32(&a, &adaptor_sig64[32], &overflow);
+    ret &= !overflow;
+    ret &= !rustsecp256k1_v0_4_1_scalar_is_zero(&e);
+    ret &= !rustsecp256k1_v0_4_1_scalar_is_zero(&a);
+    
+    rustsecp256k1_v0_4_1_scalar_negate(&e, &e);
+    rustsecp256k1_v0_4_1_scalar_add(&a, &a, &e);
+    rustsecp256k1_v0_4_1_scalar_get_b32(secret, &a);
+    
+    rustsecp256k1_v0_4_1_scalar_clear(&e);
+    rustsecp256k1_v0_4_1_scalar_clear(&a);
+    rustsecp256k1_v0_4_1_memczero(secret, 32, !ret);
+
+    return ret;
+}
+
 #endif

--- a/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/tests_exhaustive_impl.h
+++ b/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/tests_exhaustive_impl.h
@@ -161,7 +161,7 @@ static void test_exhaustive_schnorrsig_sign(const rustsecp256k1_v0_4_1_context *
                     unsigned char expected_s_bytes[32];
                     rustsecp256k1_v0_4_1_scalar_get_b32(expected_s_bytes, &expected_s);
                     /* Invoke the real function to construct a signature. */
-                    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig64, msg32, &keypairs[d - 1], rustsecp256k1_v0_4_1_hardened_nonce_function_smallint, &k));
+                    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig64, msg32, &keypairs[d - 1], rustsecp256k1_v0_4_1_hardened_nonce_function_smallint, &k, NULL));
                     /* The first 32 bytes must match the xonly pubkey for the specified k. */
                     CHECK(rustsecp256k1_v0_4_1_memcmp_var(sig64, xonly_pubkey_bytes[k - 1], 32) == 0);
                     /* The last 32 bytes must match the expected s value. */

--- a/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/tests_impl.h
+++ b/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/tests_impl.h
@@ -789,6 +789,26 @@ void test_schnorrsig_taproot(void) {
     CHECK(rustsecp256k1_v0_4_1_xonly_pubkey_tweak_add_check(ctx, output_pk_bytes, pk_parity, &internal_pk, tweak) == 1);
 }
 
+void test_schnorrsig_sign_adaptor_recover(void) {
+    unsigned char sk[32];
+    unsigned char adaptor[32];
+    unsigned char recover[32];
+    unsigned char msg[32];
+    unsigned char sig[64];
+    unsigned char adaptor_sig[64];
+    rustsecp256k1_v0_4_1_keypair keypair;
+
+    rustsecp256k1_v0_4_1_testrand256(sk);
+    rustsecp256k1_v0_4_1_testrand256(adaptor);
+    CHECK(rustsecp256k1_v0_4_1_keypair_create(ctx, &keypair, sk));
+
+    rustsecp256k1_v0_4_1_testrand256(msg);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, adaptor_sig, msg, &keypair, NULL, NULL, adaptor));
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, NULL, NULL));
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_recover(recover, sig, adaptor_sig));
+    CHECK(rustsecp256k1_v0_4_1_memcmp_var(recover, adaptor, sizeof(recover)) == 0);
+}
+
 void run_schnorrsig_tests(void) {
     int i;
     run_nonce_function_bip340_tests();
@@ -799,6 +819,7 @@ void run_schnorrsig_tests(void) {
     for (i = 0; i < count; i++) {
         test_schnorrsig_sign();
         test_schnorrsig_sign_verify();
+	test_schnorrsig_sign_adaptor_recover();
     }
     test_schnorrsig_taproot();
 }

--- a/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/tests_impl.h
+++ b/secp256k1-sys/depend/secp256k1/src/modules/schnorrsig/tests_impl.h
@@ -138,23 +138,23 @@ void test_schnorrsig_api(void) {
 
     /** main test body **/
     ecount = 0;
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(none, sig, msg, &keypairs[0], NULL, NULL) == 0);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(none, sig, msg, &keypairs[0], NULL, NULL, NULL) == 0);
     CHECK(ecount == 1);
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(vrfy, sig, msg, &keypairs[0], NULL, NULL) == 0);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(vrfy, sig, msg, &keypairs[0], NULL, NULL, NULL) == 0);
     CHECK(ecount == 2);
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, msg, &keypairs[0], NULL, NULL) == 1);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, msg, &keypairs[0], NULL, NULL, NULL) == 1);
     CHECK(ecount == 2);
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, NULL, msg, &keypairs[0], NULL, NULL) == 0);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, NULL, msg, &keypairs[0], NULL, NULL, NULL) == 0);
     CHECK(ecount == 3);
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, NULL, &keypairs[0], NULL, NULL) == 0);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, NULL, &keypairs[0], NULL, NULL, NULL) == 0);
     CHECK(ecount == 4);
     CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, msg, NULL, NULL, NULL) == 0);
     CHECK(ecount == 5);
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, msg, &invalid_keypair, NULL, NULL) == 0);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, msg, &invalid_keypair, NULL, NULL, NULL) == 0);
     CHECK(ecount == 6);
 
     ecount = 0;
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, msg, &keypairs[0], NULL, NULL) == 1);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(sign, sig, msg, &keypairs[0], NULL, NULL, NULL) == 1);
     CHECK(rustsecp256k1_v0_4_1_schnorrsig_verify(none, sig, msg, &pk[0]) == 0);
     CHECK(ecount == 1);
     CHECK(rustsecp256k1_v0_4_1_schnorrsig_verify(sign, sig, msg, &pk[0]) == 0);
@@ -196,7 +196,7 @@ void test_schnorrsig_bip_vectors_check_signing(const unsigned char *sk, const un
     rustsecp256k1_v0_4_1_xonly_pubkey pk, pk_expected;
 
     CHECK(rustsecp256k1_v0_4_1_keypair_create(ctx, &keypair, sk));
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, aux_rand));
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, aux_rand, NULL));
     CHECK(rustsecp256k1_v0_4_1_memcmp_var(sig, expected_sig, 64) == 0);
 
     CHECK(rustsecp256k1_v0_4_1_xonly_pubkey_parse(ctx, &pk_expected, pk_serialized));
@@ -677,16 +677,16 @@ void test_schnorrsig_sign(void) {
 
     rustsecp256k1_v0_4_1_testrand256(sk);
     CHECK(rustsecp256k1_v0_4_1_keypair_create(ctx, &keypair, sk));
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, NULL) == 1);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, NULL, NULL) == 1);
 
     /* Test different nonce functions */
     memset(sig, 1, sizeof(sig));
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_failing, NULL) == 0);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_failing, NULL, NULL) == 0);
     CHECK(rustsecp256k1_v0_4_1_memcmp_var(sig, zeros64, sizeof(sig)) == 0);
     memset(&sig, 1, sizeof(sig));
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_0, NULL) == 0);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_0, NULL, NULL) == 0);
     CHECK(rustsecp256k1_v0_4_1_memcmp_var(sig, zeros64, sizeof(sig)) == 0);
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_overflowing, NULL) == 1);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_overflowing, NULL, NULL) == 1);
     CHECK(rustsecp256k1_v0_4_1_memcmp_var(sig, zeros64, sizeof(sig)) != 0);
 }
 
@@ -709,7 +709,7 @@ void test_schnorrsig_sign_verify(void) {
 
     for (i = 0; i < N_SIGS; i++) {
         rustsecp256k1_v0_4_1_testrand256(msg[i]);
-        CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig[i], msg[i], &keypair, NULL, NULL));
+        CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig[i], msg[i], &keypair, NULL, NULL, NULL));
         CHECK(rustsecp256k1_v0_4_1_schnorrsig_verify(ctx, sig[i], msg[i], &pk));
     }
 
@@ -738,13 +738,13 @@ void test_schnorrsig_sign_verify(void) {
     }
 
     /* Test overflowing s */
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig[0], msg[0], &keypair, NULL, NULL));
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig[0], msg[0], &keypair, NULL, NULL, NULL));
     CHECK(rustsecp256k1_v0_4_1_schnorrsig_verify(ctx, sig[0], msg[0], &pk));
     memset(&sig[0][32], 0xFF, 32);
     CHECK(!rustsecp256k1_v0_4_1_schnorrsig_verify(ctx, sig[0], msg[0], &pk));
 
     /* Test negative s */
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig[0], msg[0], &keypair, NULL, NULL));
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig[0], msg[0], &keypair, NULL, NULL, NULL));
     CHECK(rustsecp256k1_v0_4_1_schnorrsig_verify(ctx, sig[0], msg[0], &pk));
     rustsecp256k1_v0_4_1_scalar_set_b32(&s, &sig[0][32], NULL);
     rustsecp256k1_v0_4_1_scalar_negate(&s, &s);
@@ -777,7 +777,7 @@ void test_schnorrsig_taproot(void) {
 
     /* Key spend */
     rustsecp256k1_v0_4_1_testrand256(msg);
-    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, NULL) == 1);
+    CHECK(rustsecp256k1_v0_4_1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, NULL, NULL) == 1);
     /* Verify key spend */
     CHECK(rustsecp256k1_v0_4_1_xonly_pubkey_parse(ctx, &output_pk, output_pk_bytes) == 1);
     CHECK(rustsecp256k1_v0_4_1_schnorrsig_verify(ctx, sig, msg, &output_pk) == 1);

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -470,6 +470,13 @@ extern "C" {
         pubkey: *const XOnlyPublicKey,
     ) -> c_int;
 
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_1_schnorrsig_recover")]
+    pub fn secp256k1_schnorrsig_recover(
+        secret: *mut c_uchar,
+        sig: *const c_uchar,
+        adaptor_sig: *const c_uchar,
+    ) -> c_int;
+
     // Extra keys
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_1_keypair_create")]
     pub fn secp256k1_keypair_create(
@@ -1031,6 +1038,21 @@ mod fuzz_dummy {
         let msg_sl = slice::from_raw_parts(msg32 as *const u8, 32);
         sig_sl[..32].copy_from_slice(msg_sl);
         sig_sl[32..].copy_from_slice(&new_kp.0[32..64]);
+        1
+    }
+
+    /// Sets secret to sig[32..], then adaptor_sig[32..]
+    pub unsafe fn secp256k1_schnorrsig_recover(
+        secret: *mut c_uchar,
+        sig: *const c_uchar,
+        adaptor_sig: *const c_uchar,
+    ) -> c_int {
+        // Recover
+        let sec_sl = slice::from_raw_parts_mut(secret as *mut u8, 32);
+        let sig_sl = slice::from_raw_parts(sig as *const u8, 64);
+        let adaptor_sl = slice::from_raw_parts(adaptor_sig as *const u8, 64);
+        sec_sl.copy_from_slice(&sig_sl[32..]);
+        sec_sl.copy_from_slice(&adaptor_sl[32..]);
         1
     }
 

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -458,7 +458,8 @@ extern "C" {
         msg32: *const c_uchar,
         keypair: *const KeyPair,
         noncefp: SchnorrNonceFn,
-        noncedata: *const c_void
+        noncedata: *const c_void,
+        adaptor: *const c_uchar,
     ) -> c_int;
 
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_4_1_schnorrsig_verify")]


### PR DESCRIPTION
Modify `rust_.*_schnorrsig_sign` to enable the option to create adaptor Schnorr signatures.

Add function to recover the adaptor secret from a Schnorr signature and adaptor Schnorr signature.