### PR TITLE
Use clang instead of clang-9

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout Crate
         uses: actions/checkout@v2
       - name: Install clang
-        run: sudo apt-get install -y clang-9
+        run: sudo apt-get install -y clang
       - name: Checkout Toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -69,11 +69,11 @@ fi
 
 # Webassembly stuff
 if [ "$DO_WASM" = true ]; then
-    clang-9 --version
+    clang --version
     CARGO_TARGET_DIR=wasm cargo install --force wasm-pack
     printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml
-    CC=clang-9 wasm-pack build
-    CC=clang-9 wasm-pack test --node
+    CC=clang wasm-pack build
+    CC=clang wasm-pack test --node
 fi
 
 # Address Sanitizer


### PR DESCRIPTION
The current version of clang is 14, there is no obvious reason why we use clang-9 (as far as I can tell on my local machine).

Use `clang` instead of `clang-9` so that the latest version is used by default. This effects the version installed by CI as well as the version used to run commands in `test.sh`.