### PR TITLE
Manually implement `PartialEq`, `Eq`, and `Hash` for `PublicKey`

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -100,8 +100,8 @@ pub const ONE_KEY: SecretKey = SecretKey(constants::ONE);
 /// ```
 /// [`bincode`]: https://docs.rs/bincode
 /// [`cbor`]: https://docs.rs/cbor
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
-#[cfg_attr(fuzzing, derive(PartialOrd, Ord))]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 #[repr(transparent)]
 pub struct PublicKey(ffi::PublicKey);
 
@@ -811,6 +811,24 @@ impl Ord for PublicKey {
             ffi::secp256k1_ec_pubkey_cmp(ffi::secp256k1_context_no_precomp, self.as_c_ptr(), other.as_c_ptr())
         };
         ret.cmp(&0i32)
+    }
+}
+
+#[cfg(not(fuzzing))]
+impl PartialEq for PublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == core::cmp::Ordering::Equal
+    }
+}
+
+#[cfg(not(fuzzing))]
+impl Eq for PublicKey {}
+
+#[cfg(not(fuzzing))]
+impl core::hash::Hash for PublicKey {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        let ser = self.serialize();
+        ser.hash(state);
     }
 }
 


### PR DESCRIPTION
`PartialEq` and `Eq` should agree with `PartialOrd` and `Ord` but we are deriving `PartialEq`/`Eq` and doing a custom implementation of `PartialOrd` and `Ord` (that calls down to ffi functions).
    
If two keys are equal their hashes should be equal so, we should add a custom implementation of `Hash` also. In order to guarantee the digest will be the same across library versions first serialize the key before hashing it.
    
Add custom implementation of `PartialEq`, `Eq`, and `Hash` when not fuzzing.
    
Please note, this is for the main `PublicKey` type, the patch does not effect the `ffi::PublicKey`, nor do we call methods on the `ffi::PublicKey`.

EDIT: Please note the comment below by apoelstra about the possible performance hit introduced by this PR.