### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -196,6 +196,8 @@ mod alloc_only {
             let size = unsafe { ffi::secp256k1_context_preallocated_size(C::FLAGS) };
             let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
             let ptr = unsafe {alloc::alloc(layout)};
+
+            #[allow(unused_mut)] // ctx is not mutated under some feature combinations.
             let mut ctx = Secp256k1 {
                 ctx: unsafe { ffi::secp256k1_context_preallocated_create(ptr as *mut c_void, C::FLAGS) },
                 phantom: PhantomData,
@@ -207,6 +209,7 @@ mod alloc_only {
                 ctx.randomize(&mut rand::thread_rng());
             }
 
+            #[allow(clippy::let_and_return)] // as for unusted_mut
             ctx
         }
     }

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -45,7 +45,7 @@ impl PartialEq for SerializedSignature {
 impl AsRef<[u8]> for SerializedSignature {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        &*self
+        self
     }
 }
 


### PR DESCRIPTION
Clippy default settings seemed to have changed introducing a few new warnings.

warning: variable does not need to be mutable
warning: deref on an immutable reference
warning: returning the result of a `let` binding from a block

Fix them all in a single patch because CI has to pass for each patch.

cc apoelstra, turns out you were right I was wrong, clippy did change, cannot remember which PR we were discussing it on.