### PR TITLE
Impl `ThirtyTwoByteHash` for `Message`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,12 @@ impl<T: hashes::sha256t::Tag> ThirtyTwoByteHash for hashes::sha256t::Hash<T> {
     }
 }
 
+impl ThirtyTwoByteHash for Message {
+    fn into_32(self) -> [u8; 32] {
+        self.0
+    }
+}
+
 impl SerializedSignature {
     /// Get a pointer to the underlying data with the specified capacity.
     pub(crate) fn get_data_mut_ptr(&mut self) -> *mut u8 {


### PR DESCRIPTION
A `Message` should always be a hash, thus it makes sense to implement `ThirtyTwoByteHash` for it so that the trait bound `M: ThirtyTwoByteHash` allows to both accept `Message`s and direct hashes.