### PR TITLE
Fix example dependency list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! trigger any assertion failures in the upstream library.
 //!
 //! ```rust
-//! # #[cfg(all(feature="rand", feature="bitcoin_hashes", any(feature = "alloc", feature = "std")))] {
+//! # #[cfg(all(feature = "std", feature="rand-std", feature="bitcoin_hashes"))] {
 //! use secp256k1::rand::rngs::OsRng;
 //! use secp256k1::{Secp256k1, Message};
 //! use secp256k1::hashes::sha256;


### PR DESCRIPTION
Example relies on `rand-std` not plain `rand` dependency.

I do not understand why the following command passes without this patch
applied

```
cargo test --no-default-features --features=std,rand,bitcoin_hashes
```

But if we put the same code in a standalone binary it fails as expected?

Since the running of this test is _unusual_ and it is primarily meant as
an entry point example to the library, remove the mention of "alloc"
feature and just depend upon "std".

Fixes: #395 