### PR TITLE
Correct bench feature gating

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -287,6 +287,7 @@ mod tests {
 }
 
 #[cfg(bench)]
+#[cfg(feature = "rand-std")]    // Currently only a single bench that requires "rand-std".
 mod benches {
     use test::{Bencher, black_box};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,7 +1058,7 @@ mod benches {
     use super::{Message, Secp256k1};
 
     #[bench]
-    #[cfg(any(feature = "alloc", feature = "std"))]
+    #[cfg(all(feature = "std", feature = "rnd-std"))]
     pub fn generate(bh: &mut Bencher) {
 
         let s = Secp256k1::new();
@@ -1071,7 +1071,7 @@ mod benches {
     }
 
     #[bench]
-    #[cfg(any(feature = "alloc", feature = "std"))]
+    #[cfg(all(feature = "std", feature = "rnd-std"))]
     pub fn bench_sign_ecdsa(bh: &mut Bencher) {
         let s = Secp256k1::new();
         let mut msg = [0u8; 32];
@@ -1086,7 +1086,7 @@ mod benches {
     }
 
     #[bench]
-    #[cfg(any(feature = "alloc", feature = "std"))]
+    #[cfg(all(feature = "std", feature = "rnd-std"))]
     pub fn bench_verify_ecdsa(bh: &mut Bencher) {
         let s = Secp256k1::new();
         let mut msg = [0u8; 32];


### PR DESCRIPTION
We currently have the feature gating incorrect in a few places, `thread_rng` requires "rand-std".

Found while doing https://github.com/rust-bitcoin/rust-bitcoin/pull/1387