### PR TITLE
Fixed docs(rs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autoexamples = false # Remove when edition 2018 https://github.com/rust-lang/car
 
 # Should make docs.rs show all functions, even those behind non-default features
 [package.metadata.docs.rs]
-features = [ "rand", "rand-std", "serde", "recovery" ]
+features = [ "rand", "rand-std", "serde", "bitcoin_hashes", "recovery", "global-context" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,7 +10,7 @@ use Secp256k1;
 pub use self::alloc_only::*;
 
 #[cfg(feature = "global-context-less-secure")]
-#[cfg_attr(docsrs, doc(cfg(feature = "global-context-less-secure")))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "global-context", feature = "global-context-less-secure"))))]
 /// Module implementing a singleton pattern for a global `Secp256k1` context
 pub mod global {
     #[cfg(feature = "global-context")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ use core::{mem, fmt, str};
 use ffi::{CPtr, types::AlignedType};
 
 #[cfg(feature = "global-context-less-secure")]
-#[cfg_attr(docsrs, doc(cfg(feature = "global-context-less-secure")))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "global-context", feature = "global-context-less-secure"))))]
 pub use context::global::SECP256K1;
 
 #[cfg(feature = "bitcoin_hashes")]


### PR DESCRIPTION
Sadly, I missed two details in #353: features missing in docs.rs configuration and `global-context` being a bit confusing.
This PR fixes those, see commit messages for details.