### PR TITLE
context: introduce alternate global context scheme based on #346

### DIFF
--- a/secp256k1-sys/depend/secp256k1.c.patch
+++ b/secp256k1-sys/depend/secp256k1.c.patch
@@ -1,4 +1,33 @@
-139,149d138
+61a62,89
+> /* rust-secp: add two static contexts which are initialized for signing. We
+>  * need two so that we can effect updates (i.e. rerandomization) by atomic
+>  * pointer assignment */
+> static secp256k1_context secp256k1_context_signing_1_ = {
+>     {
+>         1,
+>         SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0),
+>         SECP256K1_GEJ_CONST_INFINITY
+>     },
+>     { secp256k1_default_illegal_callback_fn, 0 },
+>     { secp256k1_default_error_callback_fn, 0 },
+>     0
+> };
+> secp256k1_context *secp256k1_context_signing_1 = &secp256k1_context_signing_1_;
+> 
+> static secp256k1_context secp256k1_context_signing_2_ = {
+>     {
+>         1,
+>         SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0),
+>         SECP256K1_GEJ_CONST_INFINITY
+>     },
+>     { secp256k1_default_illegal_callback_fn, 0 },
+>     { secp256k1_default_error_callback_fn, 0 },
+>     0
+> };
+> secp256k1_context *secp256k1_context_signing_2 = &secp256k1_context_signing_2_;
+> /* end rust-secp */
+> 
+107,117d125
 < secp256k1_context* secp256k1_context_create(unsigned int flags) {
 <     size_t const prealloc_size = secp256k1_context_preallocated_size(flags);
 <     secp256k1_context* ctx = (secp256k1_context*)checked_malloc(&default_error_callback, prealloc_size);
@@ -10,7 +39,7 @@
 <     return ctx;
 < }
 < 
-164,174d152
+128,138d135
 < secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
 <     secp256k1_context* ret;
 <     size_t prealloc_size;
@@ -22,7 +51,7 @@
 <     return ret;
 < }
 < 
-183,189d160
+146,152d142
 < void secp256k1_context_destroy(secp256k1_context* ctx) {
 <     if (ctx != NULL) {
 <         secp256k1_context_preallocated_destroy(ctx);
@@ -30,7 +59,7 @@
 <     }
 < }
 < 
