### PR TITLE
Document unsafe code

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -62,12 +62,20 @@ pub mod global {
 
 /// A trait for all kinds of contexts that lets you define the exact flags and a function to
 /// deallocate memory. It isn't possible to implement this for types outside this crate.
+///
+/// # Safety
+///
+/// This trait is marked unsafe to allow unsafe implementations of `deallocate`.
 pub unsafe trait Context: private::Sealed {
     /// Flags for the ffi.
     const FLAGS: c_uint;
     /// A constant description of the context.
     const DESCRIPTION: &'static str;
     /// A function to deallocate the memory when the context is dropped.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be valid. Further safety constraints may be imposed by [`std::alloc::dealloc`].
     unsafe fn deallocate(ptr: *mut u8, size: usize);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,6 @@
 // Coding conventions
 #![deny(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 #![warn(missing_docs, missing_copy_implementations, missing_debug_implementations)]
-#![allow(clippy::missing_safety_doc)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
Functions that are `unsafe` should include a `# Safety` section.

- Patch 1: Documents `unsafe` methods in `secp256k1-sys`. Please not this includes a minor refactor.
- Patch 2: Documents the `unsafe` `Context` trait

Together these two patches remove `#![allow(clippy::missing_safety_doc)]` from the repo.

Fix: #447

## Note to reviewers

The only function that was curly to understand the safety of was `secp256k1_context_create`, all the other stuff should be trivial to review.