### PR TITLE
Re-implement public key ordering using underlying FFI functions

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -379,6 +379,12 @@ extern "C" {
                                         tweak: *const c_uchar)
                                         -> c_int;
 
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_ec_pubkey_cmp")]
+    pub fn secp256k1_ec_pubkey_cmp(cx: *const Context,
+                                   pubkey1: *const PublicKey,
+                                   pubkey2: *const PublicKey)
+                                   -> c_int;
+
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_keypair_sec")]
     pub fn secp256k1_keypair_sec(cx: *const Context,
                                  output_seckey: *mut c_uchar,
@@ -390,6 +396,12 @@ extern "C" {
                                  output_pubkey: *mut PublicKey,
                                  keypair: *const KeyPair)
                                  -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_xonly_pubkey_cmp")]
+    pub fn secp256k1_xonly_pubkey_cmp(cx: *const Context,
+                                      pubkey1: *const XOnlyPublicKey,
+                                      pubkey2: *const XOnlyPublicKey)
+                                      -> c_int;
 }
 
 #[cfg(not(fuzzing))]

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -379,12 +379,6 @@ extern "C" {
                                         tweak: *const c_uchar)
                                         -> c_int;
 
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_ec_pubkey_cmp")]
-    pub fn secp256k1_ec_pubkey_cmp(cx: *const Context,
-                                   pubkey1: *const PublicKey,
-                                   pubkey2: *const PublicKey)
-                                   -> c_int;
-
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_keypair_sec")]
     pub fn secp256k1_keypair_sec(cx: *const Context,
                                  output_seckey: *mut c_uchar,
@@ -396,12 +390,6 @@ extern "C" {
                                  output_pubkey: *mut PublicKey,
                                  keypair: *const KeyPair)
                                  -> c_int;
-
-    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_xonly_pubkey_cmp")]
-    pub fn secp256k1_xonly_pubkey_cmp(cx: *const Context,
-                                      pubkey1: *const XOnlyPublicKey,
-                                      pubkey2: *const XOnlyPublicKey)
-                                      -> c_int;
 }
 
 #[cfg(not(fuzzing))]
@@ -445,6 +433,12 @@ extern "C" {
     pub fn secp256k1_ec_pubkey_negate(cx: *const Context,
                                       pk: *mut PublicKey) -> c_int;
 
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_ec_pubkey_cmp")]
+    pub fn secp256k1_ec_pubkey_cmp(cx: *const Context,
+                                   pubkey1: *const PublicKey,
+                                   pubkey2: *const PublicKey)
+                                   -> c_int;
 
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_ec_pubkey_tweak_add")]
     pub fn secp256k1_ec_pubkey_tweak_add(cx: *const Context,
@@ -550,6 +544,13 @@ extern "C" {
         xonly_pubkey: *mut XOnlyPublicKey,
         pk_parity: *mut c_int,
         pubkey: *const PublicKey,
+    ) -> c_int;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_xonly_pubkey_cmp")]
+    pub fn secp256k1_xonly_pubkey_cmp(
+        cx: *const Context,
+        pubkey1: *const XOnlyPublicKey,
+        pubkey2: *const XOnlyPublicKey
     ) -> c_int;
 
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_xonly_pubkey_tweak_add")]

--- a/src/key.rs
+++ b/src/key.rs
@@ -673,13 +673,16 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
 
 impl PartialOrd for PublicKey {
     fn partial_cmp(&self, other: &PublicKey) -> Option<core::cmp::Ordering> {
-        self.serialize().partial_cmp(&other.serialize())
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for PublicKey {
     fn cmp(&self, other: &PublicKey) -> core::cmp::Ordering {
-        self.serialize().cmp(&other.serialize())
+        let ret = unsafe {
+            ffi::secp256k1_ec_pubkey_cmp(ffi::secp256k1_context_no_precomp, self.as_c_ptr(), other.as_c_ptr())
+        };
+        ret.cmp(&0i32)
     }
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -82,6 +82,7 @@ pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
 /// # }
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "fuzzing", derive(PartialOrd, Ord))]
 #[repr(transparent)]
 pub struct PublicKey(ffi::PublicKey);
 
@@ -671,12 +672,14 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
     }
 }
 
+#[cfg(not(fuzzing))]
 impl PartialOrd for PublicKey {
     fn partial_cmp(&self, other: &PublicKey) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
+#[cfg(not(fuzzing))]
 impl Ord for PublicKey {
     fn cmp(&self, other: &PublicKey) -> core::cmp::Ordering {
         let ret = unsafe {
@@ -1899,6 +1902,7 @@ mod test {
         assert_eq!(Ok(sksum), sum1);
     }
 
+    #[cfg(not(fuzzing))]
     #[test]
     fn pubkey_equal() {
         let pk1 = PublicKey::from_slice(
@@ -1909,7 +1913,7 @@ mod test {
             &hex!("02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443"),
         ).unwrap();
 
-        assert!(pk1 == pk2);
+        assert_eq!(pk1, pk2);
         assert!(pk1 <= pk2);
         assert!(pk2 <= pk1);
         assert!(!(pk2 < pk1));

--- a/src/key.rs
+++ b/src/key.rs
@@ -2204,3 +2204,24 @@ mod test {
         assert_eq!(got, want)
     }
 }
+
+#[cfg(all(test, feature = "unstable"))]
+mod benches {
+    use test::Bencher;
+    use std::collections::BTreeSet;
+    use crate::PublicKey;
+    use crate::constants::GENERATOR_X;
+
+    #[bench]
+    fn bench_pk_ordering(b: &mut Bencher) {
+        let mut map = BTreeSet::new();
+        let mut g_slice = [02u8; 33];
+        g_slice[1..].copy_from_slice(&GENERATOR_X);
+        let g = PublicKey::from_slice(&g_slice).unwrap();
+        let mut pk = g;
+        b.iter(|| {
+            map.insert(pk);
+            pk = pk.combine(&pk).unwrap();
+        })
+    }
+}


### PR DESCRIPTION
Re-base #309 for @dr-orlovsky on request by @Kixunil.

To do the rebase I just had to change instances of cfg_attr to use `v0_5_0` instead of `v0_4_1` e.g.,
```
    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_5_0_xonly_pubkey_cmp")]
```

And drop the changes to `src/schnorrsig.rs`, all these changes are covered by the changes in `key.rs` I believe.