### PR TITLE
Add logging infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ global-context = ["std"]
 # and is not necessary.)
 global-context-less-secure = ["global-context"]
 
+# Enables debug logging, do not enable in production systems.
+danger-leak-secret-material = ["log", "std", "global-context"]
+
 [dependencies]
 secp256k1-sys = { version = "0.6.0", default-features = false, path = "./secp256k1-sys" }
 serde = { version = "1.0", default-features = false, optional = true }
@@ -44,12 +47,16 @@ serde = { version = "1.0", default-features = false, optional = true }
 bitcoin_hashes = { version = "0.11", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 
+# DO NOT ENABLE THIS, use danger-leak-secret-material instead.
+log = { version = "0.4", default-features = false, optional = true }
+
 [dev-dependencies]
 rand = "0.8"
 rand_core = "0.6"
 serde_test = "1.0"
 bitcoin_hashes = "0.11"
 bincode = "1.3.3"
+env_logger = "0.9.1"
 
 # cbor does not build on WASM, we use it in a single trivial test (an example of when
 # fixed-width-serde breaks down). Just run the test when on an x86_64 machine.
@@ -73,6 +80,11 @@ required-features = ["std"]
 name = "generate_keys"
 required-features = ["std", "rand-std"]
 
+[[example]]
+name = "log"
+required-features = ["std", "danger-leak-secret-material", "rand-std", "serde"]
+
 [workspace]
 members = ["secp256k1-sys"]
 exclude = ["no_std_test"]
+

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,0 +1,35 @@
+//! An example showing debug logging.
+//!
+
+use log::info;
+use secp256k1::{rand, KeyPair, SECP256K1, SecretKey};
+
+fn main() {
+    env_logger::init();
+    info!("Running the logging example");
+
+    keys();
+}
+
+fn keys() {
+    let secp = SECP256K1;
+    info!("Using global secp context");
+
+    let _ = SecretKey::new(&mut rand::thread_rng());
+
+    let sec_bytes = [59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94, 203, 174, 253, 102, 39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28];
+    let sk = SecretKey::from_slice(&sec_bytes).expect("failed to parse seckey bytes for SecretKey");
+
+    let ser = bincode::serialize(&sk).expect("failed to serialize sk");
+    let _: SecretKey = bincode::deserialize(&ser).expect("failed to deserialize sk");
+
+    // FIXME: KeyPair overflows the stack?
+    //
+    // let kp = KeyPair::from_secret_key(&secp, &sk);
+    // let _ = SecretKey::from_keypair(&kp);
+    // let _ = KeyPair::from_seckey_slice(&secp, &sec_bytes).expect("failed to parse seckey bytes for KeyPair");
+    // let _ = KeyPair::new(&secp, &mut rand::thread_rng());
+
+    // let ser = bincode::serialize(&kp).expect("failed to serialize sk");
+    // let _: SecretKey = bincode::deserialize(&ser).expect("failed to deserialize sk");
+}

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -253,13 +253,14 @@ impl<C: Signing> Secp256k1<C> {
         self.sign_ecdsa(msg, sk)
     }
 
+    #[allow(clippy::let_and_return)] // When feature danger-leak-secret-material not enabled.
     fn sign_ecdsa_with_noncedata_pointer(
         &self,
         msg: &Message,
         sk: &SecretKey,
         noncedata: Option<&[u8; 32]>,
     ) -> Signature {
-        unsafe {
+        let sig = unsafe {
             let mut ret = ffi::Signature::new();
             let noncedata_ptr = match noncedata {
                 Some(arr) => arr.as_c_ptr() as *const _,
@@ -271,7 +272,15 @@ impl<C: Signing> Secp256k1<C> {
                                                  sk.as_c_ptr(), ffi::secp256k1_nonce_function_rfc6979,
                                                  noncedata_ptr), 1);
             Signature::from(ret)
+        };
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let pk = PublicKey::from_secret_key_global(sk);
+            crate::log!("ECDSA signing message: {:?} {:?} sig={}", pk, msg, sig);
         }
+
+        sig
     }
 
     /// Constructs a signature for `msg` using the secret key `sk` and RFC6979 nonce

--- a/src/key.rs
+++ b/src/key.rs
@@ -171,6 +171,18 @@ impl SecretKey {
                 data = random_32_bytes(rng);
             }
         }
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let sk = SecretKey(data);
+            let pk = PublicKey::from_secret_key_global(&sk);
+
+            let mut target = [0_u8; 64];
+            let hex = crate::to_hex(&data, &mut target).expect("failed to encode hex data");
+
+            crate::log!("Created private key from random data: data={} {:?} {:?}", hex, sk, pk);
+        }
+
         SecretKey(data)
     }
 
