### PR TITLE
Use NonNull for Secp256k1 inner context field

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -258,7 +258,7 @@ impl<C: Signing> Secp256k1<C> {
             // an invalid signature from a valid `Message` and `SecretKey`
             assert_eq!(
                 ffi::secp256k1_ecdsa_sign(
-                    self.ctx,
+                    self.ctx.as_ptr(),
                     &mut ret,
                     msg.as_c_ptr(),
                     sk.as_c_ptr(),
@@ -307,7 +307,7 @@ impl<C: Signing> Secp256k1<C> {
                 // an invalid signature from a valid `Message` and `SecretKey`
                 assert_eq!(
                     ffi::secp256k1_ecdsa_sign(
-                        self.ctx,
+                        self.ctx.as_ptr(),
                         &mut ret,
                         msg.as_c_ptr(),
                         sk.as_c_ptr(),
@@ -388,8 +388,12 @@ impl<C: Verification> Secp256k1<C> {
         pk: &PublicKey,
     ) -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ecdsa_verify(self.ctx, sig.as_c_ptr(), msg.as_c_ptr(), pk.as_c_ptr())
-                == 0
+            if ffi::secp256k1_ecdsa_verify(
+                self.ctx.as_ptr(),
+                sig.as_c_ptr(),
+                msg.as_c_ptr(),
+                pk.as_c_ptr(),
+            ) == 0
             {
                 Err(Error::IncorrectSignature)
             } else {

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -158,7 +158,7 @@ impl<C: Signing> Secp256k1<C> {
             // an invalid signature from a valid `Message` and `SecretKey`
             assert_eq!(
                 ffi::secp256k1_ecdsa_sign_recoverable(
-                    self.ctx,
+                    self.ctx.as_ptr(),
                     &mut ret,
                     msg.as_c_ptr(),
                     sk.as_c_ptr(),
@@ -208,7 +208,12 @@ impl<C: Verification> Secp256k1<C> {
     ) -> Result<key::PublicKey, Error> {
         unsafe {
             let mut pk = super_ffi::PublicKey::new();
-            if ffi::secp256k1_ecdsa_recover(self.ctx, &mut pk, sig.as_c_ptr(), msg.as_c_ptr()) != 1
+            if ffi::secp256k1_ecdsa_recover(
+                self.ctx.as_ptr(),
+                &mut pk,
+                sig.as_c_ptr(),
+                msg.as_c_ptr(),
+            ) != 1
             {
                 return Err(Error::InvalidSignature);
             }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -107,7 +107,7 @@ impl<C: Signing> Secp256k1<C> {
             assert_eq!(
                 1,
                 ffi::secp256k1_schnorrsig_sign(
-                    self.ctx,
+                    self.ctx.as_ptr(),
                     sig.as_mut_c_ptr(),
                     msg.as_c_ptr(),
                     keypair.as_c_ptr(),
@@ -168,7 +168,7 @@ impl<C: Verification> Secp256k1<C> {
     ) -> Result<(), Error> {
         unsafe {
             let ret = ffi::secp256k1_schnorrsig_verify(
-                self.ctx,
+                self.ctx.as_ptr(),
                 sig.as_c_ptr(),
                 msg.as_c_ptr(),
                 32,


### PR DESCRIPTION
For raw pointers that can never be null Rust provides the `core::ptr::NonNull` type. Our `Secp256k1` type has an inner field that is a non-null pointer; use `NonNull` for it.

Fix: #534