### PR TITLE
Add logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ global-context = ["std"]
 # and is not necessary.)
 global-context-less-secure = ["global-context"]
 
+# Enables debug logging, do not enable in production systems.
+danger_leak_secret_material = ["std"]
+
 [dependencies]
 secp256k1-sys = { version = "0.6.0", default-features = false, path = "./secp256k1-sys" }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ global-context = ["std"]
 global-context-less-secure = ["global-context"]
 
 # Enables debug logging, do not enable in production systems.
-danger_leak_secret_material = ["std"]
+danger_leak_secret_material = ["std", "global-context"]
 
 [dependencies]
 secp256k1-sys = { version = "0.6.0", default-features = false, path = "./secp256k1-sys" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,8 @@ mod macros;
 #[macro_use]
 mod secret;
 mod context;
+#[macro_use]
+mod logging;
 mod key;
 
 pub mod constants;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,51 @@
+//! Provides debug logging.
+//!
+//! WARNING: Logging leaks secret information and is provided for debugging purposes only.
+//!
+//! DO NOT ENABLE LOGGING IN PRODUCTION SYSTEMS.
+//!
+
+use std::fs::File;
+use std::sync::Mutex;
+
+#[allow(dead_code)] // When danger_leak_secret_material not enabled.
+pub static LOGFILE: Mutex<Option<File>> = Mutex::new(None);
+
+#[allow(dead_code)] // When danger_leak_secret_material not enabled.
+pub const CRYPTO_DEBUG_FILE: &str = "/tmp/rust-secp256k1.log";
+
+/// Logs a format string to `CRYPTO_DEBUG_FILE`.
+#[cfg(feature = "danger_leak_secret_material")]
+#[macro_export]
+macro_rules! log {
+    ($fmt:literal, $($args:tt),*) => {
+        use std::io::Write;
+
+        let mut guard = $crate::logging::LOGFILE.lock().expect("poisoned mutex");
+
+        if guard.is_none() {
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .append(true)
+                .open($crate::logging::CRYPTO_DEBUG_FILE)
+                .expect("failed to create/open log file");
+
+            *guard = Some(file);
+        }
+
+        match *guard {
+            Some(ref mut file) => {
+                let _ = writeln!(file, $fmt, $($args),*);
+            },
+            None => panic!("log file missing"),
+        }
+    }
+}
+
+/// No-op when `danger_leak_secret_material` feature is not enabled.
+#[cfg(not(feature = "danger_leak_secret_material"))]
+#[macro_export]
+macro_rules! log {
+    ($fmt:literal, $($args:tt),*) => {}
+}


### PR DESCRIPTION
Draft for initial feedback please. (#498 is the same but uses `log` crate)

- Add logging infrastructure as described in #495, logs to a file hardcode as a string in the `logging` module.
- Add logging when signing.
- Add logging when creating private keys.

Fix: #495 