### PR TITLE
Re-export Parity struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.21.0"
+version = "0.21.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,11 +152,7 @@ pub mod schnorr;
 #[cfg(feature = "serde")]
 mod serde_util;
 
-pub use key::SecretKey;
-pub use key::PublicKey;
-pub use key::ONE_KEY;
-pub use key::KeyPair;
-pub use key::XOnlyPublicKey;
+pub use key::{SecretKey, PublicKey, ONE_KEY, KeyPair, XOnlyPublicKey, Parity};
 pub use context::*;
 use core::marker::PhantomData;
 use core::{mem, fmt, str};


### PR DESCRIPTION
pub struct Parity is under a private module key and not re-exported in lib.rs . It is therefore not
possible to use it downstream. 