### PR TITLE
Clean up `impl_array_newtype` macro

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -117,7 +117,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     assert_eq!(rec_sig, new_rec_sig);
 
     let mut cbor_ser = [0u8; 100];
-    let writer = SliceWrite::new(&mut cbor_ser[..]);
+    let writer = SliceWrite::new(&mut cbor_ser);
     let mut ser = Serializer::new(writer);
     sig.serialize(&mut ser).unwrap();
     let size = ser.into_inner().bytes_written();

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -785,9 +785,9 @@ mod fuzz_dummy {
                 if have_ctx == HAVE_CONTEXT_NONE {
                     assert!(rustsecp256k1_v0_6_1_context_preallocated_size(SECP256K1_START_SIGN | SECP256K1_START_VERIFY) + std::mem::size_of::<c_uint>() <= CTX_SIZE);
                     assert_eq!(rustsecp256k1_v0_6_1_context_preallocated_create(
-                            PREALLOCATED_CONTEXT[..].as_ptr() as *mut c_void,
+                            PREALLOCATED_CONTEXT.as_ptr() as *mut c_void,
                             SECP256K1_START_SIGN | SECP256K1_START_VERIFY),
-                        PREALLOCATED_CONTEXT[..].as_ptr() as *mut Context);
+                        PREALLOCATED_CONTEXT.as_ptr() as *mut Context);
                     assert_eq!(HAVE_PREALLOCATED_CONTEXT.swap(HAVE_CONTEXT_DONE, Ordering::AcqRel),
                         HAVE_CONTEXT_WORKING);
                 } else if have_ctx == HAVE_CONTEXT_DONE {
@@ -802,7 +802,7 @@ mod fuzz_dummy {
                 std::thread::yield_now();
             }
         }
-        ptr::copy_nonoverlapping(PREALLOCATED_CONTEXT[..].as_ptr(), prealloc as *mut u8, CTX_SIZE);
+        ptr::copy_nonoverlapping(PREALLOCATED_CONTEXT.as_ptr(), prealloc as *mut u8, CTX_SIZE);
         let ptr = (prealloc as *mut u8).add(CTX_SIZE).sub(std::mem::size_of::<c_uint>());
         (ptr as *mut c_uint).write(flags);
         prealloc as *mut Context
