### PR TITLE
Add custom Debug impl for RecoverableSignature

### DIFF
--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -337,7 +337,7 @@ mod tests {
             0xff, 0x20, 0x80, 0xc4, 0xa3, 0x9a, 0xae, 0x06,
             0x8d, 0x12, 0xee, 0xd0, 0x09, 0xb6, 0x8c, 0x89],
             RecoveryId(1)).unwrap();
-        assert_eq!(&format!("{:?}", sig), "RecoverableSignature(98882e09f4ed6dc3659e43fc771e0cafa60b1f926f2b77041f744721adff7366898cb609d0ee128d06ae9aa3c48020ff9f705e02f80e1280a8ade05216971a4c01)");
+        assert_eq!(&format!("{:?}", sig), "RecoverableSignature(6673ffad2147741f04772b6f921f0ba6af0c1e77fc439e65c36dedf4092e88984c1a971652e0ada880120ef8025e709fff2080c4a39aae068d12eed009b68c8901)");
     }
 
     #[test]


### PR DESCRIPTION
Currently when debug printing the `RecoverableSignature` we do so byte by byte, this means that the output differs depending on the endianess of the machine. If instead we serialize the signature in compact form then the output is the same irrespective of the endianess.

With this applied the following two commands now pass:

```
cargo test test_debug_output --features=recovery
```
```
cross test --target powerpc-unknown-linux-gnu test_debug_output --features=recovery
```

Fixes: #375