### PR TITLE
secp256k1-sys: Remove unused flags in build.rs

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -35,11 +35,7 @@ fn main() {
                .define("SECP256K1_API", Some(""))
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))
-               .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))
-               // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
-               .define("USE_NUM_NONE", Some("1"))
-               .define("USE_FIELD_INV_BUILTIN", Some("1"))
-               .define("USE_SCALAR_INV_BUILTIN", Some("1"));
+               .define("ENABLE_MODULE_EXTRAKEYS", Some("1"));
 
     if cfg!(feature = "lowmemory") {
         base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume negligible memory


### PR DESCRIPTION
These are no longer used in upstream, so there's no reason for us to set them