### PR TITLE
secp256k1-sys: bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ global-context = ["std"]
 global-context-less-secure = ["global-context"]
 
 [dependencies]
-secp256k1-sys = { version = "0.5.0", default-features = false, path = "./secp256k1-sys" }
+secp256k1-sys = { version = "0.6.0", default-features = false, path = "./secp256k1-sys" }
 serde = { version = "1.0", default-features = false, optional = true }
 
 # You likely only want to enable these if you explicitly do not want to use "std", otherwise enable

--- a/secp256k1-sys/CHANGELOG.md
+++ b/secp256k1-sys/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# 0.6.0 - 2022-06-21
+
+* [Bump MSRV to 1.41](https://github.com/rust-bitcoin/rust-secp256k1/pull/331)
+* [Re-implement `Ord` on `PublicKey` using upstream ordering function](https://github.com/rust-bitcoin/rust-secp256k1/pull/449)
+
 # 0.5.1 - 2022-04-30
 
 * [Fix WASM build](https://github.com/rust-bitcoin/rust-secp256k1/pull/421)

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.6.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>" ]


### PR DESCRIPTION
Needed for release of secp256k1 0.23.0