### PR TITLE
Use generic implementation of `core::ops::Index`

### DIFF
--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -13,32 +13,32 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-// This is a macro that routinely comes in handy
+/// Implement methods and traits for types that contain an inner array.
 #[macro_export]
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {
         impl Copy for $thing {}
 
         impl $thing {
-            /// Converts the object to a raw pointer for FFI interfacing
+            /// Converts the object to a raw pointer for FFI interfacing.
             #[inline]
             pub fn as_ptr(&self) -> *const $ty {
                 let &$thing(ref dat) = self;
                 dat.as_ptr()
             }
 
-            /// Converts the object to a mutable raw pointer for FFI interfacing
+            /// Converts the object to a mutable raw pointer for FFI interfacing.
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $ty {
                 let &mut $thing(ref mut dat) = self;
                 dat.as_mut_ptr()
             }
 
-            /// Returns the length of the object as an array
+            /// Returns the length of the object as an array.
             #[inline]
             pub fn len(&self) -> usize { $len }
 
-            /// Returns whether the object as an array is empty
+            /// Returns whether the object as an array is empty.
             #[inline]
             pub fn is_empty(&self) -> bool { false }
         }

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -89,55 +89,16 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl core::ops::Index<usize> for $thing {
-            type Output = $ty;
+        impl<I> core::ops::Index<I> for $thing
+        where
+            [$ty]: core::ops::Index<I>,
+        {
+            type Output = <[$ty] as core::ops::Index<I>>::Output;
 
             #[inline]
-            fn index(&self, index: usize) -> &$ty {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
+            fn index(&self, index: I) -> &Self::Output { &self.0[index] }
         }
 
-        impl core::ops::Index<core::ops::Range<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: core::ops::Range<usize>) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
-        }
-
-        impl core::ops::Index<core::ops::RangeTo<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: core::ops::RangeTo<usize>) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
-        }
-
-        impl core::ops::Index<core::ops::RangeFrom<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: core::ops::RangeFrom<usize>) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[index]
-            }
-        }
-
-        impl core::ops::Index<core::ops::RangeFull> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, _: core::ops::RangeFull) -> &[$ty] {
-                let &$thing(ref dat) = self;
-                &dat[..]
-            }
-        }
         impl $crate::CPtr for $thing {
             type Target = $ty;
             fn as_c_ptr(&self) -> *const Self::Target {


### PR DESCRIPTION
Instead of all the manual implementations of `Index` for ranged types we can just use a generic implementation as we do in `rust-bitcoin/internals/src/macros.rs`.

Patch 2 does some trivial docs improvements to the `impl_array_newtype` macro since we are touching it anyways.