### PR TITLE
Add a static immutable zero aligned type

### DIFF
--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -40,10 +40,10 @@ impl AlignedType {
     pub fn zeroed() -> Self {
         AlignedType([0u8; 16])
     }
-}
 
-/// A static zeroed out AlignedType for use in static assignments of [AlignedType; _]
-pub static ZERO_ALIGNED: AlignedType = AlignedType([0u8; 16]);
+    /// A static zeroed out AlignedType for use in static assignments of [AlignedType; _]
+    const ZERO: AlignedType = AlignedType([0u8; 16]);
+}
 
 #[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
 pub(crate) const ALIGN_TO: usize = mem::align_of::<AlignedType>();

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -42,6 +42,9 @@ impl AlignedType {
     }
 }
 
+/// A static zeroed out AlignedType for use in static assignments of [AlignedType; _]
+pub static ZERO_ALIGNED: AlignedType = AlignedType([0u8; 16]);
+
 #[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
 pub(crate) const ALIGN_TO: usize = mem::align_of::<AlignedType>();
 


### PR DESCRIPTION
The `zeroed` fn can not be used in static assignments.

In environments where it is no_std and no allocator are present, the only way to get a slice of AlignedTypes is dynamically, so `preallocated_gen_new` can't be used.

By offering this as a static, it can be used in static assignments as such:

```rust
#[cfg(target_pointer_width = "32")]
static mut CONTEXT_BUFFER: [AlignedType; 69645] = [ZERO_ALIGNED; 69645];
#[cfg(target_pointer_width = "64")]
static mut CONTEXT_BUFFER: [AlignedType; 69646] = [ZERO_ALIGNED; 69646];
static mut SECP256K1: Option<Secp256k1<AllPreallocated>> = None;

pub fn get_context(seed: Option<&[u8; 32]>) -> &'static Secp256k1<AllPreallocated<'static>> {
    unsafe {
        if SECP256K1.is_none() {
            SECP256K1 = Some(
                Secp256k1::preallocated_gen_new(&mut CONTEXT_BUFFER)
                    .expect("CONTEXT_BUFFER size is wrong"),
            );
        }
        if let Some(seed) = seed {
            SECP256K1.as_mut().unwrap().seeded_randomize(seed);
        }
        SECP256K1.as_ref().unwrap()
    }
}
```