### PR TITLE
release secp256k1-sys 0.4.2; make new `ZERO` type publically accessible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ global-context = ["std", "rand-std", "global-context-less-secure"]
 global-context-less-secure = []
 
 [dependencies]
-secp256k1-sys = { version = "0.4.1", default-features = false, path = "./secp256k1-sys" }
+secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }
 bitcoin_hashes = { version = "0.10", optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-sys"
-version = "0.4.1"
+version = "0.4.2"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>" ]

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -42,7 +42,7 @@ impl AlignedType {
     }
 
     /// A static zeroed out AlignedType for use in static assignments of [AlignedType; _]
-    const ZERO: AlignedType = AlignedType([0u8; 16]);
+    pub const ZERO: AlignedType = AlignedType([0u8; 16]);
 }
 
 #[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]


### PR DESCRIPTION
Exposes the new const object provided by #345 