### PR TITLE
Add NIGHTLY variable to CI script

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -17,6 +17,12 @@ fi
 cargo --version
 rustc --version
 
+# Work out if we are using a nightly toolchain.
+NIGHTLY=false
+if cargo --version | grep nightly; then
+    NIGHTLY=true
+fi
+
 # Test if panic in C code aborts the process (either with a real panic or with SIGILL)
 cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at '\[libsecp256k1\]"
 
@@ -51,7 +57,7 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all --features="$FEATURES"
     cargo test --all --features="rand serde"
 
-    if [ "$DO_BENCH" = true ]; then  # proxy for us having a nightly compiler
+    if [ "$NIGHTLY" = true ]; then
         cargo test --all --all-features
         RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS='--cfg=fuzzing' cargo test --all --all-features
     fi

--- a/src/key.rs
+++ b/src/key.rs
@@ -1651,6 +1651,7 @@ mod test {
     use crate::Error::{InvalidPublicKey, InvalidSecretKey};
     use crate::Scalar;
 
+    #[cfg(not(fuzzing))]
     macro_rules! hex {
         ($hex:expr) => ({
             let mut result = vec![0; $hex.len() / 2];


### PR DESCRIPTION
We are currently using the DO_BENCH variable as a proxy for whether or not we are using a nightly toolchain, while this is technically correct we use it from within an if guarded statement that is guarded by DO_FEATURE_MATRIX and we never run the CI script with _both_ of these variables set to true. This means that the all features test is never being run.

Add a NIGHTLY variable and set it based on the output of `cargo --version`.

This PR catches the bug fixed in: https://github.com/rust-bitcoin/rust-secp256k1/pull/466 as such it will not be able to be merged until #466 merges.