### PR TITLE
Implement de/serialization for SharedSecret

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,8 @@ pub enum Error {
     InvalidSignature,
     /// Bad secret key.
     InvalidSecretKey,
+    /// Bad shared secret.
+    InvalidSharedSecret,
     /// Bad recovery id.
     InvalidRecoveryId,
     /// Invalid tweak for `add_*_assign` or `mul_*_assign`.
@@ -372,6 +374,7 @@ impl Error {
             Error::InvalidPublicKey => "secp: malformed public key",
             Error::InvalidSignature => "secp: malformed signature",
             Error::InvalidSecretKey => "secp: malformed or out-of-range secret key",
+            Error::InvalidSharedSecret => "secp: malformed or out-of-range shared secret",
             Error::InvalidRecoveryId => "secp: bad recovery id",
             Error::InvalidTweak => "secp: bad tweak",
             Error::NotEnoughMemory => "secp: not enough memory allocated",
@@ -399,6 +402,7 @@ impl std::error::Error for Error {
             Error::InvalidPublicKey => None,
             Error::InvalidSignature => None,
             Error::InvalidSecretKey => None,
+            Error::InvalidSharedSecret => None,
             Error::InvalidRecoveryId => None,
             Error::InvalidTweak => None,
             Error::NotEnoughMemory => None,


### PR DESCRIPTION
As we do for other keys implement serde de/serialization for the `SharedSecret`.

Please note, this adds `from_slice` and `from_bytes` (borrowed and owner respectively) because I needed to use them. Doing so treads on @dspicher's toes because he is in the process of implementing an owned conversion method for `SharedSecret`. The fair thing to do would be let https://github.com/rust-bitcoin/rust-secp256k1/pull/417 resolve and merge before merging this one (I can rebase).

~Side note, its kind of rubbish that `BytesVisitor` deserializes into a buffer (presumably) then we reallocate and copy the buffer to use the borrowed conversion method due to the serde function signature `fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E>`~ (I was bumbling nonsense.)

Closes: #416 
