### PR TITLE
Implement fast unstable comparisons

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -23,6 +23,7 @@ use crate::SECP256K1;
 #[derive(Copy, Clone)]
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 pub struct Signature(pub(crate) ffi::Signature);
+impl_fast_comparisons!(Signature);
 
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/key.rs
+++ b/src/key.rs
@@ -104,6 +104,7 @@ pub const ONE_KEY: SecretKey = SecretKey(constants::ONE);
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 #[repr(transparent)]
 pub struct PublicKey(ffi::PublicKey);
+impl_fast_comparisons!(PublicKey);
 
 impl fmt::LowerHex for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -802,6 +803,7 @@ impl core::hash::Hash for PublicKey {
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 pub struct KeyPair(ffi::KeyPair);
 impl_display_secret!(KeyPair);
+impl_fast_comparisons!(KeyPair);
 
 impl KeyPair {
     /// Obtains a raw const pointer suitable for use with FFI functions.
@@ -1177,6 +1179,7 @@ impl CPtr for KeyPair {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(fuzzing, derive(PartialOrd, Ord, PartialEq, Eq, Hash))]
 pub struct XOnlyPublicKey(ffi::XOnlyPublicKey);
+impl_fast_comparisons!(XOnlyPublicKey);
 
 impl fmt::LowerHex for XOnlyPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,3 +45,32 @@ macro_rules! write_err {
         }
     }
 }
+
+/// Implements fast unstable versions of Ord, PartialOrd, Eq, PartialEq, and Hash.
+macro_rules! impl_fast_comparisons {
+    ($ty:ident) => {
+        impl $ty {
+            /// Equivalent to `Ord` but faster and not stable across library versions.
+            ///
+            /// The `Ord` implementation for `Self` is stable but slow because we first serialize
+            /// `self` and `other` before comparing them. The `Ord` implementation for FFI types
+            /// compares the inner bytes directly. The inner bytes are passed across the FFI boundry
+            /// and as such there are no guarantees to the layout of the bytes. The layout may
+            /// change unexpectedly between versions of the library, even minor versions.
+            pub fn cmp_fast_unstable(&self, other: &Self) -> core::cmp::Ordering {
+                self.0.cmp(&other.0)
+            }
+
+            /// Equivalent to `Eq` but faster and not stable across library versions.
+            ///
+            /// The `Eq` implementation for `Self` is stable but slow because we first serialize
+            /// `self` and `other` before comparing them. The `Eq` implementation for FFI types
+            /// compares the inner bytes directly. The inner bytes are passed across the FFI boundry
+            /// and as such there are no guarantees to the layout of the bytes. The layout may
+            /// change unexpectedly between versions of the library, even minor versions.
+            pub fn eq_fast_unstable(&self, other: &Self) -> bool {
+                self.0.eq(&other.0)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Builds on top of #515

We recently improved the comparison implementations to be stable across library versions by first serializing the data types before comparing them instead of just comparing the inner bytes. This had the downside that the comparisons are now slower.
    
Add public methods `cmp_fast_unstable` and `eq_fast_unstable` to each of the types that wraps an FFI type.