### PR TITLE
Add functional style methods to various keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ pub enum Error {
     InvalidSharedSecret,
     /// Bad recovery id.
     InvalidRecoveryId,
-    /// Invalid tweak for `add_*_assign` or `mul_*_assign`.
+    /// Tried to add/multiply by an invalid tweak.
     InvalidTweak,
     /// Didn't pass enough memory to context creation with preallocated memory.
     NotEnoughMemory,


### PR DESCRIPTION
The various `_assign` methods (`add_assign`, `add_expr_assign`, `mul_assign`, `tweak_add_assign`) are cumbersome to use because a local variable that uses these methods changes meaning but keeps the same identifier. It would be more useful if we had methods that consumed `self` and returned the newly modified type.

We notice also that this API is for adding/multiplying tweaks not arbitraryly adding keys.

- Patch 1: Changes add/mul_assign -> add/mul_tweak for `PublicKey` and `SecretKey` (incl. re-working unit tests)
- Patch 2: Changes `tweak_add_assign` -> `add_tweak` for `KeyPair` and `XOnlyPublicKey`
- Patch 3: Changes `negate_assign` -> `negate`

All methods changed include:
- New method consumes self and returns the tweaked key
- Original  method remains with a `deprecated` attribute, however I've left a TODO in there for adding the `since` field.

Close: #415 