### PR TITLE
Fix incorrect method call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! If the "global-context" feature is enabled you have access to an alternate API.
 //!
 //! ```rust
-//! # #[cfg(all(feature="global-context", feature = "std", feature="rand-std", features = "bitcoin-hashes-std"))] {
+//! # #[cfg(all(feature = "global-context", feature = "std", feature = "rand-std", feature = "bitcoin-hashes-std"))] {
 //! use secp256k1::rand::thread_rng;
 //! use secp256k1::{generate_keypair, Message};
 //! use secp256k1::hashes::sha256;
@@ -66,7 +66,7 @@
 //! let (secret_key, public_key) = generate_keypair(&mut thread_rng());
 //! let message = Message::from_hashed_data::<sha256::Hash>("Hello World!".as_bytes());
 //!
-//! let sig = secret_key.sign_ecdsa(&message, &secret_key);
+//! let sig = secret_key.sign_ecdsa(message);
 //! assert!(sig.verify(&message, &public_key).is_ok());
 //! # }
 //! ```


### PR DESCRIPTION
We have the following method on `SecretKey`

```
    pub fn sign_ecdsa(&self, msg: Message) -> ecdsa::Signature {
        SECP256K1.sign_ecdsa(&msg, self)
    }
```

But we have a method call in rustdocs
```
//! let (secret_key, public_key) = generate_keypair(&mut thread_rng());
//! let message = Message::from_hashed_data::<sha256::Hash>("Hello World!".as_bytes());
//!
//! let sig = secret_key.sign_ecdsa(&message, &secret_key);
```

This is incorrect, I have no idea why this code builds.

(Also see https://github.com/rust-bitcoin/rust-secp256k1/issues/508.)