### PR TITLE
Fix typo in public method

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -374,7 +374,7 @@ impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
     /// * The user must handle the freeing of the context(using the correct functions) by himself.
     /// * This list *is not* exhaustive, and any violation may lead to Undefined Behavior.
     ///
-    pub unsafe fn from_raw_signining_only(raw_ctx: *mut ffi::Context) -> ManuallyDrop<Secp256k1<SignOnlyPreallocated<'buf>>> {
+    pub unsafe fn from_raw_signing_only(raw_ctx: *mut ffi::Context) -> ManuallyDrop<Secp256k1<SignOnlyPreallocated<'buf>>> {
         ManuallyDrop::new(Secp256k1 {
             ctx: raw_ctx,
             phantom: PhantomData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,7 +610,7 @@ mod tests {
         let ctx_vrfy = Secp256k1::verification_only();
 
         let mut full = unsafe {Secp256k1::from_raw_all(ctx_full.ctx)};
-        let mut sign = unsafe {Secp256k1::from_raw_signining_only(ctx_sign.ctx)};
+        let mut sign = unsafe {Secp256k1::from_raw_signing_only(ctx_sign.ctx)};
         let mut vrfy = unsafe {Secp256k1::from_raw_verification_only(ctx_vrfy.ctx)};
 
         let (sk, pk) = full.generate_keypair(&mut thread_rng());


### PR DESCRIPTION
We have a method called `from_raw_signining_only`, I'm guessing this should be `from_raw_signing_only`.