### PR TITLE
Run `shellcheck` on the ci script

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -49,6 +49,7 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all
     RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all --features="$FEATURES"
     cargo test --all --features="rand serde"
+    cargo test --features="$STD_FEATURES"
 
     if [ "$NIGHTLY" = true ]; then
         cargo test --all --all-features

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -46,8 +46,8 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
         cargo test --all --no-default-features --features="std,$feature"
     done
     # Other combos 
-    RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all
-    RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS=$RUSTFLAGS cargo test --all --features="$FEATURES"
+    RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS='--cfg=fuzzing' cargo test --all
+    RUSTFLAGS='--cfg=fuzzing' RUSTDOCFLAGS='--cfg=fuzzing' cargo test --all --features="$FEATURES"
     cargo test --all --features="rand serde"
     cargo test --features="$STD_FEATURES"
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -7,12 +7,6 @@ FEATURES="bitcoin_hashes global-context lowmemory rand recovery serde std alloc"
 # them together with 'std'.
 STD_FEATURES="rand-std bitcoin-hashes-std"
 
-# Use toolchain if explicitly specified
-if [ -n "$TOOLCHAIN" ]
-then
-    alias cargo="cargo +$TOOLCHAIN"
-fi
-
 cargo --version
 rustc --version
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
-#!/bin/sh -ex
+#!/bin/sh
 
-set -e
+set -ex
 
 # TODO: Add "alloc" once we bump MSRV to past 1.29
 FEATURES="bitcoin_hashes global-context lowmemory rand recovery serde std"

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,8 +2,7 @@
 
 set -ex
 
-# TODO: Add "alloc" once we bump MSRV to past 1.29
-FEATURES="bitcoin_hashes global-context lowmemory rand recovery serde std"
+FEATURES="bitcoin_hashes global-context lowmemory rand recovery serde std alloc"
 # These features are typically enabled along with the 'std' feature, so we test
 # them together with 'std'.
 STD_FEATURES="rand-std bitcoin-hashes-std"


### PR DESCRIPTION
The first 3 patches are preparatory cleanup in line with what has been done lately in `rust-bitcoin`. The last two are real bugs found by `shellcheck`.

Props to dpc for putting me on to `shellcheck`.