### PR TITLE
Deprecate generate_schnorrsig_keypair method

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -1553,7 +1553,10 @@ mod test {
         for _ in 0..10 {
             let mut tweak = [0u8; 32];
             thread_rng().fill_bytes(&mut tweak);
-            let (mut kp, mut pk) = s.generate_schnorrsig_keypair(&mut thread_rng());
+
+            let mut kp = KeyPair::new(&s, &mut thread_rng());
+            let mut pk = kp.public_key();
+
             let orig_pk = pk;
             kp.tweak_add_assign(&s, &tweak).expect("Tweak error");
             let parity = pk.tweak_add_assign(&s, &tweak).expect("Tweak error");

--- a/src/key.rs
+++ b/src/key.rs
@@ -650,6 +650,12 @@ impl KeyPair {
             Ok(())
         }
     }
+
+    /// Gets the [XOnlyPublicKey] for this [KeyPair].
+    #[inline]
+    pub fn public_key(&self) -> XOnlyPublicKey {
+        XOnlyPublicKey::from_keypair(self)
+    }
 }
 
 impl From<KeyPair> for SecretKey {


### PR DESCRIPTION
Recently we deprecated a bunch of functions/methods that used the term `schnorrsig`. Seems we left `generate_schnorrsig_keypair` in there, along with some stale docs on it.

- Patch 1: Adds method `KeyPair::public_key` that calls through to `XOnlyPublicKey::from_keypair`.
- Patch 2: Deprecates `generate_schnorrsig_keypair` and uses the newly defined `pk.public_key()` everywhere.

### Note to reviewers

Please note, this PR has been totally re-written using the suggestions below by @apoelstra. 