### PR TITLE
Limit SharedSecret to 32 byte buffer

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -65,7 +65,7 @@ use core::fmt::{self, write, Write};
 use core::intrinsics;
 use core::panic::PanicInfo;
 
-use secp256k1::ecdh::SharedSecret;
+use secp256k1::ecdh::{self, SharedSecret};
 use secp256k1::ffi::types::AlignedType;
 use secp256k1::rand::{self, RngCore};
 use secp256k1::serde::Serialize;
@@ -125,13 +125,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     assert_eq!(sig, new_sig);
 
     let _ = SharedSecret::new(&public_key, &secret_key);
-    let mut x_arr = [0u8; 32];
-    let y_arr = SharedSecret::new_with_hash(&public_key, &secret_key, |x,y| {
-        x_arr = x;
-        y.into()
-    });
-    assert_ne!(x_arr, [0u8; 32]);
-    assert_ne!(&y_arr[..], &[0u8; 32][..]);
+    let _ = ecdh::shared_secret_point(&public_key, &secret_key);
 
     #[cfg(feature = "alloc")]
     {

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -16,7 +16,7 @@
 //!
 
 use core::ptr;
-use core::ops::{FnMut, Deref};
+use core::ops::Deref;
 
 use key::{SecretKey, PublicKey};
 use ffi::{self, CPtr};
@@ -135,52 +135,52 @@ impl SharedSecret {
         ss.set_len(32); // The default hash function is SHA256, which is 32 bytes long.
         ss
     }
+}
 
+/// Creates a shared point from public key and secret key.
+///
+/// Can be used like `SharedSecret` but caller is responsible for then hashing the returned buffer.
+/// This allows for the use of a custom hash function since `SharedSecret` uses SHA256.
+///
+/// # Returns
+///
+/// 64 bytes representing the (x,y) co-ordinates of a point on the curve (32 bytes each).
+///
+/// # Examples
+/// ```
+/// # #[cfg(all(feature = "bitcoin_hashes", feature = "rand-std", feature = "std"))] {
+/// # use secp256k1::{ecdh, Secp256k1, PublicKey, SecretKey};
+/// # use secp256k1::hashes::{Hash, sha512};
+/// # use secp256k1::rand::thread_rng;
+///
+/// let s = Secp256k1::new();
+/// let (sk1, pk1) = s.generate_keypair(&mut thread_rng());
+/// let (sk2, pk2) = s.generate_keypair(&mut thread_rng());
+///
+/// let point1 = ecdh::shared_secret_point(&pk2, &sk1);
+/// let secret1 = sha512::Hash::hash(&point1);
+/// let point2 = ecdh::shared_secret_point(&pk1, &sk2);
+/// let secret2 = sha512::Hash::hash(&point2);
+/// assert_eq!(secret1, secret2)
+/// # }
+/// ```
+pub fn shared_secret_point(point: &PublicKey, scalar: &SecretKey) -> [u8; 64] {
+    let mut xy = [0u8; 64];
 
-    /// Creates a new shared secret from a pubkey and secret key with applied custom hash function.
-    /// The custom hash function must be in the form of `fn(x: [u8;32], y: [u8;32]) -> SharedSecret`
-    /// `SharedSecret` can be easily created via the `From` impl from arrays.
-    /// # Examples
-    /// ```
-    /// # #[cfg(any(feature = "alloc", features = "std"))] {
-    /// # use secp256k1::ecdh::SharedSecret;
-    /// # use secp256k1::{Secp256k1, PublicKey, SecretKey};
-    /// # fn sha2(_a: &[u8], _b: &[u8]) -> [u8; 32] {[0u8; 32]}
-    /// # let secp = Secp256k1::signing_only();
-    /// # let secret_key = SecretKey::from_slice(&[3u8; 32]).unwrap();
-    /// # let secret_key2 = SecretKey::from_slice(&[7u8; 32]).unwrap();
-    /// # let public_key = PublicKey::from_secret_key(&secp, &secret_key2);
-    ///
-    /// let secret = SharedSecret::new_with_hash(&public_key, &secret_key, |x,y| {
-    ///     let hash: [u8; 32] = sha2(&x,&y);
-    ///     hash.into()
-    /// });
-    /// # }
-    /// ```
-    pub fn new_with_hash<F>(point: &PublicKey, scalar: &SecretKey, mut hash_function: F) -> SharedSecret
-        where F: FnMut([u8; 32], [u8; 32]) -> SharedSecret {
-        let mut xy = [0u8; 64];
-
-        let res = unsafe {
-            ffi::secp256k1_ecdh(
-                ffi::secp256k1_context_no_precomp,
-                xy.as_mut_ptr(),
-                point.as_ptr(),
-                scalar.as_ptr(),
-                Some(c_callback),
-                ptr::null_mut(),
-            )
-        };
-        // Our callback *always* returns 1.
-        // and the scalar was verified to be valid(0 > scalar > group_order) via the type system
-        debug_assert_eq!(res, 1);
-
-        let mut x = [0u8; 32];
-        let mut y = [0u8; 32];
-        x.copy_from_slice(&xy[..32]);
-        y.copy_from_slice(&xy[32..]);
-        hash_function(x, y)
-    }
+    let res = unsafe {
+        ffi::secp256k1_ecdh(
+            ffi::secp256k1_context_no_precomp,
+            xy.as_mut_ptr(),
+            point.as_ptr(),
+            scalar.as_ptr(),
+            Some(c_callback),
+            ptr::null_mut(),
+        )
+    };
+    // Our callback *always* returns 1.
+    // The scalar was verified to be valid (0 > scalar > group_order) via the type system.
+    debug_assert_eq!(res, 1);
+    xy
 }
 
 #[cfg(test)]
