### PR TITLE
`SerializedSignature` improvements

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -167,6 +167,7 @@ impl Signature {
                 self.as_c_ptr(),
             );
             debug_assert!(err == 1);
+            assert!(len <= serialized_signature::MAX_LEN, "libsecp256k1 set length to {} but the maximum is {}", len, serialized_signature::MAX_LEN);
             ret.set_len(len);
         }
         ret

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -76,13 +76,13 @@ impl Default for SerializedSignature {
 
 impl PartialEq for SerializedSignature {
     fn eq(&self, other: &SerializedSignature) -> bool {
-        self.data[..self.len] == other.data[..other.len]
+        **self == **other
     }
 }
 
 impl AsRef<[u8]> for SerializedSignature {
     fn as_ref(&self) -> &[u8] {
-        &self.data[..self.len]
+        &*self
     }
 }
 

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -1,9 +1,11 @@
 //! Structs and functionality related to the ECDSA signature algorithm.
 
-use core::{fmt, str, ops, ptr};
+use core::{fmt, str, ptr};
 
 use crate::{Signing, Verification, Message, PublicKey, Secp256k1, SecretKey, from_hex, Error, ffi};
 use crate::ffi::CPtr;
+
+pub mod serialized_signature;
 
 #[cfg(feature = "recovery")]
 mod recovery;
@@ -12,19 +14,14 @@ mod recovery;
 #[cfg_attr(docsrs, doc(cfg(feature = "recovery")))]
 pub use self::recovery::{RecoveryId, RecoverableSignature};
 
+pub use serialized_signature::SerializedSignature;
+
 #[cfg(feature = "global-context")]
 use crate::SECP256K1;
 
 /// An ECDSA signature
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Signature(pub(crate) ffi::Signature);
-
-/// A DER serialized Signature
-#[derive(Copy, Clone)]
-pub struct SerializedSignature {
-    data: [u8; 72],
-    len: usize,
-}
 
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -39,21 +36,6 @@ impl fmt::Display for Signature {
     }
 }
 
