### PR TITLE
Use the new recover_ecdsa in bench function

### DIFF
--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -387,7 +387,7 @@ mod benches {
         let sig = s.sign_ecdsa_recoverable(&msg, &sk);
 
         bh.iter(|| {
-            let res = s.recover(&msg, &sig).unwrap();
+            let res = s.recover_ecdsa(&msg, &sig).unwrap();
             black_box(res);
         });
     }


### PR DESCRIPTION
We recently deprecated `recover` in favour of `recover_ecdsa` but missed
one call site in benches.