### PR TITLE
Remove size field

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -201,7 +201,6 @@ mod alloc_only {
                     ffi::secp256k1_context_preallocated_create(ptr as *mut c_void, C::FLAGS)
                 },
                 phantom: PhantomData,
-                size,
             };
 
             #[cfg(all(
@@ -259,7 +258,6 @@ mod alloc_only {
                     ffi::secp256k1_context_preallocated_clone(self.ctx, ptr as *mut c_void)
                 },
                 phantom: PhantomData,
-                size,
             }
         }
     }
@@ -315,7 +313,6 @@ impl<'buf, C: Context + 'buf> Secp256k1<C> {
                 )
             },
             phantom: PhantomData,
-            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
         })
     }
 }
@@ -344,11 +341,7 @@ impl<'buf> Secp256k1<AllPreallocated<'buf>> {
     pub unsafe fn from_raw_all(
         raw_ctx: *mut ffi::Context,
     ) -> ManuallyDrop<Secp256k1<AllPreallocated<'buf>>> {
-        ManuallyDrop::new(Secp256k1 {
-            ctx: raw_ctx,
-            phantom: PhantomData,
-            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
-        })
+        ManuallyDrop::new(Secp256k1 { ctx: raw_ctx, phantom: PhantomData })
     }
 }
 
@@ -378,11 +371,7 @@ impl<'buf> Secp256k1<SignOnlyPreallocated<'buf>> {
     pub unsafe fn from_raw_signing_only(
         raw_ctx: *mut ffi::Context,
     ) -> ManuallyDrop<Secp256k1<SignOnlyPreallocated<'buf>>> {
-        ManuallyDrop::new(Secp256k1 {
-            ctx: raw_ctx,
-            phantom: PhantomData,
-            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
-        })
+        ManuallyDrop::new(Secp256k1 { ctx: raw_ctx, phantom: PhantomData })
     }
 }
 
@@ -412,10 +401,6 @@ impl<'buf> Secp256k1<VerifyOnlyPreallocated<'buf>> {
     pub unsafe fn from_raw_verification_only(
         raw_ctx: *mut ffi::Context,
     ) -> ManuallyDrop<Secp256k1<VerifyOnlyPreallocated<'buf>>> {
-        ManuallyDrop::new(Secp256k1 {
-            ctx: raw_ctx,
-            phantom: PhantomData,
-            size: 0, // We don't care about the size because it's the caller responsibility to deallocate.
-        })
+        ManuallyDrop::new(Secp256k1 { ctx: raw_ctx, phantom: PhantomData })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,6 @@ impl std::error::Error for Error {
 pub struct Secp256k1<C: Context> {
     ctx: *mut ffi::Context,
     phantom: PhantomData<C>,
-    size: usize,
 }
 
 // The underlying secp context does not contain any references to memory it does not own.
@@ -390,8 +389,9 @@ impl<C: Context> Eq for Secp256k1<C> {}
 impl<C: Context> Drop for Secp256k1<C> {
     fn drop(&mut self) {
         unsafe {
+            let size = ffi::secp256k1_context_preallocated_clone_size(self.ctx);
             ffi::secp256k1_context_preallocated_destroy(self.ctx);
-            C::deallocate(self.ctx as _, self.size);
+            C::deallocate(self.ctx as _, size);
         }
     }
 }
@@ -558,13 +558,11 @@ mod tests {
         let ctx_sign = unsafe { ffi::secp256k1_context_create(SignOnlyPreallocated::FLAGS) };
         let ctx_vrfy = unsafe { ffi::secp256k1_context_create(VerifyOnlyPreallocated::FLAGS) };
 
-        let size = 0;
-        let full: Secp256k1<AllPreallocated> =
-            Secp256k1 { ctx: ctx_full, phantom: PhantomData, size };
+        let full: Secp256k1<AllPreallocated> = Secp256k1 { ctx: ctx_full, phantom: PhantomData };
         let sign: Secp256k1<SignOnlyPreallocated> =
-            Secp256k1 { ctx: ctx_sign, phantom: PhantomData, size };
+            Secp256k1 { ctx: ctx_sign, phantom: PhantomData };
         let vrfy: Secp256k1<VerifyOnlyPreallocated> =
-            Secp256k1 { ctx: ctx_vrfy, phantom: PhantomData, size };
+            Secp256k1 { ctx: ctx_vrfy, phantom: PhantomData };
 
         let (sk, pk) = full.generate_keypair(&mut rand::thread_rng());
         let msg = Message::from_slice(&[2u8; 32]).unwrap();


### PR DESCRIPTION
The `Secp256k1` `size` field is a cached value that we get using `ffi::secp256k1_context_preallocated_size` or
`ffi::secp256k1_context_preallocated_clone_size`, both of which just return the result of `sizeof(rustsecp256k1_v0_6_1_context)`. Instead of caching this value we can just call
`ffi::secp256k1_context_preallocated_clone_size` in the `Drop` implementation.

Fix #537 