### PR TITLE
Add array constants

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -83,4 +83,10 @@ pub const GENERATOR_Y: [u8; 32] = [
     0x9c, 0x47, 0xd0, 0x8f, 0xfb, 0x10, 0xd4, 0xb8
 ];
 
+/// The value zero as an array of bytes.
+pub const ZERO: [u8; 32] = [0; 32];
 
+/// The value one as big-endian array of bytes.
+pub const ONE: [u8; 32] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+];

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -236,6 +236,7 @@ mod tests {
     use rand::{RngCore, thread_rng};
 
     use crate::{Error, SecretKey, Secp256k1, Message};
+    use crate::constants::ONE;
     use super::{RecoveryId, RecoverableSignature};
 
     #[cfg(target_arch = "wasm32")]
@@ -280,13 +281,12 @@ mod tests {
     fn sign() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
-        let one: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
-        let sk = SecretKey::from_slice(&one).unwrap();
-        let msg = Message::from_slice(&one).unwrap();
+        let sk = SecretKey::from_slice(&ONE).unwrap();
+        let msg = Message::from_slice(&ONE).unwrap();
 
         let sig = s.sign_ecdsa_recoverable(&msg, &sk);
+
         assert_eq!(Ok(sig), RecoverableSignature::from_compact(&[
             0x66, 0x73, 0xff, 0xad, 0x21, 0x47, 0x74, 0x1f,
             0x04, 0x77, 0x2b, 0x6f, 0x92, 0x1f, 0x0b, 0xa6,
@@ -305,14 +305,13 @@ mod tests {
     fn sign_with_noncedata() {
         let mut s = Secp256k1::new();
         s.randomize(&mut thread_rng());
-        let one: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
-        let sk = SecretKey::from_slice(&one).unwrap();
-        let msg = Message::from_slice(&one).unwrap();
+        let sk = SecretKey::from_slice(&ONE).unwrap();
+        let msg = Message::from_slice(&ONE).unwrap();
         let noncedata = [42u8; 32];
 
         let sig = s.sign_ecdsa_recoverable_with_noncedata(&msg, &sk, &noncedata);
+
         assert_eq!(Ok(sig), RecoverableSignature::from_compact(&[
             0xb5, 0x0b, 0xb6, 0x79, 0x5f, 0x31, 0x74, 0x8a,
             0x4d, 0x37, 0xc3, 0xa9, 0x7e, 0xbd, 0x06, 0xa2,

--- a/src/key.rs
+++ b/src/key.rs
@@ -72,10 +72,7 @@ impl str::FromStr for SecretKey {
 }
 
 /// The number 1 encoded as a secret key.
-pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 0, 0, 0, 1]);
+pub const ONE_KEY: SecretKey = SecretKey(constants::ONE);
 
 /// A Secp256k1 public key, used for verification of signatures.
 ///

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -7,6 +7,8 @@
 
 use core::fmt;
 
+use crate::constants;
+
 /// Positive 256-bit integer guaranteed to be less than the secp256k1 curve order.
 ///
 /// The difference between `PrivateKey` and `Scalar` is that `Scalar` doesn't guarantee being
@@ -28,9 +30,9 @@ const MAX_RAW: [u8; 32] = [
 
 impl Scalar {
     /// Scalar representing `0`
-    pub const ZERO: Scalar = Scalar([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    pub const ZERO: Scalar = Scalar(constants::ZERO);
     /// Scalar representing `1`
-    pub const ONE: Scalar = Scalar([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    pub const ONE: Scalar = Scalar(constants::ONE);
     /// Maximum valid value: `curve_order - 1`
     pub const MAX: Scalar = Scalar(MAX_RAW);
 


### PR DESCRIPTION
In multiple places we use array constants for zero and one. Add two constants and use them throughout the codebase. Note the endian-ness of `ONE` in the docs.