### PR TITLE
Remove derives for ffi wrapped types

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -23,6 +23,7 @@ use crate::SECP256K1;
 #[derive(Copy, Clone)]
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 pub struct Signature(pub(crate) ffi::Signature);
+impl_fast_comparisons!(Signature);
 
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/key.rs
+++ b/src/key.rs
@@ -104,6 +104,7 @@ pub const ONE_KEY: SecretKey = SecretKey(constants::ONE);
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 #[repr(transparent)]
 pub struct PublicKey(ffi::PublicKey);
+impl_fast_comparisons!(PublicKey);
 
 impl fmt::LowerHex for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -802,6 +803,7 @@ impl core::hash::Hash for PublicKey {
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 pub struct KeyPair(ffi::KeyPair);
 impl_display_secret!(KeyPair);
+impl_fast_comparisons!(KeyPair);
 
 impl KeyPair {
     /// Obtains a raw const pointer suitable for use with FFI functions.
@@ -1177,6 +1179,7 @@ impl CPtr for KeyPair {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 pub struct XOnlyPublicKey(ffi::XOnlyPublicKey);
+impl_fast_comparisons!(XOnlyPublicKey);
 
 impl fmt::LowerHex for XOnlyPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,3 +45,32 @@ macro_rules! write_err {
         }
     }
 }
+
+/// Implements fast unstable versions of Ord, PartialOrd, Eq, PartialEq, and Hash.
+macro_rules! impl_fast_comparisons {
+    ($ty:ident) => {
+        impl $ty {
+            /// Equivalent to `Ord` but faster and not stable across library versions.
+            ///
+            /// The `Ord` implementation for `Self` is stable but slow because we first serialize
+            /// `self` and `other` before comparing them. The `Ord` implementation for FFI types
+            /// compares the inner bytes directly. The inner bytes are passed across the FFI boundry
+            /// and as such there are no guarantees to the layout of the bytes. The layout may
+            /// change unexpectedly between versions of the library, even minor versions.
+            pub fn cmp_fast_unstable(&self, other: &Self) -> core::cmp::Ordering {
+                self.0.cmp(&other.0)
+            }
+
+            /// Equivalent to `Eq` but faster and not stable across library versions.
+            ///
+            /// The `Eq` implementation for `Self` is stable but slow because we first serialize
+            /// `self` and `other` before comparing them. The `Eq` implementation for FFI types
+            /// compares the inner bytes directly. The inner bytes are passed across the FFI boundry
+            /// and as such there are no guarantees to the layout of the bytes. The layout may
+            /// change unexpectedly between versions of the library, even minor versions.
+            pub fn eq_fast_unstable(&self, other: &Self) -> bool {
+                self.0.eq(&other.0)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently we are deriving various traits that call down to the traits implemented in `secp265k1-sys` that in turn call down to implementations on the inner byte array. Since we cannot guarantee the inner byte arrays in `secp256k1-sys` this results in trait implementations that may not be stable across versions of the library.

For `XOnlyPublicKey`, `KeyPair`, and `ecdsa::Signature` manually implement `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` by first converting the type into a form that is guaranteed to be stable across library versions e.g., by serializing it to a known format.

EDIT: Now includes a patch to add fast unstable comparisons.

### Review notes

- Please review carefully the code and comment on the `Hash` implementation for `KeyPair` - I am not a cryptographer.
- We did the same for `PublicKey` already in https://github.com/rust-bitcoin/rust-secp256k1/pull/506