@@ -1192,7 +1192,7 @@ mod fuzz_dummy {
         let mut sk = [0u8; 32];
         sk.copy_from_slice(&(*keypair).0[..32]);
         assert_eq!(secp256k1_ec_pubkey_tweak_add(cx, &mut pk, tweak32), 1);
-        assert_eq!(secp256k1_ec_seckey_tweak_add(cx, (&mut sk[..]).as_mut_ptr(), tweak32), 1);
+        assert_eq!(secp256k1_ec_seckey_tweak_add(cx, (&mut sk).as_mut_ptr(), tweak32), 1);
         (*keypair).0[..32].copy_from_slice(&sk);
         (*keypair).0[32..].copy_from_slice(&pk.0);
         1

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -132,6 +132,7 @@ impl SchnorrSigExtraParams {
 #[repr(C)] pub struct Context(c_int);
 
 /// Library-internal representation of a Secp256k1 public key
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct PublicKey([c_uchar; 64]);
 impl_array_newtype!(PublicKey, c_uchar, 64);
@@ -172,6 +173,7 @@ impl PublicKey {
 }
 
 /// Library-internal representation of a Secp256k1 signature
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct Signature([c_uchar; 64]);
 impl_array_newtype!(Signature, c_uchar, 64);
@@ -211,6 +213,7 @@ impl Signature {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct XOnlyPublicKey([c_uchar; 64]);
 impl_array_newtype!(XOnlyPublicKey, c_uchar, 64);
@@ -250,6 +253,7 @@ impl XOnlyPublicKey {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct KeyPair([c_uchar; 96]);
 impl_array_newtype!(KeyPair, c_uchar, 96);

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -50,55 +50,16 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl core::ops::Index<usize> for $thing {
-            type Output = $ty;
+        impl<I> core::ops::Index<I> for $thing
+        where
+            [$ty]: core::ops::Index<I>,
+        {
+            type Output = <[$ty] as core::ops::Index<I>>::Output;
 
             #[inline]
-            fn index(&self, index: usize) -> &$ty {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
+            fn index(&self, index: I) -> &Self::Output { &self.0[index] }
         }
 
-        impl core::ops::Index<core::ops::Range<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: core::ops::Range<usize>) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
-        }
-
-        impl core::ops::Index<core::ops::RangeTo<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: core::ops::RangeTo<usize>) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
-        }
-
-        impl core::ops::Index<core::ops::RangeFrom<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: core::ops::RangeFrom<usize>) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
-        }
-
-        impl core::ops::Index<core::ops::RangeFull> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, _: core::ops::RangeFull) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[..]
-            }
-        }
         impl $crate::CPtr for $thing {
             type Target = $ty;
             fn as_c_ptr(&self) -> *const Self::Target {

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -17,8 +17,6 @@
 #[macro_export]
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {
-        impl Copy for $thing {}
-
         impl $thing {
             /// Converts the object to a raw pointer for FFI interfacing
             #[inline]
@@ -49,43 +47,6 @@ macro_rules! impl_array_newtype {
             fn as_ref(&self) -> &[$ty; $len] {
                 let &$thing(ref dat) = self;
                 dat
-            }
-        }
-
-        impl PartialEq for $thing {
-            #[inline]
-            fn eq(&self, other: &$thing) -> bool {
-                &self[..] == &other[..]
-            }
-        }
-
-        impl Eq for $thing {}
-
-        impl ::core::hash::Hash for $thing {
-            fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
-                (&self[..]).hash(state)
-            }
-        }
-
-        impl PartialOrd for $thing {
-            #[inline]
-            fn partial_cmp(&self, other: &$thing) -> Option<core::cmp::Ordering> {
-                self[..].partial_cmp(&other[..])
-            }
-        }
-
-        impl Ord for $thing {
-            #[inline]
-            fn cmp(&self, other: &$thing) -> core::cmp::Ordering {
-                self[..].cmp(&other[..])
-            }
-        }
-
-        impl Clone for $thing {
-            #[inline]
-            fn clone(&self) -> $thing {
-                let &$thing(ref dat) = self;
-                $thing(dat.clone())
             }
         }
 

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -39,15 +39,15 @@ macro_rules! impl_array_newtype {
             /// Returns whether the object as an array is empty
             #[inline]
             pub fn is_empty(&self) -> bool { false }
-        }
 
-        impl AsRef<[$ty; $len]> for $thing {
+            /// Returns a reference the underlying bytes.
             #[inline]
-            /// Gets a reference to the underlying array
-            fn as_ref(&self) -> &[$ty; $len] {
-                let &$thing(ref dat) = self;
-                dat
-            }
+            pub fn as_bytes(&self) -> &[$ty; $len] { &self.0 }
+
+            /// Returns a clone of the underlying bytes.
+            #[inline]
+            pub fn to_bytes(self) -> [$ty; $len] { self.0.clone() }
+
         }
 
         impl<I> core::ops::Index<I> for $thing

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -13,30 +13,30 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-// This is a macro that routinely comes in handy
+/// Implement methods and traits for types that contain an inner array.
 #[macro_export]
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {
         impl $thing {
-            /// Converts the object to a raw pointer for FFI interfacing
+            /// Converts the object to a raw pointer for FFI interfacing.
             #[inline]
             pub fn as_ptr(&self) -> *const $ty {
                 let &$thing(ref dat) = self;
                 dat.as_ptr()
             }
 
-            /// Converts the object to a mutable raw pointer for FFI interfacing
+            /// Converts the object to a mutable raw pointer for FFI interfacing.
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $ty {
                 let &mut $thing(ref mut dat) = self;
                 dat.as_mut_ptr()
             }
 
-            /// Returns the length of the object as an array
+            /// Returns the length of the object as an array.
             #[inline]
             pub fn len(&self) -> usize { $len }
 
-            /// Returns whether the object as an array is empty
+            /// Returns whether the object as an array is empty.
             #[inline]
             pub fn is_empty(&self) -> bool { false }
 

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -86,7 +86,7 @@ macro_rules! impl_raw_debug {
     ($thing:ident) => {
         impl core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                for i in self[..].iter().cloned() {
+                for i in self.to_bytes().iter() {
                     write!(f, "{:02x}", i)?;
                 }
                 Ok(())

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -20,6 +20,7 @@ use crate::types::*;
 use core::fmt;
 
 /// Library-internal representation of a Secp256k1 signature + recovery ID
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct RecoverableSignature([c_uchar; 65]);
 impl_array_newtype!(RecoverableSignature, c_uchar, 65);

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -82,7 +82,7 @@ impl SharedSecret {
         match bytes.len() {
             SHARED_SECRET_SIZE => {
                 let mut ret = [0u8; SHARED_SECRET_SIZE];
-                ret[..].copy_from_slice(bytes);
+                ret.copy_from_slice(bytes);
                 Ok(SharedSecret(ret))
             }
             _ => Err(Error::InvalidSharedSecret)
@@ -276,7 +276,7 @@ mod tests {
 
         let secret = SharedSecret::from_slice(&BYTES).unwrap();
 
-        assert_tokens(&secret.compact(), &[Token::BorrowedBytes(&BYTES[..])]);
+        assert_tokens(&secret.compact(), &[Token::BorrowedBytes(&BYTES)]);
         assert_tokens(&secret.compact(), &[Token::Bytes(&BYTES)]);
         assert_tokens(&secret.compact(), &[Token::ByteBuf(&BYTES)]);
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -434,7 +434,7 @@ mod tests {
         ).unwrap();
         let (recid_out, bytes_out) = sig.serialize_compact();
         assert_eq!(recid_in, recid_out);
-        assert_eq!(&bytes_in[..], &bytes_out[..]);
+        assert_eq!(bytes_in, &bytes_out);
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -109,7 +109,7 @@ pub struct PublicKey(ffi::PublicKey);
 impl fmt::LowerHex for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ser = self.serialize();
-        for ch in &ser[..] {
+        for ch in &ser {
             write!(f, "{:02x}", *ch)?;
         }
         Ok(())
@@ -1149,7 +1149,7 @@ pub struct XOnlyPublicKey(ffi::XOnlyPublicKey);
 impl fmt::LowerHex for XOnlyPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ser = self.serialize();
-        for ch in &ser[..] {
+        for ch in &ser {
             write!(f, "{:02x}", *ch)?;
         }
         Ok(())
@@ -1700,9 +1700,9 @@ mod test {
         let s = Secp256k1::new();
 
         let (sk1, pk1) = s.generate_keypair(&mut thread_rng());
-        assert_eq!(SecretKey::from_slice(&sk1[..]), Ok(sk1));
-        assert_eq!(PublicKey::from_slice(&pk1.serialize()[..]), Ok(pk1));
-        assert_eq!(PublicKey::from_slice(&pk1.serialize_uncompressed()[..]), Ok(pk1));
+        assert_eq!(SecretKey::from_slice(sk1.as_bytes()), Ok(sk1));
+        assert_eq!(PublicKey::from_slice(&pk1.serialize()), Ok(pk1));
+        assert_eq!(PublicKey::from_slice(&pk1.serialize_uncompressed()), Ok(pk1));
     }
 
     #[test]
@@ -1749,7 +1749,7 @@ mod test {
                     0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b,
                     0xbf, 0xd2, 0x5e, 0x8c, 0xd0, 0x36, 0x41, 0x41];
                 assert_eq!(data.len(), 32);
-                data.copy_from_slice(&group_order[..]);
+                data.copy_from_slice(&group_order);
                 data[31] = self.0;
                 self.0 -= 1;
             }
@@ -1835,7 +1835,7 @@ mod test {
                    "SecretKey(#d3e0c51a23169bb5)");
 
         let mut buf = [0u8; constants::SECRET_KEY_SIZE * 2];
-        assert_eq!(to_hex(&sk[..], &mut buf).unwrap(),
+        assert_eq!(to_hex(sk.as_bytes(), &mut buf).unwrap(),
                    "0100000000000000020000000000000003000000000000000400000000000000");
     }
 
@@ -1909,10 +1909,10 @@ mod test {
 
         let s = Secp256k1::new();
         let (_, pk1) = s.generate_keypair(&mut StepRng::new(1,1));
-        assert_eq!(&pk1.serialize_uncompressed()[..],
-                   &[4, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229, 185, 28, 165, 110, 27, 3, 162, 126, 238, 167, 157, 242, 221, 76, 251, 237, 34, 231, 72, 39, 245, 3, 191, 64, 111, 170, 117, 103, 82, 28, 102, 163][..]);
-        assert_eq!(&pk1.serialize()[..],
-                   &[3, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229][..]);
+        assert_eq!(&pk1.serialize_uncompressed(),
+                   &[4, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229, 185, 28, 165, 110, 27, 3, 162, 126, 238, 167, 157, 242, 221, 76, 251, 237, 34, 231, 72, 39, 245, 3, 191, 64, 111, 170, 117, 103, 82, 28, 102, 163]);
+        assert_eq!(&pk1.serialize(),
+                   &[3, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229]);
     }
 
     #[test]
@@ -2218,8 +2218,8 @@ mod test {
         let pk1 = XOnlyPublicKey::from(kpk1);
         let pk2 = XOnlyPublicKey::from(kpk2);
 
-        assert_eq!(pk1.serialize()[..], kpk1.serialize()[1..]);
-        assert_eq!(pk2.serialize()[..], kpk2.serialize()[1..]);
+        assert_eq!(pk1.serialize(), kpk1.serialize()[1..]);
+        assert_eq!(pk2.serialize(), kpk2.serialize()[1..]);
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -933,7 +933,7 @@ impl KeyPair {
     /// Returns the secret bytes for this key pair.
     #[inline]
     pub fn secret_bytes(&self) -> [u8; constants::SECRET_KEY_SIZE] {
-        *SecretKey::from_keypair(self).as_ref()
+        *SecretKey::from_keypair(self).as_bytes()
     }
 
     /// Tweaks a keypair by adding the given tweak to the secret key and updating the public key

--- a/src/key.rs
+++ b/src/key.rs
@@ -56,6 +56,7 @@ use crate::Scalar;
 /// ```
 /// [`bincode`]: https://docs.rs/bincode
 /// [`cbor`]: https://docs.rs/cbor
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SecretKey([u8; constants::SECRET_KEY_SIZE]);
 impl_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE);
 impl_display_secret!(SecretKey);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,7 @@ impl<T: hashes::sha256t::Tag> ThirtyTwoByteHash for hashes::sha256t::Hash<T> {
 }
 
 /// A (hashed) message input to an ECDSA signature.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Message([u8; constants::MESSAGE_SIZE]);
 impl_array_newtype!(Message, u8, constants::MESSAGE_SIZE);
 impl_pretty_debug!(Message);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ impl Message {
         match data.len() {
             constants::MESSAGE_SIZE => {
                 let mut ret = [0u8; constants::MESSAGE_SIZE];
-                ret[..].copy_from_slice(data);
+                ret.copy_from_slice(data);
                 Ok(Message(ret))
             }
             _ => Err(Error::InvalidMessage)
@@ -692,7 +692,7 @@ mod tests {
         assert!(full.verify_ecdsa(&msg, &sig, &pk).is_ok());
 
         // Check that we can produce keys from slices with no precomputation
-        let (pk_slice, sk_slice) = (&pk.serialize(), &sk[..]);
+        let (pk_slice, sk_slice) = (&pk.serialize(), sk.as_bytes());
         let new_pk = PublicKey::from_slice(pk_slice).unwrap();
         let new_sk = SecretKey::from_slice(sk_slice).unwrap();
         assert_eq!(sk, new_sk);
@@ -713,16 +713,16 @@ mod tests {
             let (sk, _) = s.generate_keypair(&mut thread_rng());
             let sig1 = s.sign_ecdsa(&msg, &sk);
             let der = sig1.serialize_der();
-            let sig2 = ecdsa::Signature::from_der(&der[..]).unwrap();
+            let sig2 = ecdsa::Signature::from_der(&der).unwrap();
             assert_eq!(sig1, sig2);
 
             let compact = sig1.serialize_compact();
-            let sig2 = ecdsa::Signature::from_compact(&compact[..]).unwrap();
+            let sig2 = ecdsa::Signature::from_compact(&compact).unwrap();
             assert_eq!(sig1, sig2);
 
-            assert!(ecdsa::Signature::from_compact(&der[..]).is_err());
+            assert!(ecdsa::Signature::from_compact(&der).is_err());
             assert!(ecdsa::Signature::from_compact(&compact[0..4]).is_err());
-            assert!(ecdsa::Signature::from_der(&compact[..]).is_err());
+            assert!(ecdsa::Signature::from_der(&compact).is_err());
             assert!(ecdsa::Signature::from_der(&der[0..4]).is_err());
          }
     }
@@ -773,7 +773,7 @@ mod tests {
         macro_rules! check_lax_sig(
             ($hex:expr) => ({
                 let sig = hex!($hex);
-                assert!(ecdsa::Signature::from_der_lax(&sig[..]).is_ok());
+                assert!(ecdsa::Signature::from_der_lax(&sig).is_ok());
             })
         );
 
@@ -836,14 +836,14 @@ mod tests {
         wild_msgs[0][0] = 1;
 
         use constants;
-        wild_keys[1][..].copy_from_slice(&constants::CURVE_ORDER[..]);
-        wild_msgs[1][..].copy_from_slice(&constants::CURVE_ORDER[..]);
+        wild_keys[1].copy_from_slice(&constants::CURVE_ORDER);
+        wild_msgs[1].copy_from_slice(&constants::CURVE_ORDER);
 
         wild_keys[1][0] -= 1;
         wild_msgs[1][0] -= 1;
 
-        for key in wild_keys.iter().map(|k| SecretKey::from_slice(&k[..]).unwrap()) {
-            for msg in wild_msgs.iter().map(|m| Message::from_slice(&m[..]).unwrap()) {
+        for key in wild_keys.iter().map(|k| SecretKey::from_slice(k).unwrap()) {
+            for msg in wild_msgs.iter().map(|m| Message::from_slice(m).unwrap()) {
                 let sig = s.sign_ecdsa(&msg, &key);
                 let low_r_sig = s.sign_ecdsa_low_r(&msg, &key);
                 let grind_r_sig = s.sign_ecdsa_grind_r(&msg, &key, 1);
@@ -945,9 +945,9 @@ mod tests {
         let msg = hex!("a4965ca63b7d8562736ceec36dfa5a11bf426eb65be8ea3f7a49ae363032da0d");
 
         let secp = Secp256k1::new();
-        let mut sig = ecdsa::Signature::from_der(&sig[..]).unwrap();
-        let pk = PublicKey::from_slice(&pk[..]).unwrap();
-        let msg = Message::from_slice(&msg[..]).unwrap();
+        let mut sig = ecdsa::Signature::from_der(&sig).unwrap();
+        let pk = PublicKey::from_slice(&pk).unwrap();
+        let msg = Message::from_slice(&msg).unwrap();
 
         // without normalization we expect this will fail
         assert_eq!(secp.verify_ecdsa(&msg, &sig, &pk), Err(Error::IncorrectSignature));
@@ -1011,7 +1011,7 @@ mod tests {
             4b02202876e7102f204f6bfee26c967c3926ce702cf97d4b010062e193f763190f6776\
         ";
 
-        assert_tokens(&sig.compact(), &[Token::BorrowedBytes(&SIG_BYTES[..])]);
+        assert_tokens(&sig.compact(), &[Token::BorrowedBytes(&SIG_BYTES)]);
         assert_tokens(&sig.compact(), &[Token::Bytes(&SIG_BYTES)]);
         assert_tokens(&sig.compact(), &[Token::ByteBuf(&SIG_BYTES)]);
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,7 +18,7 @@ macro_rules! impl_pretty_debug {
         impl core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}(", stringify!($thing))?;
-                for i in &self[..] {
+                for i in self.to_bytes().iter() {
                     write!(f, "{:02x}", i)?;
                 }
                 f.write_str(")")

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -15,6 +15,7 @@ use crate::ffi::{self, CPtr, impl_array_newtype};
 use crate::SECP256K1;
 
 /// Represents a Schnorr signature.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Signature([u8; constants::SCHNORR_SIGNATURE_SIZE]);
 impl_array_newtype!(Signature, u8, constants::SCHNORR_SIGNATURE_SIZE);
 impl_pretty_debug!(Signature);

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -26,7 +26,7 @@ impl serde::Serialize for Signature {
         if s.is_human_readable() {
             s.collect_str(self)
         } else {
-            s.serialize_bytes(&self[..])
+            s.serialize_bytes(self.as_bytes())
         }
     }
 }
@@ -49,7 +49,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
 
 impl fmt::LowerHex for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for ch in &self.0[..] {
+        for ch in &self.0 {
             write!(f, "{:02x}", ch)?;
         }
         Ok(())
@@ -82,7 +82,7 @@ impl Signature {
         match data.len() {
             constants::SCHNORR_SIGNATURE_SIZE => {
                 let mut ret = [0u8; constants::SCHNORR_SIGNATURE_SIZE];
-                ret[..].copy_from_slice(data);
+                ret.copy_from_slice(data);
                 Ok(Signature(ret))
             }
             _ => Err(Error::InvalidSignature),
@@ -521,11 +521,11 @@ mod tests {
         let kp = KeyPair::new(&secp, &mut StepRng::new(1, 1));
         let (pk, _parity) = kp.x_only_public_key();
         assert_eq!(
-            &pk.serialize()[..],
+            &pk.serialize(),
             &[
                 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9,
                 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229
-            ][..]
+            ]
         );
     }
 
@@ -560,9 +560,9 @@ mod tests {
         static PK_STR: &str = "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
         let pk = XOnlyPublicKey::from_slice(&PK_BYTES).unwrap();
 
-        assert_tokens(&sig.compact(), &[Token::BorrowedBytes(&SIG_BYTES[..])]);
-        assert_tokens(&sig.compact(), &[Token::Bytes(&SIG_BYTES[..])]);
-        assert_tokens(&sig.compact(), &[Token::ByteBuf(&SIG_BYTES[..])]);
+        assert_tokens(&sig.compact(), &[Token::BorrowedBytes(&SIG_BYTES)]);
+        assert_tokens(&sig.compact(), &[Token::Bytes(&SIG_BYTES)]);
+        assert_tokens(&sig.compact(), &[Token::ByteBuf(&SIG_BYTES)]);
 
         assert_tokens(&sig.readable(), &[Token::BorrowedStr(SIG_STR)]);
         assert_tokens(&sig.readable(), &[Token::Str(SIG_STR)]);

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -52,8 +52,8 @@ macro_rules! impl_display_secret {
 
                 let mut engine = sha256::Hash::engine();
                 let tag_hash = sha256::Hash::hash(tag.as_bytes());
-                engine.input(&tag_hash[..]);
-                engine.input(&tag_hash[..]);
+                engine.input(&tag_hash);
+                engine.input(&tag_hash);
                 engine.input(&self.secret_bytes());
                 let hash = sha256::Hash::from_engine(engine);
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -80,7 +80,7 @@ fn cbor() {
     let sk = secret_key();
 
     let mut e = cbor::Encoder::from_memory();
-    e.encode(sk.as_ref()).unwrap();
+    e.encode(sk.as_bytes()).unwrap();
 
     // 52 because there are 22 bytes in the key for which cbor adds metadata.
     assert_eq!(e.as_bytes().len(), 52);


### PR DESCRIPTION
Clean up `impl_array_newtype` macro by doing:
- Use derive where possible
- Use generic `Index` implementation
- Remove `AsRef` in favour of `as_bytes` and `into_bytes`
- Improve the docs

If this PR interests you please see https://github.com/rust-bitcoin/rust-secp256k1/issues/501 for further discussion on the macro.