@@ -195,6 +207,18 @@ impl SecretKey {
                         return Err(InvalidSecretKey);
                     }
                 }
+
+                #[cfg(feature = "danger-leak-secret-material")]
+                {
+                    let sk = SecretKey(data);
+                    let pk = PublicKey::from_secret_key_global(&sk);
+
+                    let mut target = [0_u8; constants::SECRET_KEY_SIZE * 2];
+                    let hex = crate::to_hex(&data, &mut target).expect("failed to encode hex data");
+
+                    crate::log!("Created private key from input data: data={} {:?} {:?}", hex, sk, pk);
+                }
+
                 Ok(SecretKey(data))
             }
             Err(_) => Err(InvalidSecretKey)
@@ -225,6 +249,14 @@ impl SecretKey {
             );
             debug_assert_eq!(ret, 1);
         }
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let sk = SecretKey(sk);
+            let pk = PublicKey::from_secret_key_global(&sk);
+            crate::log!("Created private key from keypair: keypair={:?} {:?} {:?}", keypair, sk, pk);
+        }
+
         SecretKey(sk)
     }
 
@@ -373,7 +405,7 @@ impl serde::Serialize for SecretKey {
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for SecretKey {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        if d.is_human_readable() {
+        let sk = if d.is_human_readable() {
             d.deserialize_str(super::serde_util::FromStrVisitor::new(
                 "a hex string representing 32 byte SecretKey"
             ))
@@ -383,7 +415,15 @@ impl<'de> serde::Deserialize<'de> for SecretKey {
                 SecretKey::from_slice
             );
             d.deserialize_tuple(constants::SECRET_KEY_SIZE, visitor)
+        }?;
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let pk = PublicKey::from_secret_key_global(&sk);
+            crate::log!("Deserialized private key: {:?} {:?}", sk, pk);
         }
+
+        Ok(sk)
     }
 }
 
@@ -824,18 +864,29 @@ impl KeyPair {
 
     /// Creates a [`KeyPair`] directly from a Secp256k1 secret key.
     #[inline]
+    #[allow(clippy::let_and_return)] // When feature danger-leak-secret-material not enabled.
     pub fn from_secret_key<C: Signing>(
         secp: &Secp256k1<C>,
         sk: &SecretKey,
     ) -> KeyPair {
-        unsafe {
+        let kp = unsafe {
             let mut kp = ffi::KeyPair::new();
             if ffi::secp256k1_keypair_create(secp.ctx, &mut kp, sk.as_c_ptr()) == 1 {
                 KeyPair(kp)
             } else {
                 panic!("the provided secret key is invalid: it is corrupted or was not produced by Secp256k1 library")
             }
+        };
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            assert_eq!(*sk, kp.secret_key());
+            let pk = kp.public_key();
+            crate::log!("Created keypair from secret key: keypair={:?} sk={:?} pk={}",
+                        kp, sk, pk);
         }
+
+        kp
     }
 
     /// Creates a [`KeyPair`] directly from a secret key slice.
@@ -853,14 +904,24 @@ impl KeyPair {
             return Err(Error::InvalidSecretKey);
         }
 
-        unsafe {
+        let keypair = unsafe {
             let mut kp = ffi::KeyPair::new();
             if ffi::secp256k1_keypair_create(secp.ctx, &mut kp, data.as_c_ptr()) == 1 {
                 Ok(KeyPair(kp))
             } else {
                 Err(Error::InvalidSecretKey)
             }
+        }?;
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let sk = keypair.secret_key();
+            let pk = keypair.public_key();
+            crate::log!("Created keypair from secret key data: data={:?} keypair={:?} sk={:?} pk={}",
+                        data, keypair, sk, pk);
         }
+
+        Ok(keypair)
     }
 
     /// Creates a [`KeyPair`] directly from a secret key string.