-impl fmt::Debug for SerializedSignature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for SerializedSignature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for v in self.data.iter().take(self.len) {
-            write!(f, "{:02x}", v)?;
-        }
-        Ok(())
-    }
-}
-
 impl str::FromStr for Signature {
     type Err = Error;
     fn from_str(s: &str) -> Result<Signature, Error> {
@@ -63,83 +45,6 @@ impl str::FromStr for Signature {
             _ => Err(Error::InvalidSignature),
         }
     }
-}
-
-impl Default for SerializedSignature {
-    fn default() -> SerializedSignature {
-        SerializedSignature {
-            data: [0u8; 72],
-            len: 0,
-        }
-    }
-}
-
-impl PartialEq for SerializedSignature {
-    fn eq(&self, other: &SerializedSignature) -> bool {
-        **self == **other
-    }
-}
-
-impl AsRef<[u8]> for SerializedSignature {
-    fn as_ref(&self) -> &[u8] {
-        &*self
-    }
-}
-
-impl ops::Deref for SerializedSignature {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        &self.data[..self.len]
-    }
-}
-
-impl Eq for SerializedSignature {}
-
-impl<'a> IntoIterator for &'a SerializedSignature {
-    type IntoIter = core::slice::Iter<'a, u8>;
-    type Item = &'a u8;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl SerializedSignature {
-    /// Get a pointer to the underlying data with the specified capacity.
-    pub(crate) fn get_data_mut_ptr(&mut self) -> *mut u8 {
-        self.data.as_mut_ptr()
-    }
-
-    /// Get the capacity of the underlying data buffer.
-    pub fn capacity(&self) -> usize {
-        self.data.len()
-    }
-
-    /// Get the len of the used data.
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    /// Set the length of the object.
-    pub(crate) fn set_len(&mut self, len: usize) {
-        self.len = len;
-    }
-
-    /// Convert the serialized signature into the Signature struct.
-    /// (This DER deserializes it)
-    pub fn to_signature(&self) -> Result<Signature, Error> {
-        Signature::from_der(self)
-    }
-
-    /// Create a SerializedSignature from a Signature.
-    /// (this DER serializes it)
-    pub fn from_signature(sig: &Signature) -> SerializedSignature {
-        sig.serialize_der()
-    }
-
-    /// Check if the space is zero.
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl Signature {

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -96,6 +96,15 @@ impl ops::Deref for SerializedSignature {
 
 impl Eq for SerializedSignature {}
 
+impl<'a> IntoIterator for &'a SerializedSignature {
+    type IntoIter = core::slice::Iter<'a, u8>;
+    type Item = &'a u8;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl SerializedSignature {
     /// Get a pointer to the underlying data with the specified capacity.
     pub(crate) fn get_data_mut_ptr(&mut self) -> *mut u8 {

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -1,0 +1,109 @@
+//! Implements [`SerializedSignature`] and related types.
+//!
+//! DER-serialized signatures have the issue that they can have different lengths.
+//! We want to avoid using `Vec` since that would require allocations making the code slower and
+//! unable to run on platforms without allocator. We implement a special type to encapsulate
+//! serialized signatures and since it's a bit more complicated it has its own module.
+
+use core::{fmt, ops};
+use crate::Error;
+use super::Signature;
+
+/// A DER serialized Signature
+#[derive(Copy, Clone)]
+pub struct SerializedSignature {
+    data: [u8; 72],
+    len: usize,
+}
+
+impl fmt::Debug for SerializedSignature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for SerializedSignature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for v in self.data.iter().take(self.len) {
+            write!(f, "{:02x}", v)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for SerializedSignature {
+    fn default() -> SerializedSignature {
+        SerializedSignature {
+            data: [0u8; 72],
+            len: 0,
+        }
+    }
+}
+
+impl PartialEq for SerializedSignature {
+    fn eq(&self, other: &SerializedSignature) -> bool {
+        **self == **other
+    }
+}
+
+impl AsRef<[u8]> for SerializedSignature {
+    fn as_ref(&self) -> &[u8] {
+        &*self
+    }
+}
+
+impl ops::Deref for SerializedSignature {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.data[..self.len]
+    }
+}
+
+impl Eq for SerializedSignature {}
+
+impl<'a> IntoIterator for &'a SerializedSignature {
+    type IntoIter = core::slice::Iter<'a, u8>;
+    type Item = &'a u8;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl SerializedSignature {
+    /// Get a pointer to the underlying data with the specified capacity.
+    pub(crate) fn get_data_mut_ptr(&mut self) -> *mut u8 {
+        self.data.as_mut_ptr()
+    }
+
+    /// Get the capacity of the underlying data buffer.
+    pub fn capacity(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Get the len of the used data.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Set the length of the object.
+    pub(crate) fn set_len(&mut self, len: usize) {
+        self.len = len;
+    }
+
+    /// Convert the serialized signature into the Signature struct.
+    /// (This DER deserializes it)
+    pub fn to_signature(&self) -> Result<Signature, Error> {
+        Signature::from_der(self)
+    }
+
+    /// Create a SerializedSignature from a Signature.
+    /// (this DER serializes it)
+    pub fn from_signature(sig: &Signature) -> SerializedSignature {
+        sig.serialize_der()
+    }
+
+    /// Check if the space is zero.
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
+}

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -11,10 +11,12 @@ use core::{fmt, ops};
 use crate::Error;
 use super::Signature;
 
+pub(crate) const MAX_LEN: usize = 72;
+
 /// A DER serialized Signature
 #[derive(Copy, Clone)]
 pub struct SerializedSignature {
-    data: [u8; 72],
+    data: [u8; MAX_LEN],
     len: usize,
 }
 
@@ -37,7 +39,7 @@ impl Default for SerializedSignature {
     #[inline]
     fn default() -> SerializedSignature {
         SerializedSignature {
-            data: [0u8; 72],
+            data: [0u8; MAX_LEN],
             len: 0,
         }
     }
@@ -224,18 +226,18 @@ mod into_iter {
 
 #[cfg(test)]
 mod tests {
-    use super::SerializedSignature;
+    use super::{SerializedSignature, MAX_LEN};
 
     #[test]
     fn iterator_ops_are_homomorphic() {
-        let mut fake_signature_data = [0; 72];
+        let mut fake_signature_data = [0; MAX_LEN];
         // fill it with numbers 0 - 71
         for (i, byte) in fake_signature_data.iter_mut().enumerate() {
-            // up to 72
+            // up to MAX_LEN
             *byte = i as u8;
         }
 
-        let fake_signature = SerializedSignature { data: fake_signature_data, len: 72 };
+        let fake_signature = SerializedSignature { data: fake_signature_data, len: MAX_LEN };
 
         let mut iter1 = fake_signature.into_iter();
         let mut iter2 = fake_signature.iter();

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -34,6 +34,7 @@ impl fmt::Display for SerializedSignature {
 }
 
 impl Default for SerializedSignature {
+    #[inline]
     fn default() -> SerializedSignature {
         SerializedSignature {
             data: [0u8; 72],
@@ -43,12 +44,14 @@ impl Default for SerializedSignature {
 }
 
 impl PartialEq for SerializedSignature {
+    #[inline]
     fn eq(&self, other: &SerializedSignature) -> bool {
         **self == **other
     }
 }
 
 impl AsRef<[u8]> for SerializedSignature {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &*self
     }
@@ -57,6 +60,7 @@ impl AsRef<[u8]> for SerializedSignature {
 impl ops::Deref for SerializedSignature {
     type Target = [u8];
 
+    #[inline]
     fn deref(&self) -> &[u8] {
         &self.data[..self.len]
     }
@@ -78,6 +82,7 @@ impl<'a> IntoIterator for &'a SerializedSignature {
     type IntoIter = core::slice::Iter<'a, u8>;
     type Item = &'a u8;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -85,38 +90,45 @@ impl<'a> IntoIterator for &'a SerializedSignature {
 
 impl SerializedSignature {
     /// Get a pointer to the underlying data with the specified capacity.
+    #[inline]
     pub(crate) fn get_data_mut_ptr(&mut self) -> *mut u8 {
         self.data.as_mut_ptr()
     }
 
     /// Get the capacity of the underlying data buffer.
+    #[inline]
     pub fn capacity(&self) -> usize {
         self.data.len()
     }
 
     /// Get the len of the used data.
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Set the length of the object.
+    #[inline]
     pub(crate) fn set_len(&mut self, len: usize) {
         self.len = len;
     }
 
     /// Convert the serialized signature into the Signature struct.
     /// (This DER deserializes it)
+    #[inline]
     pub fn to_signature(&self) -> Result<Signature, Error> {
         Signature::from_der(self)
     }
 
     /// Create a SerializedSignature from a Signature.
     /// (this DER serializes it)
+    #[inline]
     pub fn from_signature(sig: &Signature) -> SerializedSignature {
         sig.serialize_der()
     }
 
     /// Check if the space is zero.
+    #[inline]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -28,7 +28,7 @@ impl fmt::Debug for SerializedSignature {
 
 impl fmt::Display for SerializedSignature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for v in self.data.iter().take(self.len) {
+        for v in self {
             write!(f, "{:02x}", v)?;
         }
         Ok(())


### PR DESCRIPTION
This

* Deduplicates slicing operations
* Implements `IntoIterator` (owned and borrowed)
* Reorganizes the code for better clarity
* Adds `#[inline]`s
* Checks length set by libsep256k1

Closes #367
Closes #368

Individual commits are hopefully easier to review.