### PR TITLE
Fix getting parity from keypair in fuzzing

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -1169,7 +1169,7 @@ mod fuzz_dummy {
     ) -> c_int {
         check_context_flags(cx, 0);
         if !pk_parity.is_null() {
-            *pk_parity = ((*keypair).0[32] == 0).into();
+            *pk_parity = ((*keypair).0[64] == 0).into();
         }
         (*pubkey).0.copy_from_slice(&(*keypair).0[32..]);
         1

--- a/src/key.rs
+++ b/src/key.rs
@@ -2180,8 +2180,6 @@ mod test {
             let (want_tweaked_xonly, tweaked_kp_parity) = XOnlyPublicKey::from_keypair(&tweaked_kp);
 
             assert_eq!(tweaked_xonly, want_tweaked_xonly);
-
-            #[cfg(not(fuzzing))]
             assert_eq!(parity, tweaked_kp_parity);
 
             assert!(xonly.tweak_add_check(&s, &tweaked_xonly, parity, tweak));


### PR DESCRIPTION
This also enables a test that was failung due to the parity bug.
