### PR TITLE
ci: Check rustdocs build

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -60,7 +60,7 @@ fi
 
 # Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs" cargo rustdoc --features="$FEATURES" -- -D rustdoc::broken-intra-doc-links
+    RUSTDOCFLAGS="--cfg docsrs" cargo rustdoc --features="$FEATURES" -- -D rustdoc::broken-intra-doc-links -D warnings || exit 1
 fi
 
 # Webassembly stuff


### PR DESCRIPTION
Currently we are not failing the docs build in CI if any warnings are generated.

Exit the script with error code 1 if docs build throws any warnings.