### PR TITLE
Create configuration conditional "bench"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ features = [ "rand", "rand-std", "serde", "bitcoin_hashes", "recovery", "global-
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-unstable = ["recovery"]
 default = ["std"]
 std = ["alloc", "secp256k1-sys/std"]
 # allow use of Secp256k1::new and related API that requires an allocator

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ features = [ "rand", "rand-std", "serde", "bitcoin_hashes", "recovery", "global-
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-unstable = ["recovery", "rand-std"]
+unstable = ["recovery"]
 default = ["std"]
 std = ["alloc", "secp256k1-sys/std"]
 # allow use of Secp256k1::new and related API that requires an allocator

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ git config --local core.hooksPath githooks/
 
 Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.
 
+### Benchmarks
+
+We use a custom Rust compiler configuration conditional to guard the bench mark code. To run the
+bench marks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench --features=recovery`.
+
 ## Fuzzing
 
 If you want to fuzz this library, or any library which depends on it, you will

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Full documentation](https://docs.rs/secp256k1/)
 
-### rust-secp256k1
+## rust-secp256k1
 
 `rust-secp256k1` is a wrapper around [libsecp256k1](https://github.com/bitcoin-core/secp256k1),
 a C library by Pieter Wuille for producing ECDSA signatures using the SECG curve

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -98,9 +98,11 @@ if [ "$DO_ASAN" = true ]; then
     cargo run --release --features=alloc --manifest-path=./no_std_test/Cargo.toml | grep -q "Verified alloc Successfully"
 fi
 
-# Bench
-if [ "$DO_BENCH" = true ]; then
-    cargo bench --all --features="unstable"
+
+# Bench if told to, only works with non-stable toolchain (nightly, beta).
+if [ "$DO_BENCH" = true ]
+then
+    RUSTFLAGS='--cfg=bench' cargo bench --features=recovery
 fi
 
 exit 0

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -286,7 +286,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod benches {
     use test::{Bencher, black_box};
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -452,7 +452,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod benches {
     use rand::{thread_rng, RngCore};
     use test::{Bencher, black_box};

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -452,7 +452,6 @@ mod tests {
     }
 }
 
-
 #[cfg(all(test, feature = "unstable"))]
 mod benches {
     use rand::{thread_rng, RngCore};

--- a/src/key.rs
+++ b/src/key.rs
@@ -2433,7 +2433,7 @@ mod test {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod benches {
     use test::Bencher;
     use std::collections::BTreeSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,14 +155,16 @@
 #![allow(clippy::missing_safety_doc)]
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
+
+// Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(bench, feature(test))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 extern crate test;
 
 #[macro_use]
@@ -1060,7 +1062,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod benches {
     use test::{Bencher, black_box};
 


### PR DESCRIPTION
As we did in rust-bitcoin [0] create a configuration conditional `bench`
that we can use to guard bench mark code. This has the benefit of
making our features additive i.e., we can now test with `--all-features`
with a stable toolchain (currently this fails because of our use of the
`test` crate).

Please note, this patch maintains the current behaviour of turning on
the `recovery` and `rand-std` features when benching although I was
unable to ascertain why this is needed.

[0] - https://github.com/rust-bitcoin/rust-bitcoin/pull/1092