### PR TITLE
Derive Hash for Signature

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -16,7 +16,7 @@ pub use self::recovery::{RecoveryId, RecoverableSignature};
 use SECP256K1;
 
 /// An ECDSA signature
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Signature(pub(crate) ffi::Signature);
 
 /// A DER serialized Signature


### PR DESCRIPTION
In preparation for deriving `Hash` in miniscript, derive `Hash` on the `ecdsa::Signature`.

ref: https://github.com/rust-bitcoin/rust-miniscript/issues/226