### PR TITLE
Add global context API

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -12,6 +12,9 @@ mod recovery;
 #[cfg_attr(docsrs, doc(cfg(feature = "recovery")))]
 pub use self::recovery::{RecoveryId, RecoverableSignature};
 
+#[cfg(feature = "global-context")]
+use SECP256K1;
+
 /// An ECDSA signature
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Signature(pub(crate) ffi::Signature);
@@ -268,6 +271,14 @@ impl Signature {
             debug_assert!(err == 1);
         }
         ret
+    }
+
+    /// Verifies an ECDSA signature for `msg` using `pk` and the global [`SECP256K1`] context.
+    #[inline]
+    #[cfg(feature = "global-context")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "global-context")))]
+    pub fn verify(&self, msg: &Message, pk: &PublicKey) -> Result<(), Error> {
+        SECP256K1.verify_ecdsa(msg, self, pk)
     }
 }
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -121,6 +121,15 @@ impl RecoverableSignature {
             Signature(ret)
         }
     }
+
+    /// Determines the public key for which this [`Signature`] is valid for `msg`. Requires a
+    /// verify-capable context.
+    #[inline]
+    #[cfg(feature = "global-context")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "global-context")))]
+    pub fn recover(&self, msg: &Message) -> Result<key::PublicKey, Error> {
+        SECP256K1.recover_ecdsa(msg, self)
+    }
 }
 
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -338,9 +338,7 @@ impl PublicKey {
     /// # }
     /// ```
     #[inline]
-    pub fn from_secret_key<C: Signing>(secp: &Secp256k1<C>,
-                           sk: &SecretKey)
-                           -> PublicKey {
+    pub fn from_secret_key<C: Signing>(secp: &Secp256k1<C>,sk: &SecretKey) -> PublicKey {
         unsafe {
             let mut pk = ffi::PublicKey::new();
             // We can assume the return value because it's not possible to construct

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,22 @@
 //! # }
 //! ```
 //!
+//! If the "global-context" feature is enabled you have access to an alternate API.
+//!
+//! ```rust
+//! # #[cfg(all(feature="global-context", feature = "std", feature="rand-std", features = "bitcoin_hashes"))] {
+//! use secp256k1::rand::thread_rng;
+//! use secp256k1::{generate_keypair, Message};
+//! use secp256k1::hashes::sha256;
+//!
+//! let (secret_key, public_key) = generate_keypair(&mut thread_rng());
+//! let message = Message::from_hashed_data::<sha256::Hash>("Hello World!".as_bytes());
+//!
+//! let sig = secret_key.sign_ecdsa(&message, &secret_key);
+//! assert!(sig.verify(&message, &public_key).is_ok());
+//! # }
+//! ```
+//!
 //! The above code requires `rust-secp256k1` to be compiled with the `rand-std` and `bitcoin_hashes`
 //! feature enabled, to get access to [`generate_keypair`](struct.Secp256k1.html#method.generate_keypair)
 //! Alternately, keys and messages can be parsed from slices, like
@@ -968,8 +984,6 @@ mod tests {
     #[cfg(feature = "global-context")]
     #[test]
     fn test_global_context() {
-        use super::SECP256K1;
-
         let sk_data = hex!("e6dd32f8761625f105c39a39f19370b3521d845a12456d60ce44debd0a362641");
         let sk = SecretKey::from_slice(&sk_data).unwrap();
         let msg_data = hex!("a4965ca63b7d8562736ceec36dfa5a11bf426eb65be8ea3f7a49ae363032da0d");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ use core::{mem, fmt, str};
 use ffi::{CPtr, types::AlignedType};
 
 #[cfg(feature = "global-context")]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "global-context", feature = "global-context"))))]
+#[cfg_attr(docsrs, doc(cfg(feature = "global-context")))]
 pub use context::global::SECP256K1;
 
 #[cfg(feature = "bitcoin_hashes")]
@@ -456,6 +456,14 @@ impl<C: Signing> Secp256k1<C> {
         let pk = key::PublicKey::from_secret_key(self, &sk);
         (sk, pk)
     }
+}
+
+/// Generates a random keypair using the global [`SECP256K1`] context.
+#[inline]
+#[cfg(all(feature = "global-context", feature = "rand"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "global-context", feature = "rand"))))]
+pub fn generate_keypair<R: Rng + ?Sized>(rng: &mut R) -> (key::SecretKey, key::PublicKey) {
+    SECP256K1.generate_keypair(rng)
 }
 
 /// Utility function used to parse hex into a target u8 buffer. Returns

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -13,6 +13,9 @@ use ffi::{self, CPtr};
 use {constants, Secp256k1};
 use {Message, Signing, Verification, KeyPair, XOnlyPublicKey};
 
+#[cfg(all(feature  = "global-context", feature = "rand-std"))]
+use SECP256K1;
+
 /// Represents a Schnorr signature.
 pub struct Signature([u8; constants::SCHNORRSIG_SIGNATURE_SIZE]);
 impl_array_newtype!(Signature, u8, constants::SCHNORRSIG_SIGNATURE_SIZE);
@@ -87,6 +90,14 @@ impl Signature {
             }
             _ => Err(Error::InvalidSignature),
         }
+    }
+
+    /// Verifies a schnorr signature for `msg` using `pk` and the global [`SECP256K1`] context.
+    #[inline]
+    #[cfg(all(feature = "global-context", feature = "rand-std"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "global-context", feature = "rand-std"))))]
+    pub fn verify(&self, msg: &Message, pk: &XOnlyPublicKey) -> Result<(), Error> {
+        SECP256K1.verify_schnorr(self, msg, pk)
     }
 }
 


### PR DESCRIPTION
Our API often involves a `Secp256k1` parameter, when users enable the `global-context` feature they must then pass `SECP256K1` into these functions. This is kind of clunky since the global is by definition available everywhere.

Make the API more ergonomic for `global-context` builds by adding various API functions/methods that use the global context implicitly.

The first 3 patches are clean up.

Resolves: #330 