### PR TITLE
secp256k1: Improve docs on `Error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,8 +304,7 @@ impl fmt::Display for Message {
 pub enum Error {
     /// Signature failed verification
     IncorrectSignature,
-    /// Badly sized message ("messages" are actually fixed-sized digests; see the `MESSAGE_SIZE`
-    /// constant).
+    /// Bad sized message ("messages" are actually fixed-sized digests [`constants::MESSAGE_SIZE`]).
     InvalidMessage,
     /// Bad public key.
     InvalidPublicKey,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ impl fmt::Display for Message {
 /// The main error type for this library.
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub enum Error {
-    /// Signature failed verification
+    /// Signature failed verification.
     IncorrectSignature,
     /// Bad sized message ("messages" are actually fixed-sized digests [`constants::MESSAGE_SIZE`]).
     InvalidMessage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
-/// An ECDSA error
+/// The main error type for this library.
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub enum Error {
     /// Signature failed verification


### PR DESCRIPTION
The docs on `Error` currently mention ECDSA which is no longer correct since we use this error in `schnorr` as well.

Fix the `Error` doc issue described above and do a couple trivial other fixes while we are touching the code.