### PR TITLE
Fix the mess around Parity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,8 @@ pub enum Error {
     NotEnoughMemory,
     /// Bad set of public keys
     InvalidPublicKeySum,
+    /// The only valid parity values are 0 or 1.
+    InvalidParityValue,
 }
 
 impl Error {
@@ -336,6 +338,7 @@ impl Error {
             Error::InvalidTweak => "secp: bad tweak",
             Error::NotEnoughMemory => "secp: not enough memory allocated",
             Error::InvalidPublicKeySum => "secp: the sum of public keys was invalid or the input vector lengths was less than 1",
+            Error::InvalidParityValue => "The only valid parity values are 0 or 1",
         }
     }
 }


### PR DESCRIPTION
Recently we made a wee mess with the `Parity` opaque type. Let's fix it
up by doing:

- Use an enum with variants `Even` and `Odd`.
- Add explicit conversion methods to/from u8 and i32
- Implement `BitXor`

This PR attempts to follow the plan laid out in the issue but:
- I don't get why`to_u8` is requested, I added it anyways.
- `to_i32` is not mentioned but we need it if we are going to pass the parity back to FFI code after receiving it _without_ having to care about the value. And that is the whole point of this `Parity` type in the first place.
- I don't get why `from_xxx` is fallible, when is an integer not even or odd?

Please note: This patch is an API breaking change that does _not_ follow the deprecation guidelines. Rust does not allow deprecating `From` impl blocks AFAICT.

Fixes: #370