### PR TITLE
Support non-WASM platforms that are missing `string.h`

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -62,7 +62,14 @@ fn main() {
     base_config.file("depend/secp256k1/contrib/lax_der_parsing.c")
                .file("depend/secp256k1/src/precomputed_ecmult_gen.c")
                .file("depend/secp256k1/src/precomputed_ecmult.c")
-               .file("depend/secp256k1/src/secp256k1.c")
-               .compile("libsecp256k1.a");
+               .file("depend/secp256k1/src/secp256k1.c");
+
+    if base_config.try_compile("libsecp256k1.a").is_err() {
+        // Some embedded platforms may not have, eg, string.h available, so if the build fails
+        // simply try again with the wasm sysroot (but without the wasm type sizes) in the hopes
+        // that it works.
+        base_config.include("wasm/wasm-sysroot");
+        base_config.compile("libsecp256k1.a");
+    }
 }
 


### PR DESCRIPTION
Dunno why we haven't seen this elsewhere, but when trying to build locally for an ARM embedded target `secp256k1-sys` failed to compile as it was missing `string.h`, just like WASM.

This patch adds a trivial fallback - if we fail to compile initially we unconditionally retry with the wasm-sysroot, giving us a valid `string.h`.