### PR TITLE
Enable build with global context less secure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std", "rand-std", "global-context-less-secure"]
-global-context-less-secure = []
+global-context-less-secure = ["std"]
 
 [dependencies]
 secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-FEATURES="bitcoin_hashes global-context lowmemory rand rand-std recovery serde"
+FEATURES="bitcoin_hashes global-context-less-secure global-context lowmemory rand rand-std recovery serde"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types)]
-use core::{fmt, mem};
+use core::fmt;
 
 pub type c_int = i32;
 pub type c_uchar = u8;
@@ -46,7 +46,7 @@ impl AlignedType {
 }
 
 #[cfg(all(feature = "std", not(rust_secp_no_symbol_renaming)))]
-pub(crate) const ALIGN_TO: usize = mem::align_of::<AlignedType>();
+pub(crate) const ALIGN_TO: usize = ::core::mem::align_of::<AlignedType>();
 
 #[cfg(test)]
 mod tests {

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,6 +35,7 @@ pub mod global {
     impl Deref for GlobalContext {
         type Target = Secp256k1<All>;
 
+        #[allow(unused_mut)]    // Unused when "global-context" is not enabled.
         fn deref(&self) -> &Self::Target {
             static ONCE: Once = Once::new();
             static mut CONTEXT: Option<Secp256k1<All>> = None;

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,7 +16,7 @@ pub mod global {
     #[cfg(feature = "global-context")]
     use rand;
 
-    use std::ops::Deref;
+    use core::ops::Deref;
     use std::sync::Once;
     use {Secp256k1, All};
 


### PR DESCRIPTION
Currently the following build command fails:
```
cargo build --no-default-features --features=global-context-less-secure
```

- The first two patches are benign refactorings.
- Patch 3 adds an implementation of `Debug` using `bitcoin_hashes::sha256` as the hasher as well as a fallback implementation. Please review carefully.
- Patch 4 adds `global-context-less-secure` to the test features matrix 