### PR TITLE
Allow SharedSecret to be created from byte array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.22.1 - 2022-03-10
+
+* [Reintroduce](https://github.com/rust-bitcoin/rust-secp256k1/pull/417) accidentally removed possibility to create `SharedSecret` from byte serialization
+
 # 0.22.0 - 2022-03-08
 
 * Disable `bitcoin_hashes/std` by default; [add `bitcoin-hashes-std` feature to re-enable it](https://github.com/rust-bitcoin/rust-secp256k1/pull/410)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.22.0"
+version = "0.22.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -71,6 +71,11 @@ impl SharedSecret {
     pub fn secret_bytes(&self) -> [u8; SHARED_SECRET_SIZE] {
         self.0
     }
+
+    /// Creates a shared secret from a byte serialization.
+    pub fn from_bytes(bytes: [u8; SHARED_SECRET_SIZE]) -> SharedSecret {
+        SharedSecret(bytes)
+    }
 }
 
 impl Borrow<[u8]> for SharedSecret {


### PR DESCRIPTION
This was accidentally removed in 8b2edad. See also the discussion
on https://github.com/rust-bitcoin/rust-secp256k1/pull/402

Closes #416.