### PR TITLE
call the alloc error handle if we get NULL from the allocator

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -798,6 +798,9 @@ pub unsafe extern "C" fn rustsecp256k1_v0_6_1_context_create(flags: c_uint) -> *
     let bytes = secp256k1_context_preallocated_size(flags) + ALIGN_TO;
     let layout = alloc::Layout::from_size_align(bytes, ALIGN_TO).unwrap();
     let ptr = alloc::alloc(layout);
+    if ptr.is_null() {
+        alloc::handle_alloc_error(layout);
+    }
     (ptr as *mut usize).write(bytes);
     // We must offset a whole ALIGN_TO in order to preserve the same alignment
     // this means we "lose" ALIGN_TO-size_of(usize) for padding.

--- a/src/context.rs
+++ b/src/context.rs
@@ -194,6 +194,9 @@ mod alloc_only {
             let size = unsafe { ffi::secp256k1_context_preallocated_size(C::FLAGS) };
             let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
             let ptr = unsafe { alloc::alloc(layout) };
+            if ptr.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
 
             #[allow(unused_mut)] // ctx is not mutated under some feature combinations.
             let mut ctx = Secp256k1 {
@@ -254,6 +257,9 @@ mod alloc_only {
             let size = unsafe { ffi::secp256k1_context_preallocated_clone_size(self.ctx as _) };
             let layout = alloc::Layout::from_size_align(size, ALIGN_TO).unwrap();
             let ptr = unsafe { alloc::alloc(layout) };
+            if ptr.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
             Secp256k1 {
                 ctx: unsafe {
                     ffi::secp256k1_context_preallocated_clone(self.ctx, ptr as *mut c_void)


### PR DESCRIPTION
Found that this was missing in this discussion: https://github.com/rust-bitcoin/rust-secp256k1/issues/529#issuecomment-1324832163

It is documented here that it returns a NULL on memory exhaustion: https://doc.rust-lang.org/alloc/alloc/trait.GlobalAlloc.html#tymethod.alloc 
And you can see that this is called in this example: https://doc.rust-lang.org/alloc/alloc/fn.alloc.html
Docs for the handle itself: https://doc.rust-lang.org/alloc/alloc/fn.handle_alloc_error.html
