### PR TITLE
Improve handling of parity integer

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -964,16 +964,16 @@ impl<'de> ::serde::Deserialize<'de> for XOnlyPublicKey {
 
 #[cfg(test)]
 mod test {
-    use Secp256k1;
-    use {from_hex, to_hex};
-    use super::super::Error::{InvalidPublicKey, InvalidSecretKey};
-    use super::{PublicKey, SecretKey};
-    use super::super::constants;
+    use super::*;
+
+    use std::iter;
+    use std::str::FromStr;
 
     use rand::{Error, ErrorKind, RngCore, thread_rng};
     use rand_core::impls;
-    use std::iter;
-    use std::str::FromStr;
+
+    use {to_hex, constants};
+    use Error::{InvalidPublicKey, InvalidSecretKey};
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/src/key.rs
+++ b/src/key.rs
@@ -636,12 +636,11 @@ impl KeyPair {
                 &mut self.0,
                 tweak.as_c_ptr(),
             );
-
-            if err == 1 {
-                Ok(())
-            } else {
-                Err(Error::InvalidTweak)
+            if err != 1 {
+                return Err(Error::InvalidTweak);
             }
+
+            Ok(())
         }
     }
 }
@@ -846,7 +845,6 @@ impl XOnlyPublicKey {
                 self.as_c_ptr(),
                 tweak.as_c_ptr(),
             );
-
             if err != 1 {
                 return Err(Error::InvalidTweak);
             }

--- a/src/key.rs
+++ b/src/key.rs
@@ -867,7 +867,7 @@ impl XOnlyPublicKey {
         }
     }
 
-    /// Verify that a tweak produced by `tweak_add_assign` was computed correctly
+    /// Verify that a tweak produced by `tweak_add_assign` was computed correctly.
     ///
     /// Should be called on the original untweaked key. Takes the tweaked key and
     /// output parity from `tweak_add_assign` as input.
@@ -876,6 +876,9 @@ impl XOnlyPublicKey {
     /// and checking equality. However, in future this API will support batch
     /// verification, which is significantly faster, so it is wise to design
     /// protocols with this in mind.
+    ///
+    /// # Return
+    /// True if tweak and check is successful, false otherwise.
     pub fn tweak_add_check<V: Verification>(
         &self,
         secp: &Secp256k1<V>,

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -565,37 +565,4 @@ mod tests {
         assert_tokens(&pk.readable(), &[Token::Str(PK_STR)]);
         assert_tokens(&pk.readable(), &[Token::String(PK_STR)]);
     }
-    #[test]
-    fn test_addition() {
-        let s = Secp256k1::new();
-
-        for _ in 0..10 {
-            let mut tweak = [0u8; 32];
-            thread_rng().fill_bytes(&mut tweak);
-            let (mut kp, mut pk) = s.generate_schnorrsig_keypair(&mut thread_rng());
-            let orig_pk = pk;
-            kp.tweak_add_assign(&s, &tweak).expect("Tweak error");
-            let parity = pk.tweak_add_assign(&s, &tweak).expect("Tweak error");
-            assert_eq!(XOnlyPublicKey::from_keypair(&kp), pk);
-            assert!(orig_pk.tweak_add_check(&s, &pk, parity, tweak));
-        }
-    }
-
-    #[test]
-    fn test_from_key_pubkey() {
-        let kpk1 = ::key::PublicKey::from_str(
-            "02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443",
-        )
-        .unwrap();
-        let kpk2 = ::key::PublicKey::from_str(
-            "0384526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f07",
-        )
-        .unwrap();
-
-        let pk1 = XOnlyPublicKey::from(kpk1);
-        let pk2 = XOnlyPublicKey::from(kpk2);
-
-        assert_eq!(pk1.serialize()[..], kpk1.serialize()[1..]);
-        assert_eq!(pk2.serialize()[..], kpk2.serialize()[1..]);
-    }
 }


### PR DESCRIPTION
Two functions in the FFI secp code return and accept a parity integer.

Currently we are manually converting this to a bool. Doing so forces readers of the code to think what the bool means even though understanding this value is not needed since in is just passed back down to the FFI code. 

We initially tried to solve this issue by adding an enum, discussion below refers to that version. Instead of an enum we can solve this issue by adding an opaque type that holds the parity value returned by the FFI function call and then just pass it back down to FFI code without devs needing to know what the value should be. This fully abstracts the value away and removes the boolean conversion code which must otherwise be read by each dev.

- Patch 1 and 2 improve unit tests that test the code path modified by this PR
- Patch 3 trivially changes code to be uniform between two similar methods (`tweak_add_assign`)
- Patch 4 is the meat and potatoes (main part of PR :)
- Patch 5 is docs improvements to code in the area of this PR