### PR TITLE
Misc doc fixes

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -718,7 +718,7 @@ impl KeyPair {
         }
     }
 
-    /// Creates a Schnorr [`KeyPair`] directly from a secret key slice.
+    /// Creates a [`KeyPair`] directly from a secret key slice.
     ///
     /// # Errors
     ///
@@ -743,7 +743,7 @@ impl KeyPair {
         }
     }
 
-    /// Creates a Schnorr [`KeyPair`] directly from a secret key string.
+    /// Creates a [`KeyPair`] directly from a secret key string.
     ///
     /// # Errors
     ///
@@ -759,7 +759,7 @@ impl KeyPair {
         }
     }
 
-    /// Creates a Schnorr [`KeyPair`] directly from a secret key string and the global [`SECP256K1`] context.
+    /// Creates a [`KeyPair`] directly from a secret key string and the global [`SECP256K1`] context.
     ///
     /// # Errors
     ///

--- a/src/key.rs
+++ b/src/key.rs
@@ -696,13 +696,7 @@ impl KeyPair {
         &mut self.0
     }
 
-    /// Creates a Schnorr [`KeyPair`] directly from generic Secp256k1 secret key.
-    ///
-    /// # Panics
-    ///
-    /// Panics if internal representation of the provided [`SecretKey`] does not hold correct secret
-    /// key value obtained from Secp256k1 library previously, specifically when secret key value is
-    /// out-of-range (0 or in excess of the group order).
+    /// Creates a [`KeyPair`] directly from a Secp256k1 secret key.
     #[inline]
     pub fn from_secret_key<C: Signing>(
         secp: &Secp256k1<C>,


### PR DESCRIPTION
Keypairs are pair of EC points that don't have anything to do with the
signature algorithm