### PR TITLE
WIP: Verify removal of Index trait bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,14 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 # You likely only want to enable these if you explicitly do not want to use "std", otherwise enable
 # the respective -std feature e.g., bitcoin-hashes-std
-bitcoin_hashes = { version = "0.11", default-features = false, optional = true }
+bitcoin_hashes = { git = "https://github.com/tcharding/bitcoin_hashes", branch = "08-09-rm-index-impls", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.8"
 rand_core = "0.6"
 serde_test = "1.0"
-bitcoin_hashes = "0.11"
+bitcoin_hashes = { git = "https://github.com/tcharding/bitcoin_hashes", branch = "08-09-rm-index-impls" }
 bincode = "1.3.3"
 
 # cbor does not build on WASM, we use it in a single trivial test (an example of when

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -6,7 +6,7 @@ use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey, ecdsa, Signing,
 
 fn verify<C: Verification>(secp: &Secp256k1<C>, msg: &[u8], sig: [u8; 64], pubkey: [u8; 33]) -> Result<bool, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
@@ -15,7 +15,7 @@ fn verify<C: Verification>(secp: &Secp256k1<C>, msg: &[u8], sig: [u8; 64], pubke
 
 fn sign<C: Signing>(secp: &Secp256k1<C>, msg: &[u8], seckey: [u8; 32]) -> Result<ecdsa::Signature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa(&msg, &seckey))
 }

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -7,7 +7,7 @@ use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verifi
 
 fn recover<C: Verification>(secp: &Secp256k1<C>,msg: &[u8],sig: [u8; 64],recovery_id: u8) -> Result<PublicKey, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let id = ecdsa::RecoveryId::from_i32(recovery_id as i32)?;
     let sig = ecdsa::RecoverableSignature::from_compact(&sig, id)?;
 
@@ -16,7 +16,7 @@ fn recover<C: Verification>(secp: &Secp256k1<C>,msg: &[u8],sig: [u8; 64],recover
 
 fn sign_recovery<C: Signing>(secp: &Secp256k1<C>, msg: &[u8], seckey: [u8; 32]) -> Result<ecdsa::RecoverableSignature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa_recoverable(&msg, &seckey))
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -189,6 +189,8 @@ mod alloc_only {
         /// # }
         /// ```
         #[cfg_attr(not(feature = "rand-std"), allow(clippy::let_and_return, unused_mut))]
+        #[allow(unused_mut)] // ctx is not mutated under some feature combinations.
+        #[allow(clippy::let_and_return)] // ctx as for unused_mut
         pub fn gen_new() -> Secp256k1<C> {
             #[cfg(target_arch = "wasm32")]
             ffi::types::sanity_checks_for_wasm();

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -45,7 +45,7 @@ impl PartialEq for SerializedSignature {
 impl AsRef<[u8]> for SerializedSignature {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        &*self
+        self
     }
 }
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -52,8 +52,8 @@ macro_rules! impl_display_secret {
 
                 let mut engine = sha256::Hash::engine();
                 let tag_hash = sha256::Hash::hash(tag.as_bytes());
-                engine.input(&tag_hash[..]);
-                engine.input(&tag_hash[..]);
+                engine.input(tag_hash.as_ref());
+                engine.input(tag_hash.as_ref());
                 engine.input(&self.secret_bytes());
                 let hash = sha256::Hash::from_engine(engine);
 


### PR DESCRIPTION
This is not a merge candidate. The point of this PR is to verify https://github.com/rust-bitcoin/bitcoin_hashes/pull/168

Verify we can still build after `bitcoin_hashes` removes the `Index`
trait bound and replaces it for `AsRef`.