### PR TITLE
Bump bitcoin_hashes to version 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+
+* Rename `secp256k1::bitcoin_hashes` module to `secp256k1::hashes` to align with `bitcoin` crate naming.
 
 # 0.20.3 - 2021-06-10
 
@@ -35,7 +38,7 @@
 # 0.18.0 - 2020-08-26
 
 * Add feature-gated `bitcoin_hashes` dependency and [`ThirtyTwoByteHash` trait](https://github.com/rust-bitcoin/rust-secp256k1/pull/206/)
-* Add feature-gated [global static context](https://github.com/rust-bitcoin/rust-secp256k1/pull/224) 
+* Add feature-gated [global static context](https://github.com/rust-bitcoin/rust-secp256k1/pull/224)
 * Allow [all-zero messages](https://github.com/rust-bitcoin/rust-secp256k1/pull/207) to be constructed
 * Bump rust-secp-sys to 0.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ global-context-less-secure = []
 
 [dependencies]
 secp256k1-sys = { version = "0.4.1", default-features = false, path = "./secp256k1-sys" }
-bitcoin_hashes = { version = "0.9", optional = true }
+bitcoin_hashes = { version = "0.10", optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
@@ -39,7 +39,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 rand = "0.6"
 rand_core = "0.4"
 serde_test = "1.0"
-bitcoin_hashes = "0.9"
+bitcoin_hashes = "0.10"
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! # #[cfg(all(feature="rand", feature="bitcoin_hashes"))] {
 //! use secp256k1::rand::rngs::OsRng;
 //! use secp256k1::{Secp256k1, Message};
-//! use secp256k1::bitcoin_hashes::sha256;
+//! use secp256k1::hashes::sha256;
 //!
 //! let secp = Secp256k1::new();
 //! let mut rng = OsRng::new().expect("OsRng");
@@ -126,7 +126,7 @@
 pub extern crate secp256k1_sys;
 pub use secp256k1_sys as ffi;
 
-#[cfg(feature = "bitcoin_hashes")] pub extern crate bitcoin_hashes;
+#[cfg(feature = "bitcoin_hashes")] pub extern crate bitcoin_hashes as hashes;
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 #[cfg(any(test, feature = "rand"))] pub extern crate rand;
 #[cfg(any(test))] extern crate rand_core;
@@ -163,7 +163,7 @@ use ffi::{CPtr, types::AlignedType};
 pub use context::global::SECP256K1;
 
 #[cfg(feature = "bitcoin_hashes")]
-use bitcoin_hashes::Hash;
+use hashes::Hash;
 
 /// An ECDSA signature
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -212,21 +212,21 @@ pub trait ThirtyTwoByteHash {
 }
 
 #[cfg(feature = "bitcoin_hashes")]
-impl ThirtyTwoByteHash for bitcoin_hashes::sha256::Hash {
+impl ThirtyTwoByteHash for hashes::sha256::Hash {
     fn into_32(self) -> [u8; 32] {
         self.into_inner()
     }
 }
 
 #[cfg(feature = "bitcoin_hashes")]
-impl ThirtyTwoByteHash for bitcoin_hashes::sha256d::Hash {
+impl ThirtyTwoByteHash for hashes::sha256d::Hash {
     fn into_32(self) -> [u8; 32] {
         self.into_inner()
     }
 }
 
 #[cfg(feature = "bitcoin_hashes")]
-impl<T: bitcoin_hashes::sha256t::Tag> ThirtyTwoByteHash for bitcoin_hashes::sha256t::Hash<T> {
+impl<T: hashes::sha256t::Tag> ThirtyTwoByteHash for hashes::sha256t::Hash<T> {
     fn into_32(self) -> [u8; 32] {
         self.into_inner()
     }
@@ -497,8 +497,8 @@ impl Message {
     /// assert_eq!(m1, m2);
     /// ```
     #[cfg(feature = "bitcoin_hashes")]
-    pub fn from_hashed_data<H: ThirtyTwoByteHash + bitcoin_hashes::Hash>(data: &[u8]) -> Self {
-        <H as bitcoin_hashes::Hash>::hash(data).into()
+    pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
+        <H as hashes::Hash>::hash(data).into()
     }
 }
 
@@ -1291,25 +1291,25 @@ mod tests {
     #[cfg(feature = "bitcoin_hashes")]
     #[test]
     fn test_from_hash() {
-        use bitcoin_hashes;
-        use bitcoin_hashes::Hash;
+        use hashes;
+        use hashes::Hash;
 
         let test_bytes = "Hello world!".as_bytes();
 
-        let hash = bitcoin_hashes::sha256::Hash::hash(test_bytes);
+        let hash = hashes::sha256::Hash::hash(test_bytes);
         let msg = Message::from(hash);
         assert_eq!(msg.0, hash.into_inner());
         assert_eq!(
             msg,
-            Message::from_hashed_data::<bitcoin_hashes::sha256::Hash>(test_bytes)
+            Message::from_hashed_data::<hashes::sha256::Hash>(test_bytes)
         );
 
-        let hash = bitcoin_hashes::sha256d::Hash::hash(test_bytes);
+        let hash = hashes::sha256d::Hash::hash(test_bytes);
         let msg = Message::from(hash);
         assert_eq!(msg.0, hash.into_inner());
         assert_eq!(
             msg,
-            Message::from_hashed_data::<bitcoin_hashes::sha256d::Hash>(test_bytes)
+            Message::from_hashed_data::<hashes::sha256d::Hash>(test_bytes)
         );
     }
 }


### PR DESCRIPTION
Requires for interoperability of the `ThirtyTwoByteHash` trait with
rust-bitcoin.
