### PR TITLE
Improve CI pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,40 +29,26 @@ jobs:
           DO_BENCH: true
         run: ./contrib/test.sh
 
-  wasm: 
-    name: Stable - Docs / WebAssembly Build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
-    steps:
-      - name: Checkout Crate
-        uses: actions/checkout@v2
-      - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - name: Building docs
-        env:
-          DO_DOCS: true
-        run: ./contrib/test.sh
-      - name: Running WASM build
-        env:
-          DO_WASM: true
-        run: ./contrib/test.sh
-
   Tests:
     name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - 1.29.0
-          - beta
-          - stable
+        include:
+          - rust: stable
+            env:
+              DO_FEATURE_MATRIX: true
+              DO_WASM: true
+          - rust: beta
+            env:
+              DO_FEATURE_MATRIX: true
+          - rust: nightly
+            env:
+              DO_FEATURE_MATRIX: true
+              DO_DOCS: true
+          - rust: 1.29.0
+            env:
+              DO_FEATURE_MATRIX: true
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
@@ -76,7 +62,6 @@ jobs:
         if: matrix.rust == '1.29.0'
         run: cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose
       - name: Running cargo
-        env:
-          DO_FEATURE_MATRIX: true
+        env: ${{ matrix.env }}
         run: ./contrib/test.sh
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -57,9 +57,9 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     cargo run --example generate_keys --features=std,rand-std
 fi
 
-# Docs
+# Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then
-    cargo doc --all --features="$FEATURES"
+    RUSTDOCFLAGS="--cfg docsrs" cargo doc --all --features="$FEATURES"
 fi
 
 # Webassembly stuff


### PR DESCRIPTION
We have unnecessary runs of the `test.sh` script. We can simplify the CI pipeline and at the same time improve the docs build by using `--cfg docsrs`.

- Remove the `wasm` job, replace it by enabling the `DO_WASM` env var for the stable toolchain run in the `Tests` job.
- Add `--cfg docrs` flag to the docs build and set the `DO_DOCS` env var as part of the nightly toolchain run in `Tests` job.

The end result is one less run of the `test.sh` script and better test coverage.

Idea came from @Kixunil when reviewing https://github.com/rust-bitcoin/rust-bitcoin/pull/858, thanks.