### PR TITLE
Derive Hash for ecdsa::Signature and SerializedSignature

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -16,7 +16,7 @@ pub use self::recovery::{RecoveryId, RecoverableSignature};
 use SECP256K1;
 
 /// An ECDSA signature
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Signature(pub(crate) ffi::Signature);
 
 /// A DER serialized Signature

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -20,7 +20,7 @@ use SECP256K1;
 pub struct Signature(pub(crate) ffi::Signature);
 
 /// A DER serialized Signature
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Hash)]
 pub struct SerializedSignature {
     data: [u8; 72],
     len: usize,


### PR DESCRIPTION
Hash trait is derived for `schnorr::Signature`, but not `ecdsa::Signature`. This prevents derivation of `Hash` on types downstream in `rust-bitcoin`, for instance Psbt-related types.