### PR TITLE
Move panic test to top of script

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -15,6 +15,9 @@ fi
 cargo --version
 rustc --version
 
+# Test if panic in C code aborts the process (either with a real panic or with SIGILL)
+cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at '\[libsecp256k1\]"
+
 # Make all cargo invocations verbose
 export CARGO_TERM_VERBOSE=true
 
@@ -85,9 +88,6 @@ if [ "$DO_ASAN" = true ]; then
     cargo run --release --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified Successfully"
     cargo run --release --features=alloc --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified alloc Successfully"
 fi
-
-# Test if panic in C code aborts the process (either with a real panic or with SIGILL)
-cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at '\[libsecp256k1\]"
 
 # Bench
 if [ "$DO_BENCH" = true ]; then


### PR DESCRIPTION
In `test.sh` we have a test that checks for a panic by greping the output of `cargo test --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally'`. If we put this test at the top of the script right after we run `cargo test` we are guaranteed to not trigger a re-build.

### Note to reviewers

I just noticed this patch somehow snuck into #420, all other changes in that PR are to `.github/workflows/rust.yml` so this change does not fit in there. Hence raising it as a separate PR. 