### PR TITLE
Implement `Hash` for `schnorrsig::Signature`

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -36,7 +36,7 @@ pub mod types;
 #[cfg(feature = "recovery")]
 pub mod recovery;
 
-use core::{hash, slice, ptr};
+use core::{slice, ptr};
 use types::*;
 
 /// Flag for context to enable no precomputation
@@ -133,12 +133,6 @@ impl PublicKey {
     }
 }
 
-impl hash::Hash for PublicKey {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.0)
-    }
-}
-
 /// Library-internal representation of a Secp256k1 signature
 #[repr(C)]
 pub struct Signature([c_uchar; 64]);
@@ -210,12 +204,6 @@ impl XOnlyPublicKey {
     }
 }
 
-impl hash::Hash for XOnlyPublicKey {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.0)
-    }
-}
-
 #[repr(C)]
 pub struct KeyPair([c_uchar; 96]);
 impl_array_newtype!(KeyPair, c_uchar, 96);
@@ -248,12 +236,6 @@ impl KeyPair {
     /// essentially only useful for extending the FFI interface itself.
     pub fn underlying_bytes(self) -> [c_uchar; 96] {
         self.0
-    }
-}
-
-impl hash::Hash for KeyPair {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.0)
     }
 }
 

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -61,6 +61,12 @@ macro_rules! impl_array_newtype {
 
         impl Eq for $thing {}
 
+        impl ::core::hash::Hash for $thing {
+            fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+                (&self[..]).hash(state)
+            }
+        }
+
         impl PartialOrd for $thing {
             #[inline]
             fn partial_cmp(&self, other: &$thing) -> Option<::core::cmp::Ordering> {


### PR DESCRIPTION
I pondered putting the impl into the array type macro together with `(Partial)Eq`, but that would have meant removing other implementations and potentially implementing it for types where it is not wanted. The drawback of the separate impl is that it is more disconnected from the `(Partial)Eq` impl and could theoretically diverge (although unlikely in case of such a simple type) which would break the trait's contract.