### PR TITLE
Release tracking issue -  v0.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.23.3 - 2022-06-29
+
+* [Add must_use for mut self key manipulation methods](https://github.com/rust-bitcoin/rust-secp256k1/pull/465)
+* [Fix fuzzing feature guard](https://github.com/rust-bitcoin/rust-secp256k1/pull/466)
+
 # 0.23.2 - 2022-06-27
 
 * [Move `cbor` to dev-dependencies](https://github.com/rust-bitcoin/rust-secp256k1/pull/461)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.23.2 - 2022-06-27
+
+* [Move `cbor` to dev-dependencies](https://github.com/rust-bitcoin/rust-secp256k1/pull/461)
+* [Derive `Hash` for `RecoverableSignature`](https://github.com/rust-bitcoin/rust-secp256k1/pull/462)
+
 # 0.23.1 - 2022-06-24
 
 [Enable "rand/std_rng" feature](https://github.com/rust-bitcoin/rust-secp256k1/pull/460) when the crate's "rnd-std" feature is enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.23.2"
+version = "0.23.3"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
Bump the version to v0.23.3 and add changelog entry. Also, in preparation add a changeloge entry for the already released v0.23.2