### PR TITLE
Fix test script silent failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,10 +6,6 @@ jobs:
   Nightly:
     name: Nightly - ASan + Bench
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - nightly
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
@@ -17,7 +13,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: nightly
           override: true
           components: rust-src
       - name: Running address sanitizer

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,20 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - rust: stable
-            env:
-              DO_FEATURE_MATRIX: true
-              DO_WASM: true
-          - rust: beta
-            env:
-              DO_FEATURE_MATRIX: true
-          - rust: nightly
-            env:
-              DO_FEATURE_MATRIX: true
-          - rust: 1.29.0
-            env:
-              DO_FEATURE_MATRIX: true
+        rust: [stable, beta, nightly, 1.29.0]
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
@@ -63,6 +50,29 @@ jobs:
         if: matrix.rust == '1.29.0'
         run: cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose
       - name: Running cargo
-        env: ${{ matrix.env }}
+        env:
+          DO_FEATURE_MATRIX: true
         run: ./contrib/test.sh
 
+  WASM:
+    name: WASM
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta, nightly] # No 1.29 because WASM requires Rust 1.30
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v2
+      - name: Install clang
+        run: sudo apt-get install -y clang-9
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rust-src
+      - name: Running WASM tests
+        env:
+          DO_WASM: true
+        run: ./contrib/test.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  bench_nightly:
+  Nightly:
     name: Nightly - ASan + Bench
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
         rust:
           - nightly
     steps:
-      - name: Checkout Crate 
+      - name: Checkout Crate
         uses: actions/checkout@v2
       - name: Checkout Toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
+      - name: Install clang for ASan
+        run: sudo apt-get install -y clang
       - name: Checkout Toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ name: Continuous integration
 
 jobs:
   Nightly:
-    name: Nightly - ASan + Bench
+    name: Nightly - ASan + Bench + Docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
@@ -26,6 +26,10 @@ jobs:
         env:
           DO_BENCH: true
         run: ./contrib/test.sh
+      - name: Building docs
+        env:
+          DO_DOCS: true
+        run: ./contrib/test.sh
 
   Tests:
     name: Tests
@@ -43,7 +47,6 @@ jobs:
           - rust: nightly
             env:
               DO_FEATURE_MATRIX: true
-              DO_DOCS: true
           - rust: 1.29.0
             env:
               DO_FEATURE_MATRIX: true

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -94,3 +94,4 @@ if [ "$DO_BENCH" = true ]; then
     cargo bench --all --features="unstable"
 fi
 
+exit 0

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -66,7 +66,7 @@ fi
 
 # Webassembly stuff
 if [ "$DO_WASM" = true ]; then
-    clang --version
+    clang-9 --version
     CARGO_TARGET_DIR=wasm cargo install --force wasm-pack
     printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml
     CC=clang-9 wasm-pack build
@@ -75,6 +75,7 @@ fi
 
 # Address Sanitizer
 if [ "$DO_ASAN" = true ]; then
+    clang --version
     cargo clean
     CC='clang -fsanitize=address -fno-omit-frame-pointer'                                        \
     RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
 
+set -e
+
 # TODO: Add "alloc" once we bump MSRV to past 1.29
 FEATURES="bitcoin_hashes global-context lowmemory rand recovery serde std"
 # These features are typically enabled along with the 'std' feature, so we test
@@ -64,11 +66,11 @@ fi
 
 # Webassembly stuff
 if [ "$DO_WASM" = true ]; then
-    clang --version &&
-    CARGO_TARGET_DIR=wasm cargo install --force wasm-pack &&
-    printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml &&
-    CC=clang-9 wasm-pack build &&
-    CC=clang-9 wasm-pack test --node;
+    clang --version
+    CARGO_TARGET_DIR=wasm cargo install --force wasm-pack
+    printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml
+    CC=clang-9 wasm-pack build
+    CC=clang-9 wasm-pack test --node
 fi
 
 # Address Sanitizer
@@ -77,11 +79,11 @@ if [ "$DO_ASAN" = true ]; then
     CC='clang -fsanitize=address -fno-omit-frame-pointer'                                        \
     RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \
     ASAN_OPTIONS='detect_leaks=1 detect_invalid_pointer_pairs=1 detect_stack_use_after_return=1' \
-    cargo test --lib --all --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu &&
-    cargo clean &&
+    cargo test --lib --all --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
+    cargo clean
     CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
     RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
-    cargo test --lib --all --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu &&
+    cargo test --lib --all --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
     cargo run --release --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified Successfully"
     cargo run --release --features=alloc --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified alloc Successfully"
 fi


### PR DESCRIPTION
Change the test script to exit with non-zero status code if any command fails. 

The `test.sh` script is silently failing, that means changes causing failures are slipping through our CI pipeline and being merged. 

Resolves: #419 

## Note

Just the last 3 patches, the first 6 are from #420. re-base just shows it works on top of 420, it is going to have to be rebased again when 420 merges.
