### PR TITLE
derive Hash for RecoverableSignature

### DIFF
--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -28,7 +28,7 @@ use crate::ffi::recovery as ffi;
 pub struct RecoveryId(i32);
 
 /// An ECDSA signature with a recovery ID for pubkey recovery.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct RecoverableSignature(ffi::RecoverableSignature);
 
 impl RecoveryId {


### PR DESCRIPTION
It would be nice to also derive Hash for `RecoverableSignature` so data structures containing it don't have to implement it themself if they need to derive Hash