### PR TITLE
Fix feature gating

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -179,7 +179,7 @@ mod alloc_only {
         /// If `rand-std` feature is enabled, context will have been randomized using `thread_rng`.
         /// If `rand-std` feature is not enabled please consider randomizing the context as follows:
         /// ```
-        /// # #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))] {
+        /// # #[cfg(all(feature = "std", feature = "rand-std"))] {
         /// # use secp256k1::Secp256k1;
         /// # use secp256k1::rand::{thread_rng, RngCore};
         /// let mut ctx = Secp256k1::new();

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -27,7 +27,7 @@ use secp256k1_sys::types::{c_int, c_uchar, c_void};
 /// # Examples
 ///
 /// ```
-/// # #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))] {
+/// # #[cfg(all(feature = "std", feature = "rand-std"))] {
 /// # use secp256k1::Secp256k1;
 /// # use secp256k1::ecdh::SharedSecret;
 /// # use secp256k1::rand::thread_rng;
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature="std", feature = "rand-std"))]
     fn ecdh_with_hash() {
         let s = Secp256k1::signing_only();
         let (sk1, pk1) = s.generate_keypair(&mut thread_rng());
@@ -222,7 +222,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature="std", feature = "rand-std"))]
     fn ecdh_with_hash_callback() {
         let s = Secp256k1::signing_only();
         let (sk1, pk1) = s.generate_keypair(&mut thread_rng());

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -442,7 +442,7 @@ impl<C: Verification> Secp256k1<C> {
     /// verify-capable context.
     ///
     /// ```rust
-    /// # #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature = "rand-std"))] {
     /// # use secp256k1::rand::rngs::OsRng;
     /// # use secp256k1::{Secp256k1, Message, Error};
     /// #
@@ -471,7 +471,7 @@ impl<C: Verification> Secp256k1<C> {
     /// verify-capable context.
     ///
     /// ```rust
-    /// # #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature = "rand-std"))] {
     /// # use secp256k1::rand::rngs::OsRng;
     /// # use secp256k1::{Secp256k1, Message, Error};
     /// #

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -219,7 +219,7 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     #[test]
-    #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature="std", feature = "rand-std"))]
     fn capabilities() {
         let sign = Secp256k1::signing_only();
         let vrfy = Secp256k1::verification_only();
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     #[cfg(not(fuzzing))]  // fixed sig vectors can't work with fuzz-sigs
-    #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature="std", feature = "rand-std"))]
     fn sign() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
@@ -277,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature="std", feature = "rand-std"))]
     fn sign_and_verify_fail() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature="std", feature = "rand-std"))]
     fn sign_with_recovery() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
@@ -318,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature="rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature="std", feature = "rand-std"))]
     fn bad_recovery() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());

--- a/src/key.rs
+++ b/src/key.rs
@@ -40,7 +40,7 @@ use schnorr;
 /// Basic usage:
 ///
 /// ```
-/// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+/// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
 /// use secp256k1::{rand, Secp256k1, SecretKey};
 ///
 /// let secp = Secp256k1::new();
