### PR TITLE
Fix broken links

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -64,7 +64,7 @@ fi
 
 # Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs" cargo doc --all --features="$FEATURES"
+    RUSTDOCFLAGS="--cfg docsrs" cargo rustdoc --features="$FEATURES" -- -D rustdoc::broken-intra-doc-links
 fi
 
 # Webassembly stuff

--- a/src/key.rs
+++ b/src/key.rs
@@ -1304,10 +1304,10 @@ impl XOnlyPublicKey {
         }
     }
 
-    /// Verifies that a tweak produced by [`XOnlyPublicKey::tweak_add_assign`] was computed correctly.
+    /// Verifies that a tweak produced by [`XOnlyPublicKey::add_tweak`] was computed correctly.
     ///
     /// Should be called on the original untweaked key. Takes the tweaked key and output parity from
-    /// [`XOnlyPublicKey::tweak_add_assign`] as input.
+    /// [`XOnlyPublicKey::add_tweak`] as input.
     ///
     /// Currently this is not much more efficient than just recomputing the tweak and checking
     /// equality. However, in future this API will support batch verification, which is


### PR DESCRIPTION
- Patch 1: Fix broken link (links to recently removed deprecated function)
- Patch 2: Add `-- -D rustdoc::broken-intra-doc-links` to CI

cc dpc, wasn't on this repo but you brought this to my attention, thanks man!