### PR TITLE
Add must_use for mut self key manipulation methods

### DIFF
--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -20,26 +20,26 @@ macro_rules! impl_array_newtype {
         impl Copy for $thing {}
 
         impl $thing {
-            #[inline]
             /// Converts the object to a raw pointer for FFI interfacing
+            #[inline]
             pub fn as_ptr(&self) -> *const $ty {
                 let &$thing(ref dat) = self;
                 dat.as_ptr()
             }
 
-            #[inline]
             /// Converts the object to a mutable raw pointer for FFI interfacing
+            #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $ty {
                 let &mut $thing(ref mut dat) = self;
                 dat.as_mut_ptr()
             }
 
-            #[inline]
             /// Returns the length of the object as an array
+            #[inline]
             pub fn len(&self) -> usize { $len }
 
-            #[inline]
             /// Returns whether the object as an array is empty
+            #[inline]
             pub fn is_empty(&self) -> bool { false }
         }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -243,6 +243,7 @@ impl SecretKey {
 
     /// Negates the secret key.
     #[inline]
+    #[must_use = "you forgot to use the negated secret key"]
     pub fn negate(mut self) -> SecretKey {
         unsafe {
             let res = ffi::secp256k1_ec_seckey_negate(
@@ -272,6 +273,7 @@ impl SecretKey {
     ///
     /// Returns an error if the resulting key would be invalid.
     #[inline]
+    #[must_use = "you forgot to use the tweaked secret key"]
     pub fn add_tweak(mut self, tweak: &Scalar) -> Result<SecretKey, Error> {
         unsafe {
             if ffi::secp256k1_ec_seckey_tweak_add(
@@ -302,6 +304,7 @@ impl SecretKey {
     ///
     /// Returns an error if the resulting key would be invalid.
     #[inline]
+    #[must_use = "you forgot to use the tweaked secret key"]
     pub fn mul_tweak(mut self, tweak: &Scalar) -> Result<SecretKey, Error> {
         unsafe {
             if ffi::secp256k1_ec_seckey_tweak_mul(
@@ -536,6 +539,7 @@ impl PublicKey {
 
     /// Negates the public key.
     #[inline]
+    #[must_use = "you forgot to use the negated public key"]
     pub fn negate<C: Verification>(mut self, secp: &Secp256k1<C>) -> PublicKey {
         unsafe {
             let res = ffi::secp256k1_ec_pubkey_negate(secp.ctx, &mut self.0);
@@ -566,6 +570,7 @@ impl PublicKey {
     ///
     /// Returns an error if the resulting key would be invalid.
     #[inline]
+    #[must_use = "you forgot to use the tweaked public key"]
     pub fn add_exp_tweak<C: Verification>(
         mut self,
         secp: &Secp256k1<C>,
@@ -602,6 +607,7 @@ impl PublicKey {
     ///
     /// Returns an error if the resulting key would be invalid.
     #[inline]
+    #[must_use = "you forgot to use the tweaked public key"]
     pub fn mul_tweak<C: Verification>(
         mut self,
         secp: &Secp256k1<C>,
@@ -971,6 +977,7 @@ impl KeyPair {
     /// ```
     // TODO: Add checked implementation
     #[inline]
+    #[must_use = "you forgot to use the tweaked key pair"]
     pub fn add_xonly_tweak<C: Verification>(
         mut self,
         secp: &Secp256k1<C>,
@@ -1270,6 +1277,7 @@ impl XOnlyPublicKey {
     /// let tweaked = xonly.add_tweak(&secp, &tweak).expect("Improbable to fail with a randomly generated tweak");
     /// # }
     /// ```
+    #[must_use = "you forgot to use the tweaked xonly pubkey"]
     pub fn add_tweak<V: Verification>(
         mut self,
         secp: &Secp256k1<V>,


### PR DESCRIPTION
We recently added a bunch of key tweaking methods that take `mut self`
and return the tweaked/negated keys. These functions are pure and as
such the returned result is expected to be used. To help downstream
users use the API correctly add `must_use` attributes with a descriptive
error string for each of the methods that takes `mut self`.