@@ -134,7 +134,7 @@ impl SecretKey {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{rand, SecretKey};
     /// let secret_key = SecretKey::new(&mut rand::thread_rng());
     /// # }
@@ -190,7 +190,7 @@ impl SecretKey {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{rand, Secp256k1, SecretKey, KeyPair};
     ///
     /// let secp = Secp256k1::new();
@@ -342,7 +342,7 @@ impl PublicKey {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{rand, Secp256k1, SecretKey, PublicKey};
     ///
     /// let secp = Secp256k1::new();
@@ -396,7 +396,7 @@ impl PublicKey {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{rand, Secp256k1, PublicKey, KeyPair};
     ///
     /// let secp = Secp256k1::new();
@@ -553,7 +553,7 @@ impl PublicKey {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{rand, Secp256k1, PublicKey};
     ///
     /// let secp = Secp256k1::new();
@@ -669,7 +669,7 @@ impl Ord for PublicKey {
 /// Basic usage:
 ///
 /// ```
-/// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+/// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
 /// use secp256k1::{rand, KeyPair, Secp256k1};
 ///
 /// let secp = Secp256k1::new();
@@ -775,7 +775,7 @@ impl KeyPair {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{rand, Secp256k1, SecretKey, KeyPair};
     ///
     /// let secp = Secp256k1::new();
@@ -829,7 +829,7 @@ impl KeyPair {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{Secp256k1, KeyPair};
     /// use secp256k1::rand::{RngCore, thread_rng};
     ///
@@ -961,7 +961,7 @@ impl<'de> ::serde::Deserialize<'de> for KeyPair {
 /// Basic usage:
 ///
 /// ```
-/// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+/// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
 /// use secp256k1::{rand, Secp256k1, KeyPair, XOnlyPublicKey};
 ///
 /// let secp = Secp256k1::new();
@@ -1089,7 +1089,7 @@ impl XOnlyPublicKey {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature =  "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{Secp256k1, KeyPair};
     /// use secp256k1::rand::{RngCore, thread_rng};
     ///
@@ -1154,7 +1154,7 @@ impl XOnlyPublicKey {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))] {
+    /// # #[cfg(all(feature = "std", feature =  "rand-std"))] {
     /// use secp256k1::{Secp256k1, KeyPair};
     /// use secp256k1::rand::{thread_rng, RngCore};
     ///

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -307,7 +307,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature = "std", feature = "rand-std"))]
     fn test_schnorrsig_sign_with_aux_rand_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, rng| {
             let mut aux_rand = [0u8; 32];
@@ -317,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature = "std", feature = "rand-std"))]
     fn test_schnorrsig_sign_with_rng_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, mut rng| {
             secp.sign_schnorr_with_rng(msg, seckey, &mut rng)
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature = "std", feature = "rand-std"))]
     fn test_schnorrsig_sign_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, _| {
             secp.sign_schnorr(msg, seckey)
@@ -333,14 +333,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature = "std", feature = "rand-std"))]
     fn test_schnorrsig_sign_no_aux_rand_verify() {
         test_schnorrsig_sign_helper(|secp, msg, seckey, _| {
             secp.sign_schnorr_no_aux_rand(msg, seckey)
         })
     }
 
-    #[cfg(all(feature = "rand-std", any(feature = "alloc", feature = "std")))]
+    #[cfg(all(feature = "std", feature = "rand-std"))]
     fn test_schnorrsig_sign_helper(
         sign: fn(&Secp256k1<All>, &Message, &KeyPair, &mut ThreadRng) -> Signature,
     ) {

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -128,7 +128,6 @@ impl<C: Signing> Secp256k1<C> {
 
     /// Create a schnorr signature internally using the ThreadRng random number
     /// generator to generate the auxiliary random data.
-    /// Requires compilation with "rand-std" feature.
     #[cfg(any(test, feature = "rand-std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand-std")))]
     #[deprecated(since = "0.21.0", note = "Use sign_schnorr instead.")]
@@ -138,7 +137,6 @@ impl<C: Signing> Secp256k1<C> {
 
     /// Create a schnorr signature internally using the ThreadRng random number
     /// generator to generate the auxiliary random data.
-    /// Requires compilation with "rand-std" feature.
     #[cfg(any(test, feature = "rand-std"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand-std")))]
     pub fn sign_schnorr(&self, msg: &Message, keypair: &KeyPair) -> Signature {
@@ -191,8 +189,7 @@ impl<C: Signing> Secp256k1<C> {
     }
 
     /// Create a schnorr signature using the given random number generator to
-    /// generate the auxiliary random data. Requires compilation with "rand"
-    /// feature.
+    /// generate the auxiliary random data.
     #[cfg(any(test, feature = "rand"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     #[deprecated(since = "0.21.0", note = "Use sign_schnorr_with_rng instead.")]
@@ -206,8 +203,7 @@ impl<C: Signing> Secp256k1<C> {
     }
 
     /// Create a schnorr signature using the given random number generator to
-    /// generate the auxiliary random data. Requires compilation with "rand"
-    /// feature.
+    /// generate the auxiliary random data.
     #[cfg(any(test, feature = "rand"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     pub fn sign_schnorr_with_rng<R: Rng + CryptoRng>(
@@ -262,7 +258,7 @@ impl <C: Signing> Secp256k1<C> {
     /// Generates a random Schnorr `KeyPair` and its associated Schnorr `XOnlyPublicKey`.
     ///
     /// Convenience function for [KeyPair::new] and [KeyPair::public_key].
-    /// Requires a signing-capable context and requires compilation with the "rand" feature.
+    /// Requires a signing-capable context.
     #[inline]
     #[cfg(any(test, feature = "rand"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]


### PR DESCRIPTION
Recently we fixed a bunch of feature gates to use `rand-std` instead
of `rand` but in doing so did not notice that the same feature gates
were using `alloc` which is meaningless if `std` is enabled.

- Patch 1: Feature gate on `std` if we are using `rand-std`.
- Patch 2: Remove redundant docs related to feature gating.