### PR TITLE
Add constant time `SecretKey::eq`

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -69,26 +69,6 @@ impl PartialEq for SecretKey {
 
 impl Eq for SecretKey {}
 
-impl core::hash::Hash for SecretKey {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self[..].hash(state)
-    }
-}
-
-impl PartialOrd for SecretKey {
-    #[inline]
-    fn partial_cmp(&self, other: &SecretKey) -> Option<core::cmp::Ordering> {
-        self[..].partial_cmp(&other[..])
-    }
-}
-
-impl Ord for SecretKey {
-    #[inline]
-    fn cmp(&self, other: &SecretKey) -> core::cmp::Ordering {
-        self[..].cmp(&other[..])
-    }
-}
-
 impl AsRef<[u8; constants::SECRET_KEY_SIZE]> for SecretKey {
     /// Gets a reference to the underlying array
     #[inline]

--- a/src/key.rs
+++ b/src/key.rs
@@ -61,9 +61,12 @@ pub struct SecretKey([u8; constants::SECRET_KEY_SIZE]);
 impl_display_secret!(SecretKey);
 
 impl PartialEq for SecretKey {
+    /// This implementation is designed to be constant time to help prevent side channel attacks.
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self[..] == other[..]
+        let accum = self.0.iter().zip(&other.0)
+            .fold(0, |accum, (a, b)| accum | a ^ b);
+        unsafe { core::ptr::read_volatile(&accum) == 0 }
     }
 }
 


### PR DESCRIPTION
Add constant time comparison implementation to `SecretKey`.

This PR does as suggested [here](https://github.com/rust-bitcoin/rust-secp256k1/issues/471#issuecomment-1179783309) at the end of the issue discussion thread. 

Fix: #471 