### PR TITLE
HOT FIX: Enable "rand/std_rng" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.1 - 2022-06-24
+
+[Enable "rand/std_rng" feature](https://github.com/rust-bitcoin/rust-secp256k1/pull/460) when the crate's "rnd-std" feature is enabled.
+
 # 0.23.0 - 2022-06-21
 
 The major change in this version is the increase of the Minimum Supported Rust Version (MSRV) from 1.29 to 1.41.1, this is a big change because it introduces Rust Edition 2018 to the codebase along with all the benefits that brings.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ std = ["alloc", "secp256k1-sys/std"]
 # allow use of Secp256k1::new and related API that requires an allocator
  alloc = ["secp256k1-sys/alloc"]
  bitcoin-hashes-std = ["bitcoin_hashes/std"]
-rand-std = ["rand/std"]
+rand-std = ["rand/std", "rand/std_rng"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.23.0"
+version = "0.23.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
Hot fix because currently attempting to use secp256 v0.23.0 as a dependency throws a secp build error.

We recently upgraded the rand dependency and we use it behind code feature gated on "rand-std". In that code we use `thread_rng` but this is only available if the "std_rng" feature is turned on, however in non-dev builds we do not enable this feature, we have a "rand-std" feature that enables "rand/std", it should also enable "std_rng".

Enable "rand/std_rng" in the "rand-std" feature.

I threw a version bump patch on this too in case we want to merge and release this fix (assuming I'm not mistaken about the 0.23.0 release), its Friday afternoon right now for me so if you want to forge ahead feel free to do what ever needs doing, don't wait for me and this PR :)