### PR TITLE
Add bitcoin_hashes features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,18 @@ recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std"]
 
+# Give users full control of bitcoin_hashes features while stil using the secp256k1 re-exported
+# bitcoin_hashes dependency.
+bitcoin-hashes-std = ["bitcoin_hashes/std"]
+bitcoin-hashes-alloc = ["bitcoin_hashes/alloc"]
+bitcoin-hashes-std-serde = ["bitcoin_hashes/std", "bitcoin_hashes/serde-std"]
+bitcoin-hashes-alloc-serde = ["bitcoin_hashes/alloc", "bitcoin_hashes/serde"]
+bitcoin-hashes-std-schemars = ["bitcoin_hashes/std", "bitcoin_hashes/schemars"]
+
 [dependencies]
 secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }
-bitcoin_hashes = { version = "0.10", optional = true }
+# You probably do not want to use this dependency directly, see feautures above.
+bitcoin_hashes = { version = "0.10", default-features = false, optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
@@ -48,11 +57,11 @@ rand = { version = "0.6", features = ["wasm-bindgen"] }
 
 [[example]]
 name = "sign_verify_recovery"
-required-features = ["std", "recovery"]
+required-features = ["std", "recovery", "bitcoin-hashes-std"]
 
 [[example]]
 name = "sign_verify"
-required-features = ["std"]
+required-features = ["std", "bitcoin-hashes-std"]
 
 [[example]]
 name = "generate_keys"

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 # TODO: Add "alloc" once we bump MSRV to past 1.29
-FEATURES="bitcoin_hashes global-context lowmemory rand rand-std recovery serde std"
+FEATURES="bitcoin_hashes bitcoin-hashes-alloc bitcoin-hashes-std bitcoin-hashes-alloc-serde bitcoin-hashes-std-serde bitcoin-hashes-std-schemars global-context lowmemory rand rand-std recovery serde std"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -1,7 +1,6 @@
-extern crate bitcoin_hashes;
 extern crate secp256k1;
 
-use bitcoin_hashes::{sha256, Hash};
+use secp256k1::hashes::{sha256, Hash};
 use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey, ecdsa, Signing, Verification};
 
 fn verify<C: Verification>(secp: &Secp256k1<C>, msg: &[u8], sig: [u8; 64], pubkey: [u8; 33]) -> Result<bool, Error> {

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -1,8 +1,6 @@
-
-extern crate bitcoin_hashes;
 extern crate secp256k1;
 
-use bitcoin_hashes::{sha256, Hash};
+use secp256k1::hashes::{sha256, Hash};
 use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verification, ecdsa};
 
 fn recover<C: Verification>(secp: &Secp256k1<C>,msg: &[u8],sig: [u8; 64],recovery_id: u8) -> Result<PublicKey, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! trigger any assertion failures in the upstream library.
 //!
 //! ```rust
-//! # #[cfg(all(feature = "std", feature="rand-std", feature="bitcoin_hashes"))] {
+//! # #[cfg(all(feature = "std", feature="rand-std", feature="bitcoin-hashes-std"))] {
 //! use secp256k1::rand::rngs::OsRng;
 //! use secp256k1::{Secp256k1, Message};
 //! use secp256k1::hashes::sha256;
@@ -59,7 +59,7 @@
 //! If the "global-context" feature is enabled you have access to an alternate API.
 //!
 //! ```rust
-//! # #[cfg(all(feature="global-context", feature = "std", feature="rand-std", features = "bitcoin_hashes"))] {
+//! # #[cfg(all(feature="global-context", feature = "std", feature="rand-std", features = "bitcoin-hashes-std"))] {
 //! use secp256k1::rand::thread_rng;
 //! use secp256k1::{generate_keypair, Message};
 //! use secp256k1::hashes::sha256;


### PR DESCRIPTION
We re-export `bitcoin_hashes` so users do not have to depend directly on
it. This is Rust best practice as makes keeping versions in sync easier.

Currently, however, it is not possible to enable different features in
`bitcoin_hashes` and our feature enables it with no default features -
this makes the re-export basically useless.

Add a bunch of features that can be used to turn on the various
`bitcoin_hashes` features.

## Note

The re-export/feature problem is not specific to this repo, I'd think there was a standard way to solve this. The solution presented here is made up by me so I'm inclined to think there is probably a better, more standard, solution. Hence this PR is draft for feedback please. We suffer the same problem all the way up our stack and its going to get worse when we start crate smashing.

Done while investigating: https://github.com/rust-bitcoin/rust-bitcoin/pull/819#issuecomment-1034273915