### PR TITLE
Remove capital letter in middle of docs sentence

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -51,7 +51,7 @@ pub mod global {
 }
 
 
-/// A trait for all kinds of Context's that Lets you define the exact flags and a function to deallocate memory.
+/// A trait for all kinds of Context's that lets you define the exact flags and a function to deallocate memory.
 /// It shouldn't be possible to implement this for types outside this crate.
 pub unsafe trait Context : private::Sealed {
     /// Flags for the ffi.


### PR DESCRIPTION
(Candidate for most trivial patch of all time.)

Seems to be a typo, change the 'L' to an 'l'.

