### PR TITLE
Make global-context-less-secure actually enable the global context (fixup for #407)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ global-context = ["std"]
 # (If you are sure the `rand-std` feature will not be enabled, e.g.
 # if you are doing a no-std build, then this feature does nothing
 # and is not necessary.)
-global-context-less-secure = []
+global-context-less-secure = ["global-context"]
 
 [dependencies]
 secp256k1-sys = { version = "0.5.0", default-features = false, path = "./secp256k1-sys" }


### PR DESCRIPTION
In #407 we restored the `global-context-less-secure` feature, but it didn't actually do anything because #385 changed all the cfg checks on the whole module to depend on `global-context`, so we need to enable `global-context` in order to make that module compile.

so before all this, users could enable *just* `global-context-less-secure` without enabling the `global-context`, and after this PR it will behave the same.

(this will not enable the randomization because of: https://github.com/rust-bitcoin/rust-secp256k1/blob/1cf2429b12ff06a04a5c882f2f5d918042629660/src/context.rs#L51)