-206,215d176
+169,178d158
 < }
 < 
 < secp256k1_scratch_space* secp256k1_scratch_space_create(const secp256k1_context* ctx, size_t max_size) {

--- a/secp256k1-sys/depend/secp256k1.h.patch
+++ b/secp256k1-sys/depend/secp256k1.h.patch
@@ -1,21 +1,25 @@
-226,228d225
+206a207,209
+> SECP256K1_API extern secp256k1_context *secp256k1_context_signing_1;
+> SECP256K1_API extern secp256k1_context *secp256k1_context_signing_2;
+> 
+218,220d220
 < SECP256K1_API secp256k1_context* secp256k1_context_create(
 <     unsigned int flags
 < ) SECP256K1_WARN_UNUSED_RESULT;
-231,233d227
+231,233d230
 < SECP256K1_API secp256k1_context* secp256k1_context_clone(
 <     const secp256k1_context* ctx
 < ) SECP256K1_ARG_NONNULL(1) SECP256K1_WARN_UNUSED_RESULT;
-248,250d241
+248,250d244
 < SECP256K1_API void secp256k1_context_destroy(
 <     secp256k1_context* ctx
 < ) SECP256K1_ARG_NONNULL(1);
-327,330d317
+327,330d320
 < SECP256K1_API SECP256K1_WARN_UNUSED_RESULT secp256k1_scratch_space* secp256k1_scratch_space_create(
 <     const secp256k1_context* ctx,
 <     size_t size
 < ) SECP256K1_ARG_NONNULL(1);
-338,341d324
+338,341d327
 < SECP256K1_API void secp256k1_scratch_space_destroy(
 <     const secp256k1_context* ctx,
 <     secp256k1_scratch_space* scratch

--- a/secp256k1-sys/depend/secp256k1/include/secp256k1.h
+++ b/secp256k1-sys/depend/secp256k1/include/secp256k1.h
@@ -204,6 +204,9 @@ typedef int (*rustsecp256k1_v0_6_1_nonce_function)(
  */
 SECP256K1_API extern const rustsecp256k1_v0_6_1_context *rustsecp256k1_v0_6_1_context_no_precomp;
 
+SECP256K1_API extern rustsecp256k1_v0_6_1_context *rustsecp256k1_v0_6_1_context_signing_1;
+SECP256K1_API extern rustsecp256k1_v0_6_1_context *rustsecp256k1_v0_6_1_context_signing_2;
+
 /** Create a secp256k1 context object (in dynamically allocated memory).
  *
  *  This function uses malloc to allocate memory. It is guaranteed that malloc is

--- a/secp256k1-sys/depend/secp256k1/src/secp256k1.c
+++ b/secp256k1-sys/depend/secp256k1/src/secp256k1.c
@@ -59,6 +59,34 @@ static const rustsecp256k1_v0_6_1_context rustsecp256k1_v0_6_1_context_no_precom
 };
 const rustsecp256k1_v0_6_1_context *rustsecp256k1_v0_6_1_context_no_precomp = &rustsecp256k1_v0_6_1_context_no_precomp_;
 
+/* rust-secp: add two static contexts which are initialized for signing. We
+ * need two so that we can effect updates (i.e. rerandomization) by atomic
+ * pointer assignment */
+static rustsecp256k1_v0_6_1_context rustsecp256k1_v0_6_1_context_signing_1_ = {
+    {
+        1,
+        SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0),
+        SECP256K1_GEJ_CONST_INFINITY
+    },
+    { rustsecp256k1_v0_6_1_default_illegal_callback_fn, 0 },
+    { rustsecp256k1_v0_6_1_default_error_callback_fn, 0 },
+    0
+};
+rustsecp256k1_v0_6_1_context *rustsecp256k1_v0_6_1_context_signing_1 = &rustsecp256k1_v0_6_1_context_signing_1_;
+
+static rustsecp256k1_v0_6_1_context rustsecp256k1_v0_6_1_context_signing_2_ = {
+    {
+        1,
+        SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0),
+        SECP256K1_GEJ_CONST_INFINITY
+    },
+    { rustsecp256k1_v0_6_1_default_illegal_callback_fn, 0 },
+    { rustsecp256k1_v0_6_1_default_error_callback_fn, 0 },
+    0
+};
+rustsecp256k1_v0_6_1_context *rustsecp256k1_v0_6_1_context_signing_2 = &rustsecp256k1_v0_6_1_context_signing_2_;
+/* end rust-secp */
+
 size_t rustsecp256k1_v0_6_1_context_preallocated_size(unsigned int flags) {
     size_t ret = sizeof(rustsecp256k1_v0_6_1_context);
     /* A return value of 0 is reserved as an indicator for errors when we call this function internally. */

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -39,6 +39,7 @@ pub mod types;
 pub mod recovery;
 
 use core::{slice, ptr};
+use core::sync::atomic::AtomicPtr;
 use types::*;
 
 /// Flag for context to enable no precomputation
@@ -511,10 +512,10 @@ extern "C" {
     pub static secp256k1_context_no_precomp: *const Context;
 
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_6_1_context_signing_1")]
-    pub static secp256k1_context_signing_1: *mut Context;
+    pub static secp256k1_context_signing_1: AtomicPtr<Context>;
 
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_6_1_context_signing_2")]
-    pub static secp256k1_context_signing_2: *mut Context;
+    pub static secp256k1_context_signing_2: AtomicPtr<Context>;
 
     // Contexts
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_6_1_context_preallocated_destroy")]

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -510,6 +510,12 @@ extern "C" {
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_6_1_context_no_precomp")]
     pub static secp256k1_context_no_precomp: *const Context;
 
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_6_1_context_signing_1")]
+    pub static secp256k1_context_signing_1: *mut Context;
+
+    #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_6_1_context_signing_2")]
+    pub static secp256k1_context_signing_2: *mut Context;
+
     // Contexts
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_6_1_context_preallocated_destroy")]
     pub fn secp256k1_context_preallocated_destroy(cx: *mut Context);

--- a/src/context.rs
+++ b/src/context.rs
@@ -44,7 +44,7 @@ pub mod global_ {
 }
 
 #[cfg(not(feature = "std"))]
-mod global_ {
+pub mod global_ {
     use core::sync::atomic::{AtomicBool, Ordering};
     use crate::ffi;
 
@@ -63,7 +63,7 @@ mod global_ {
     // unsafe block. As far as I know this is the best we can do.
 
     /// Do some operation using an immutable reference to the global signing context
-    pub unsafe fn with_global_ctx<F: FnOnce(*const ffi::Context) -> R, R>(f: F) -> R {
+    pub unsafe fn with_global_context<F: FnOnce(*const ffi::Context) -> R, R>(f: F) -> R {
         let ctx = unsafe { ffi::secp256k1_context_signing_1.load(Ordering::Acquire) };
         f(ctx as *const _)
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,6 +12,7 @@ use crate::{Error, Secp256k1};
 #[cfg(feature = "std")]
 pub mod global_ {
     use core::cell::RefCell;
+
     use crate::{ffi, All, Secp256k1};
 
     thread_local! {
@@ -46,6 +47,7 @@ pub mod global_ {
 #[cfg(not(feature = "std"))]
 pub mod global_ {
     use core::sync::atomic::{AtomicBool, Ordering};
+
     use crate::ffi;
 
     static LOCK: AtomicBool = AtomicBool::new(false);

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -103,11 +103,13 @@ impl<C: Signing> Secp256k1<C> {
         nonce_data: *const ffi::types::c_uchar,
     ) -> Signature {
         unsafe {
+crate::context::global_::rerandomize_context(b"this is a 32-byte random string!");
+crate::context::global_::with_global_context(|ctx| {
             let mut sig = [0u8; constants::SCHNORR_SIGNATURE_SIZE];
             assert_eq!(
                 1,
                 ffi::secp256k1_schnorrsig_sign(
-                    self.ctx,
+                    ctx,
                     sig.as_mut_c_ptr(),
                     msg.as_c_ptr(),
                     keypair.as_c_ptr(),
@@ -116,6 +118,7 @@ impl<C: Signing> Secp256k1<C> {
             );
 
             Signature(sig)
+})
         }
     }
 

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -103,22 +103,22 @@ impl<C: Signing> Secp256k1<C> {
         nonce_data: *const ffi::types::c_uchar,
     ) -> Signature {
         unsafe {
-crate::context::global_::rerandomize_context(b"this is a 32-byte random string!");
-crate::context::global_::with_global_context(|ctx| {
-            let mut sig = [0u8; constants::SCHNORR_SIGNATURE_SIZE];
-            assert_eq!(
-                1,
-                ffi::secp256k1_schnorrsig_sign(
-                    ctx,
-                    sig.as_mut_c_ptr(),
-                    msg.as_c_ptr(),
-                    keypair.as_c_ptr(),
-                    nonce_data,
-                )
-            );
+            crate::context::global_::rerandomize_context(b"this is a 32-byte random string!");
+            crate::context::global_::with_global_context(|ctx| {
+                let mut sig = [0u8; constants::SCHNORR_SIGNATURE_SIZE];
+                assert_eq!(
+                    1,
+                    ffi::secp256k1_schnorrsig_sign(
+                        ctx,
+                        sig.as_mut_c_ptr(),
+                        msg.as_c_ptr(),
+                        keypair.as_c_ptr(),
+                        nonce_data,
+                    )
+                );
 
-            Signature(sig)
-})
+                Signature(sig)
+            })
         }
     }
 


### PR DESCRIPTION
This implements, but does not use, the new global context scheme described in #346. As described in #538, we want to actually use the global context API throughout the *entire* codebase, rather than maintaining parallel global-context and non-global-context APIs.