### PR TITLE
Bitcoin hashes no default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ global-context-less-secure = []
 [dependencies]
 secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }
 
-bitcoin_hashes = { version = "0.10", optional = true }
+bitcoin_hashes = { version = "0.10", default-features = false, optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ global-context-less-secure = []
 
 [dependencies]
 secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }
+
 bitcoin_hashes = { version = "0.10", optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
-
 
 [dev-dependencies]
 rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default = ["std"]
 std = ["secp256k1-sys/std"]
 # allow use of Secp256k1::new and related API that requires an allocator
 alloc = []
+bitcoin-hashes-std = ["bitcoin_hashes/std"]
 rand-std = ["rand/std"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
@@ -37,10 +38,12 @@ global-context-less-secure = []
 
 [dependencies]
 secp256k1-sys = { version = "0.4.2", default-features = false, path = "./secp256k1-sys" }
+serde = { version = "1.0", default-features = false, optional = true }
 
+# You likely only want to enable these if you explicitly do not want to use "std", otherwise enable
+# the respective -std feature e.g., bitcoin-hashes-std
 bitcoin_hashes = { version = "0.10", default-features = false, optional = true }
 rand = { version = "0.6", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.6"

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,7 +1,10 @@
 #!/bin/sh -ex
 
 # TODO: Add "alloc" once we bump MSRV to past 1.29
-FEATURES="bitcoin_hashes global-context lowmemory rand rand-std recovery serde std"
+FEATURES="bitcoin_hashes global-context lowmemory rand recovery serde std"
+# These features are typically enabled along with the 'std' feature, so we test
+# them together with 'std'.
+STD_FEATURES="rand-std bitcoin-hashes-std"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]
@@ -32,11 +35,15 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
         cargo build --all --no-default-features --features="$feature"
         cargo test --all --no-default-features --features="$feature"
     done
-
+    # Features tested with 'std' feature enabled.
+    for feature in ${FEATURES}
+    do
+        cargo build --all --no-default-features --features="std,$feature"
+        cargo test --all --no-default-features --features="std,$feature"
+    done
     # Other combos 
     RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all
     RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all --features="$FEATURES"
-    cargo test --all --features="rand rand-std"
     cargo test --all --features="rand serde"
 
     if [ "$DO_BENCH" = true ]; then  # proxy for us having a nightly compiler


### PR DESCRIPTION
Currently we use default features for the `bitcoin_hashes` dependency, doing so breaks the `no-std` feature in `rust-bitcoin` because `std` is part of `bitcoin_hashes` default feature set.

Disable `bitcoin_hashes` default features, no changes to `rust-bitcoin` are require after this change since we manually turn on `std` and `alloc` as part of the `std`/`no-std` features of `rust-bitcoin`.

For other users of `rust-secp256k1` this is a breaking change but is unlikely to cause too much bother because `std` is so commonly used.

This PR resolves an open [issue](https://github.com/rust-bitcoin/rust-secp256k1/pull/384) in `rust-bitcoin`, see issue for discussion.
