### PR TITLE
Randomize context on creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ alloc = []
 rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
-global-context = ["std", "rand-std", "global-context-less-secure"]
-global-context-less-secure = []
+global-context = ["std"]
 
 [dependencies]
 secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }

--- a/src/context.rs
+++ b/src/context.rs
@@ -180,6 +180,19 @@ mod alloc_only {
         /// Lets you create a context in a generic manner (sign/verify/all).
         ///
         /// If `rand-std` feature is enabled, context will have been randomized using `thread_rng`.
+        /// If `rand-std` feature is not enabled please consider randomizing the context as follows:
+        /// ```
+        /// # #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))] {
+        /// # use secp256k1::Secp256k1;
+        /// # use secp256k1::rand::{thread_rng, RngCore};
+        /// let mut ctx = Secp256k1::new();
+        /// # let mut rng = thread_rng();
+        /// # let mut seed = [0u8; 32];
+        /// # rng.fill_bytes(&mut seed);
+        /// // let seed = <32 bytes of random data>
+        /// ctx.seeded_randomize(&seed);
+        /// # }
+        /// ```
         #[allow(unused_mut)]    // Unused when `rand-std` is not enabled.
         pub fn gen_new() -> Secp256k1<C> {
             #[cfg(target_arch = "wasm32")]
@@ -207,6 +220,8 @@ mod alloc_only {
         /// Creates a new Secp256k1 context with all capabilities.
         ///
         /// If `rand-std` feature is enabled, context will have been randomized using `thread_rng`.
+        /// If `rand-std` feature is not enabled please consider randomizing the context (see docs
+        /// for `Secp256k1::gen_new()`).
         pub fn new() -> Secp256k1<All> {
             Secp256k1::gen_new()
         }
@@ -216,6 +231,8 @@ mod alloc_only {
         /// Creates a new Secp256k1 context that can only be used for signing.
         ///
         /// If `rand-std` feature is enabled, context will have been randomized using `thread_rng`.
+        /// If `rand-std` feature is not enabled please consider randomizing the context (see docs
+        /// for `Secp256k1::gen_new()`).
         pub fn signing_only() -> Secp256k1<SignOnly> {
             Secp256k1::gen_new()
         }
@@ -225,6 +242,8 @@ mod alloc_only {
         /// Creates a new Secp256k1 context that can only be used for verification.
         ///
         /// If `rand-std` feature is enabled, context will have been randomized using `thread_rng`.
+        /// If `rand-std` feature is not enabled please consider randomizing the context (see docs
+        /// for `Secp256k1::gen_new()`).
         pub fn verification_only() -> Secp256k1<VerifyOnly> {
             Secp256k1::gen_new()
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -641,7 +641,7 @@ impl Ord for PublicKey {
 /// feature active. This is due to security considerations, see the [`serde_keypair`] documentation
 /// for details.
 ///
-/// If the `serde` and `global-context[-less-secure]` features are active `KeyPair`s can be serialized and
+/// If the `serde` and `global-context` features are active `KeyPair`s can be serialized and
 /// deserialized by annotating them with `#[serde(with = "secp256k1::serde_keypair")]`
 /// inside structs or enums for which [`Serialize`] and [`Deserialize`] are being derived.
 ///
@@ -1320,7 +1320,7 @@ impl<'de> ::serde::Deserialize<'de> for XOnlyPublicKey {
 ///
 /// [`SecretKey`]: crate::SecretKey
 /// [global context]: crate::SECP256K1
-#[cfg(all(feature = "global-context-less-secure", feature = "serde"))]
+#[cfg(all(feature = "global-context", feature = "serde"))]
 pub mod serde_keypair {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use key::KeyPair;
@@ -1924,7 +1924,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "global-context-less-secure", feature = "serde"))]
+    #[cfg(all(feature = "global-context", feature = "serde"))]
     fn test_serde_keypair() {
         use serde::{Deserialize, Deserializer, Serialize, Serializer};
         use serde_test::{Configure, Token, assert_tokens};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,9 +125,7 @@
 //! * `rand-std` - use `rand` library with its `std` feature enabled. (Implies `rand`.)
 //! * `recovery` - enable functions that can compute the public key from signature.
 //! * `lowmemory` - optimize the library for low-memory environments.
-//! * `global-context` - enable use of global secp256k1 context. (Implies `std`, `rand-std` and
-//!                      `global-context-less-secure`.)
-//! * `global-context-less-secure` - enables global context without extra sidechannel protection.
+//! * `global-context` - enable use of global secp256k1 context (implies `std`).
 //! * `serde` - implements serialization and deserialization for types in this crate using `serde`.
 //!           **Important**: `serde` encoding is **not** the same as consensus encoding!
 //! * `bitcoin_hashes` - enables interaction with the `bitcoin-hashes` crate (e.g. conversions).
@@ -195,8 +193,8 @@ use core::marker::PhantomData;
 use core::{mem, fmt, str};
 use ffi::{CPtr, types::AlignedType};
 
-#[cfg(feature = "global-context-less-secure")]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "global-context", feature = "global-context-less-secure"))))]
+#[cfg(feature = "global-context")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "global-context", feature = "global-context"))))]
 pub use context::global::SECP256K1;
 
 #[cfg(feature = "bitcoin_hashes")]
@@ -955,7 +953,7 @@ mod tests {
 
     }
 
-    #[cfg(feature = "global-context-less-secure")]
+    #[cfg(feature = "global-context")]
     #[test]
     fn test_global_context() {
         use super::SECP256K1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,13 @@
 //! and its derivatives.
 //!
 //! To minimize dependencies, some functions are feature-gated. To generate
-//! random keys or to re-randomize a context object, compile with the "rand"
-//! feature. To de/serialize objects with serde, compile with "serde".
-//! **Important**: `serde` encoding is **not** the same as consensus encoding!
+//! random keys or to re-randomize a context object, compile with the
+//! `rand-std` feature. If you are willing to use the `rand-std` feature, we
+//! have enabled an additional defense-in-depth sidechannel protection for
+//! our context objects, which re-blinds certain operations on secret key
+//! data. To de/serialize objects with serde, compile with "serde".
+//! **Important**: `serde` encoding is **not** the same as consensus
+//! encoding!
 //!
 //! Where possible, the bindings use the Rust type system to ensure that
 //! API usage errors are impossible. For example, the library uses context


### PR DESCRIPTION
Currently it is easy for users to mis-use our API because they may not know that `randomize()` should be called after context creation for maximum defence against side channel attacks.

This PR entails the first two parts of the plan outlined in #388. The commit messages are a bit light of information as to _why_ we are doing this so please see #388 for more context. 

In light of @real-or-random's [comment](https://github.com/rust-bitcoin/rust-secp256k1/issues/388#issuecomment-1026613592) about verification contexts the randomization is done in `gen_new` i.e., for _all_ contexts not just signing ones.

Also, I think we should add some docs about exactly _what_ randomization buys the user and what it costs. I do not know exactly what this is, can someone please write a sentence or two that we can include in the docs to `gen_new`?

@TheBlueMatt please review patch 4.

Resolves: #225

**Note**: This is a total re-write of the original PR, most of the discussion below is stale. Of note, the additional API that takes a seed during construction is not implemented here.
