### PR TITLE
Use hyperlinks

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -639,7 +639,7 @@ unsafe fn strlen(mut str_ptr: *const c_char) -> usize {
 
 
 /// A trait for producing pointers that will always be valid in C. (assuming NULL pointer is a valid no-op)
-/// Rust doesn't promise what pointers does it give to ZST (https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts)
+/// Rust doesn't promise what pointers does it give to ZST (<https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts>)
 /// In case the type is empty this trait will give a NULL pointer, which should be handled in C.
 ///
 pub trait CPtr {

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -10,7 +10,7 @@ pub type size_t = usize;
 /// The way we use it makes it fine either way but this type shouldn't be used outside of the library.
 pub type c_char = i8;
 
-/// This is an exact copy of https://doc.rust-lang.org/core/ffi/enum.c_void.html
+/// This is an exact copy of <https://doc.rust-lang.org/core/ffi/enum.c_void.html>
 /// It should be Equivalent to C's void type when used as a pointer.
 ///
 /// We can replace this with `core::ffi::c_void` once we update the rustc version to >=1.30.0.


### PR DESCRIPTION
Clippy emits two warnings of type:

 warning: this URL is not a hyperlink

As suggested, add pointy brackets to the links.

Docs built and links verified to be:

a) Not links as Clippy said before this patch is applied
b) Both are valid links with this patch applied