@@ -205,38 +205,6 @@ mod tests {
         let sec_odd = SharedSecret::new(&pk1, &sk1);
         assert_eq!(sec1, sec2);
         assert!(sec_odd != sec2);
-    }
-
-    #[test]
-    #[cfg(all(feature="std", feature = "rand-std"))]
-    fn ecdh_with_hash() {
-        let s = Secp256k1::signing_only();
-        let (sk1, pk1) = s.generate_keypair(&mut thread_rng());
-        let (sk2, pk2) = s.generate_keypair(&mut thread_rng());
-
-        let sec1 = SharedSecret::new_with_hash(&pk1, &sk2, |x,_| x.into());
-        let sec2 = SharedSecret::new_with_hash(&pk2, &sk1, |x,_| x.into());
-        let sec_odd = SharedSecret::new_with_hash(&pk1, &sk1, |x,_| x.into());
-        assert_eq!(sec1, sec2);
-        assert_ne!(sec_odd, sec2);
-    }
-
-    #[test]
-    #[cfg(all(feature="std", feature = "rand-std"))]
-    fn ecdh_with_hash_callback() {
-        let s = Secp256k1::signing_only();
-        let (sk1, pk1) = s.generate_keypair(&mut thread_rng());
-        let expect_result: [u8; 64] = [123; 64];
-        let mut x_out = [0u8; 32];
-        let mut y_out = [0u8; 32];
-        let result = SharedSecret::new_with_hash(&pk1, &sk1, |x, y| {
-            x_out = x;
-            y_out = y;
-            expect_result.into()
-        });
-        assert_eq!(&expect_result[..], &result[..]);
-        assert_ne!(x_out, [0u8; 32]);
-        assert_ne!(y_out, [0u8; 32]);
     }
 
     #[test]

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -34,8 +34,8 @@ use secp256k1_sys::types::{c_int, c_uchar, c_void};
 /// let s = Secp256k1::new();
 /// let (sk1, pk1) = s.generate_keypair(&mut thread_rng());
 /// let (sk2, pk2) = s.generate_keypair(&mut thread_rng());
-/// let sec1 = SharedSecret::new(&pk1, &sk2);
-/// let sec2 = SharedSecret::new(&pk2, &sk1);
+/// let sec1 = SharedSecret::new(&pk2, &sk1);
+/// let sec2 = SharedSecret::new(&pk1, &sk2);
 /// assert_eq!(sec1, sec2);
 /// # }
 // ```
@@ -200,8 +200,8 @@ mod tests {
         let (sk1, pk1) = s.generate_keypair(&mut thread_rng());
         let (sk2, pk2) = s.generate_keypair(&mut thread_rng());
 
-        let sec1 = SharedSecret::new(&pk1, &sk2);
-        let sec2 = SharedSecret::new(&pk2, &sk1);
+        let sec1 = SharedSecret::new(&pk2, &sk1);
+        let sec2 = SharedSecret::new(&pk1, &sk2);
         let sec_odd = SharedSecret::new(&pk1, &sk1);
         assert_eq!(sec1, sec2);
         assert!(sec_odd != sec2);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,20 +26,3 @@ macro_rules! impl_pretty_debug {
         }
      }
 }
-
-macro_rules! impl_from_array_len {
-    ($thing:ident, $capacity:tt, ($($N:tt)+)) => {
-        $(
-            impl From<[u8; $N]> for $thing {
-                fn from(arr: [u8; $N]) -> Self {
-                    let mut data = [0u8; $capacity];
-                    data[..$N].copy_from_slice(&arr);
-                    $thing {
-                        data,
-                        len: $N,
-                    }
-                }
-            }
-        )+
-    }
-}


### PR DESCRIPTION
Currently `SharedSecret` provides a way to get a shared secret using SHA256 _as well as_ a way to use a custom hash function to get the shared secret. Internally `SharedSecret` uses a 256 byte buffer, this is a tad wasteful. We would like to keep the current functionality but reduce memory usage.

- Patch 1: Pulls the `new_with_hash` logic out into a standalone public function that just returns the 64 bytes representing the x,y co-ordinates of the computed shared secret point. Callers are then responsible for hashing this point to get the shared secret (idea by @Kixunil, thanks).
- Patch 2: Does trivial refactor
- Patch 3: Uses a 32 byte buffer internally for `SharedSecret`. This is basically a revert of the work @elichai did to add the custom hashing logic. @elichai please holla if you are not happy with me walking all over this code :)

### Note to reviewers

Secret obfuscation is done on top of this in https://github.com/rust-bitcoin/rust-secp256k1/pull/396, they could be reviewed in order if this work is of interest to you.