### PR TITLE
Hot Fix: Use fuzzing not feature = "fuzzing"

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -101,7 +101,7 @@ pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
 /// [`bincode`]: https://docs.rs/bincode
 /// [`cbor`]: https://docs.rs/cbor
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
-#[cfg_attr(feature = "fuzzing", derive(PartialOrd, Ord))]
+#[cfg_attr(fuzzing, derive(PartialOrd, Ord))]
 #[repr(transparent)]
 pub struct PublicKey(ffi::PublicKey);
 


### PR DESCRIPTION
Currently the following command fails

`RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS='--cfg=fuzzing' cargo test --all --all-features`

This is because `fuzzing` is not a feature, we should be using `fuzzing` directly not `feature = "fuzzing"`.

~I have no idea how this got past CI~, found while trying to [upgrade secp in bitcoin](https://github.com/rust-bitcoin/rust-bitcoin/pull/1066).

This got past CI because of the feature gate combination `#[cfg(all(test, feature = "unstable"))]`, we never run tests on CI with both DO_FEATURE_MATRIX and DO_BENCH.
```
if [ "$DO_FEATURE_MATRIX" = true ]; then
...
    if [ "$DO_BENCH" = true ]; then  # proxy for us having a nightly compiler
        cargo test --all --all-features
        RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS='--cfg=fuzzing' cargo test --all --all-features
    fi
fi
```