@@ -905,6 +966,7 @@ impl KeyPair {
     #[inline]
     #[cfg(any(test, feature = "rand"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+    #[allow(clippy::let_and_return)] // When feature danger-leak-secret-material not enabled.
     pub fn new<R: rand::Rng + ?Sized, C: Signing>(secp: &Secp256k1<C>, rng: &mut R) -> KeyPair {
         let mut random_32_bytes = || {
             let mut ret = [0u8; 32];
@@ -912,13 +974,27 @@ impl KeyPair {
             ret
         };
         let mut data = random_32_bytes();
-        unsafe {
+        let kp = unsafe {
             let mut keypair = ffi::KeyPair::new();
             while ffi::secp256k1_keypair_create(secp.ctx, &mut keypair, data.as_c_ptr()) == 0 {
                 data = random_32_bytes();
             }
             KeyPair(keypair)
+        };
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let sk = kp.secret_key();
+            let pk = kp.public_key();
+
+            let mut target = [0_u8; 64];
+            let hex = crate::to_hex(&data, &mut target).expect("failed to encode hex data");
+
+            crate::log!("Created keypair from random data: data={} {:?} {:?} {:?}",
+                        hex, kp, sk, pk);
         }
+
+        kp
     }
 
     /// Generates a new random secret key using the global [`SECP256K1`] context.
@@ -1093,7 +1169,7 @@ impl serde::Serialize for KeyPair {
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for KeyPair {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        if d.is_human_readable() {
+        let kp = if d.is_human_readable() {
             d.deserialize_str(super::serde_util::FromStrVisitor::new(
                 "a hex string representing 32 byte KeyPair"
             ))
@@ -1115,7 +1191,18 @@ impl<'de> serde::Deserialize<'de> for KeyPair {
                 }
             );
             d.deserialize_tuple(constants::SECRET_KEY_SIZE, visitor)
+        }?;
+
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let sk = kp.secret_key();
+            let pk = kp.public_key();
+
+            crate::log!("Deserialized keypair: {:?} {:?}", sk, pk);
         }
+
+        Ok(kp)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,8 @@ mod macros;
 #[macro_use]
 mod secret;
 mod context;
+#[macro_use]
+mod logging;
 mod key;
 
 pub mod constants;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,31 @@
+//! Provides debug logging.
+//!
+//! WARNING: Logging leaks secret information and is provided for debugging purposes only.
+//!
+//! DO NOT ENABLE LOGGING IN PRODUCTION SYSTEMS.
+//!
+
+use std::fs::File;
+use std::sync::Mutex;
+
+#[allow(dead_code)] // When danger-leak-secret-material not enabled.
+pub static LOGFILE: Mutex<Option<File>> = Mutex::new(None);
+
+#[allow(dead_code)] // When danger-leak-secret-material not enabled.
+pub const CRYPTO_DEBUG_FILE: &str = "/tmp/rust-secp256k1.log";
+
+/// Logs a format string to `CRYPTO_DEBUG_FILE`.
+#[cfg(feature = "danger-leak-secret-material")]
+#[macro_export]
+macro_rules! log {
+    ($fmt:literal, $($args:tt),*) => {
+        log::info!($fmt, $($args),*)
+    }
+}
+
+/// No-op when `danger-leak-secret-material` feature is not enabled.
+#[cfg(not(feature = "danger-leak-secret-material"))]
+#[macro_export]
+macro_rules! log {
+    ($fmt:literal, $($args:tt),*) => {}
+}

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -98,13 +98,14 @@ impl Signature {
 }
 
 impl<C: Signing> Secp256k1<C> {
+    #[allow(clippy::let_and_return)] // When feature danger-leak-secret-material not enabled.
     fn sign_schnorr_helper(
         &self,
         msg: &Message,
         keypair: &KeyPair,
         nonce_data: *const ffi::types::c_uchar,
     ) -> Signature {
-        unsafe {
+        let sig = unsafe {
             let mut sig = [0u8; constants::SCHNORR_SIGNATURE_SIZE];
             assert_eq!(
                 1,
@@ -118,7 +119,15 @@ impl<C: Signing> Secp256k1<C> {
             );
 
             Signature(sig)
+        };
+
+        #[cfg(feature = "danger-leak-secret-material")]
+        {
+            let pk = keypair.public_key();
+            crate::log!("Schnorr signing message: {:?} {:?} sig={}", pk, msg, sig);
         }
+
+        sig
     }
 
     /// Create a schnorr signature internally using the ThreadRng random number


### PR DESCRIPTION
Draft for initial feedback, this is similar to #496 but uses the `log` crate and `env_logger` in an example module. 

In order to facilitate debugging add feature gated logging infrastructure. Logging leaks secret material so name the feature appropriately and include warning in docs.

During signing (ECDSA and Schnoor) log the following:

- The pubkey being used
- The message being signed
- The resulting signature

Any time we create a private key (incl. keypair) log the following:

- Any input data
- The resulting private key
- The associated public key