### PR TITLE
Use explicit u8 when assigning a byte slice

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -932,7 +932,7 @@ mod fuzz_dummy {
         let scalar_slice = slice::from_raw_parts(scalar, 32);
         let pk_slice = &(*point).0[..32];
 
-        let mut res_arr = [0; 32];
+        let mut res_arr = [0u8; 32];
         for i in 0..32 {
             res_arr[i] = scalar_slice[i] ^ pk_slice[i] ^ 1;
         }
@@ -1123,7 +1123,7 @@ mod fuzz_dummy {
         check_context_flags(cx, SECP256K1_START_VERIFY);
         let mut pk = PublicKey::new();
         pk.0.copy_from_slice(&(*keypair).0[32..]);
-        let mut sk = [0; 32];
+        let mut sk = [0u8; 32];
         sk.copy_from_slice(&(*keypair).0[..32]);
         assert_eq!(secp256k1_ec_pubkey_tweak_add(cx, &mut pk, tweak32), 1);
         assert_eq!(secp256k1_ec_seckey_tweak_add(cx, (&mut sk[..]).as_mut_ptr(), tweak32), 1);

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -123,7 +123,7 @@ mod fuzz_dummy {
             return 0;
         }
         // Pull the original pk out of the siganture
-        let mut pk_ser = [0; 33];
+        let mut pk_ser = [0u8; 33];
         pk_ser.copy_from_slice(&sig_sl[32..]);
         pk_ser.swap(0, 32);
         pk_ser[0] += 2;

--- a/src/key.rs
+++ b/src/key.rs
@@ -49,7 +49,7 @@ impl fmt::Display for SecretKey {
 impl str::FromStr for SecretKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<SecretKey, Error> {
-        let mut res = [0; constants::SECRET_KEY_SIZE];
+        let mut res = [0u8; constants::SECRET_KEY_SIZE];
         match from_hex(s, &mut res) {
             Ok(constants::SECRET_KEY_SIZE) => SecretKey::from_slice(&res),
             _ => Err(Error::InvalidSecretKey)
@@ -87,7 +87,7 @@ impl fmt::Display for PublicKey {
 impl str::FromStr for PublicKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<PublicKey, Error> {
-        let mut res = [0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
+        let mut res = [0u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
         match from_hex(s, &mut res) {
             Ok(constants::PUBLIC_KEY_SIZE) => {
                 PublicKey::from_slice(
@@ -132,7 +132,7 @@ impl SecretKey {
     pub fn from_slice(data: &[u8])-> Result<SecretKey, Error> {
         match data.len() {
             constants::SECRET_KEY_SIZE => {
-                let mut ret = [0; constants::SECRET_KEY_SIZE];
+                let mut ret = [0u8; constants::SECRET_KEY_SIZE];
                 unsafe {
                     if ffi::secp256k1_ec_seckey_verify(
                         ffi::secp256k1_context_no_precomp,
@@ -152,7 +152,7 @@ impl SecretKey {
     /// Creates a new secret key using data from BIP-340 [`::schnorrsig::KeyPair`]
     #[inline]
     pub fn from_keypair(keypair: &::schnorrsig::KeyPair) -> Self {
-        let mut sk = [0; constants::SECRET_KEY_SIZE];
+        let mut sk = [0u8; constants::SECRET_KEY_SIZE];
         unsafe {
             let ret = ffi::secp256k1_keypair_sec(
                 ffi::secp256k1_context_no_precomp,
@@ -325,7 +325,7 @@ impl PublicKey {
     /// the y-coordinate is represented by only a single bit, as x determines
     /// it up to one bit.
     pub fn serialize(&self) -> [u8; constants::PUBLIC_KEY_SIZE] {
-        let mut ret = [0; constants::PUBLIC_KEY_SIZE];
+        let mut ret = [0u8; constants::PUBLIC_KEY_SIZE];
 
         unsafe {
             let mut ret_len = constants::PUBLIC_KEY_SIZE as usize;
@@ -344,7 +344,7 @@ impl PublicKey {
 
     /// Serialize the key as a byte-encoded pair of values, in uncompressed form
     pub fn serialize_uncompressed(&self) -> [u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE] {
-        let mut ret = [0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
+        let mut ret = [0u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
 
         unsafe {
             let mut ret_len = constants::UNCOMPRESSED_PUBLIC_KEY_SIZE as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 impl str::FromStr for Signature {
 type Err = Error;
 fn from_str(s: &str) -> Result<Signature, Error> {
-    let mut res = [0; 72];
+    let mut res = [0u8; 72];
     match from_hex(s, &mut res) {
         Ok(x) => Signature::from_der(&res[0..x]),
         _ => Err(Error::InvalidSignature),
@@ -397,7 +397,7 @@ impl Signature {
     #[inline]
     /// Serializes the signature in compact format
     pub fn serialize_compact(&self) -> [u8; 64] {
-        let mut ret = [0; 64];
+        let mut ret = [0u8; 64];
         unsafe {
             let err = ffi::secp256k1_ecdsa_signature_serialize_compact(
                 ffi::secp256k1_context_no_precomp,
@@ -473,7 +473,7 @@ impl Message {
     pub fn from_slice(data: &[u8]) -> Result<Message, Error> {
         match data.len() {
             constants::MESSAGE_SIZE => {
-                let mut ret = [0; constants::MESSAGE_SIZE];
+                let mut ret = [0u8; constants::MESSAGE_SIZE];
                 ret[..].copy_from_slice(data);
                 Ok(Message(ret))
             }
@@ -647,7 +647,7 @@ impl<C: Context> Secp256k1<C> {
     /// compilation with "rand" feature.
     #[cfg(any(test, feature = "rand"))]
     pub fn randomize<R: Rng + ?Sized>(&mut self, rng: &mut R) {
-        let mut seed = [0; 32];
+        let mut seed = [0u8; 32];
         rng.fill_bytes(&mut seed);
         self.seeded_randomize(&seed);
     }
@@ -672,7 +672,7 @@ impl<C: Context> Secp256k1<C> {
 }
 
 fn der_length_check(sig: &ffi::Signature, max_len: usize) -> bool {
-    let mut ser_ret = [0; 72];
+    let mut ser_ret = [0u8; 72];
     let mut len: usize = ser_ret.len();
     unsafe {
         let err = ffi::secp256k1_ecdsa_signature_serialize_der(
@@ -687,7 +687,7 @@ fn der_length_check(sig: &ffi::Signature, max_len: usize) -> bool {
 }
 
 fn compact_sig_has_zero_first_bit(sig: &ffi::Signature) -> bool {
-    let mut compact = [0; 64];
+    let mut compact = [0u8; 64];
     unsafe {
         let err = ffi::secp256k1_ecdsa_signature_serialize_compact(
             ffi::secp256k1_context_no_precomp,
@@ -1007,7 +1007,7 @@ mod tests {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
 
-        let mut msg = [0; 32];
+        let mut msg = [0u8; 32];
         for _ in 0..100 {
             thread_rng().fill_bytes(&mut msg);
             let msg = Message::from_slice(&msg).unwrap();
@@ -1093,7 +1093,7 @@ mod tests {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
 
-        let mut msg = [0; 32];
+        let mut msg = [0u8; 32];
         for _ in 0..100 {
             thread_rng().fill_bytes(&mut msg);
             let msg = Message::from_slice(&msg).unwrap();
@@ -1126,8 +1126,8 @@ mod tests {
 
         // Wild keys: 1, CURVE_ORDER - 1
         // Wild msgs: 1, CURVE_ORDER - 1
-        let mut wild_keys = [[0; 32]; 2];
-        let mut wild_msgs = [[0; 32]; 2];
+        let mut wild_keys = [[0u8; 32]; 2];
+        let mut wild_msgs = [[0u8; 32]; 2];
 
         wild_keys[0][0] = 1;
         wild_msgs[0][0] = 1;

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -239,8 +239,8 @@ mod tests {
     fn sign() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
-        let one = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+        let one: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
         let sk = SecretKey::from_slice(&one).unwrap();
         let msg = Message::from_slice(&one).unwrap();

--- a/src/schnorrsig.rs
+++ b/src/schnorrsig.rs
@@ -65,7 +65,7 @@ impl fmt::Display for Signature {
 impl str::FromStr for Signature {
     type Err = Error;
     fn from_str(s: &str) -> Result<Signature, Error> {
-        let mut res = [0; constants::SCHNORRSIG_SIGNATURE_SIZE];
+        let mut res = [0u8; constants::SCHNORRSIG_SIGNATURE_SIZE];
         match from_hex(s, &mut res) {
             Ok(constants::SCHNORRSIG_SIGNATURE_SIZE) => {
                 Signature::from_slice(&res[0..constants::SCHNORRSIG_SIGNATURE_SIZE])
@@ -102,7 +102,7 @@ impl fmt::Display for PublicKey {
 impl str::FromStr for PublicKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<PublicKey, Error> {
-        let mut res = [0; constants::SCHNORRSIG_PUBLIC_KEY_SIZE];
+        let mut res = [0u8; constants::SCHNORRSIG_PUBLIC_KEY_SIZE];
         match from_hex(s, &mut res) {
             Ok(constants::SCHNORRSIG_PUBLIC_KEY_SIZE) => {
                 PublicKey::from_slice(&res[0..constants::SCHNORRSIG_PUBLIC_KEY_SIZE])
@@ -118,7 +118,7 @@ impl Signature {
     pub fn from_slice(data: &[u8]) -> Result<Signature, Error> {
         match data.len() {
             constants::SCHNORRSIG_SIGNATURE_SIZE => {
-                let mut ret = [0; constants::SCHNORRSIG_SIGNATURE_SIZE];
+                let mut ret = [0u8; constants::SCHNORRSIG_SIGNATURE_SIZE];
                 ret[..].copy_from_slice(data);
                 Ok(Signature(ret))
             }
@@ -183,7 +183,7 @@ impl KeyPair {
     /// Creates a Schnorr KeyPair directly from a secret key string
     #[inline]
     pub fn from_seckey_str<C: Signing>(secp: &Secp256k1<C>, s: &str) -> Result<KeyPair, Error> {
-        let mut res = [0; constants::SECRET_KEY_SIZE];
+        let mut res = [0u8; constants::SECRET_KEY_SIZE];
         match from_hex(s, &mut res) {
             Ok(constants::SECRET_KEY_SIZE) => {
                 KeyPair::from_seckey_slice(secp, &res[0..constants::SECRET_KEY_SIZE])
@@ -304,7 +304,7 @@ impl PublicKey {
     /// the y-coordinate is represented by only a single bit, as x determines
     /// it up to one bit.
     pub fn serialize(&self) -> [u8; constants::SCHNORRSIG_PUBLIC_KEY_SIZE] {
-        let mut ret = [0; constants::SCHNORRSIG_PUBLIC_KEY_SIZE];
+        let mut ret = [0u8; constants::SCHNORRSIG_PUBLIC_KEY_SIZE];
 
         unsafe {
             let err = ffi::secp256k1_xonly_pubkey_serialize(
@@ -612,7 +612,7 @@ mod tests {
 
     macro_rules! hex_32 {
         ($hex:expr) => {{
-            let mut result = [0; 32];
+            let mut result = [0u8; 32];
             from_hex($hex, &mut result).expect("valid hex string");
             result
         }};
@@ -625,7 +625,7 @@ mod tests {
 
         let mut rng = thread_rng();
         let (seckey, pubkey) = secp.generate_schnorrsig_keypair(&mut rng);
-        let mut msg = [0; 32];
+        let mut msg = [0u8; 32];
 
         for _ in 0..100 {
             rng.fill_bytes(&mut msg);
@@ -640,7 +640,7 @@ mod tests {
     #[test]
     fn test_schnorrsig_sign_with_aux_rand_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, rng| {
-            let mut aux_rand = [0; 32];
+            let mut aux_rand = [0u8; 32];
             rng.fill_bytes(&mut aux_rand);
             secp.schnorrsig_sign_with_aux_rand(msg, seckey, &aux_rand)
         })
@@ -863,7 +863,7 @@ mod tests {
 
         let msg = Message::from_slice(&[1; 32]).unwrap();
         let keypair = KeyPair::from_seckey_slice(&s, &[2; 32]).unwrap();
-        let aux = [3; 32];
+        let aux = [3u8; 32];
         let sig = s
             .schnorrsig_sign_with_aux_rand(&msg, &keypair, &aux);
         static SIG_BYTES: [u8; constants::SCHNORRSIG_SIGNATURE_SIZE] = [


### PR DESCRIPTION
Is there a way to tell the compiler to not allow `[0; 64]` and require that either the type is explicitly given to the variable, or that each member uses explicit `0u8` notation?

I noticed the usage was a mix of explicit and implicit, so I changed all to explicit.