### PR TITLE
Add missing 'standard' derives for Parity type

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -910,6 +910,7 @@ impl XOnlyPublicKey {
 }
 
 /// Opaque type used to hold the parity passed between FFI function calls.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Parity(i32);
 
 impl From<i32> for Parity {


### PR DESCRIPTION
Recently we (*cough* Tobin) added a new type `Parity` and neglected to add the standard derive attributes. By 'standard' I took to mean the ones typical in `rust-bitcoin` and mentioned in the upcoming `CONTIBUTING.md` [document ](https://github.com/rust-bitcoin/rust-bitcoin/pull/587/files)for that project.

