### PR TITLE
release minor version of secp-sys with WASM fix

### DIFF
--- a/secp256k1-sys/CHANGELOG.md
+++ b/secp256k1-sys/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 0.5.1 - 2022-04-30
+
+* [Fix WASM build](https://github.com/rust-bitcoin/rust-secp256k1/pull/421)
+
 # 0.3.0 - 2020-08-27
 
 * **Update MSRV to 1.29.0**

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-sys"
-version = "0.5.0"
+version = "0.5.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>" ]


### PR DESCRIPTION
Would like to get this quickly merged and published before we merge the breaking edition stuff.