### PR TITLE
restore `global-context-less-secure` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,13 @@ rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std"]
+# disable re-randomization of the global context, which provides some
+# defense-in-depth against sidechannel attacks. You should only use
+# this feature if you expect the `rand` crate's thread_rng to panic.
+# (If you are sure the `rand-std` feature will not be enabled, e.g.
+# if you are doing a no-std build, then this feature does nothing
+# and is not necessary.)
+global-context-less-secure = []
 
 [dependencies]
 secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }

--- a/src/context.rs
+++ b/src/context.rs
@@ -48,7 +48,7 @@ pub mod global {
             static mut CONTEXT: Option<Secp256k1<All>> = None;
             ONCE.call_once(|| unsafe {
                 let mut ctx = Secp256k1::new();
-                #[cfg(feature = "rand-std")]
+                #[cfg(all(feature = "rand-std", not(feature = "global-context-less-secure")))]
                 {
                     ctx.randomize(&mut rand::thread_rng());
                 }


### PR DESCRIPTION
We can't remove a feature in a minor release, and also I believe this feature is actually necessary in some niche applications.