### PR TITLE
fix soundness issue with `preallocated_gen_new`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -320,6 +320,11 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
 
 /// Trait marking that a particular context object internally points to
 /// memory that must outlive `'a`
+///
+/// # Safety
+/// This trait is used internally to gate which context markers can safely
+/// be used with the `preallocated_gen_new` function. Do not implement it
+/// on your own structures.
 pub unsafe trait PreallocatedContext<'a> {}
 
 unsafe impl<'buf> PreallocatedContext<'buf> for AllPreallocated<'buf> {}

--- a/src/context.rs
+++ b/src/context.rs
@@ -318,7 +318,15 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
     }
 }
 
-impl<'buf, C: Context + 'buf> Secp256k1<C> {
+/// Trait marking that a particular context object internally points to
+/// memory that must outlive `'a`
+pub unsafe trait PreallocatedContext<'a> {}
+
+unsafe impl<'buf> PreallocatedContext<'buf> for AllPreallocated<'buf> {}
+unsafe impl<'buf> PreallocatedContext<'buf> for SignOnlyPreallocated<'buf> {}
+unsafe impl<'buf> PreallocatedContext<'buf> for VerifyOnlyPreallocated<'buf> {}
+
+impl<'buf, C: Context + PreallocatedContext<'buf>> Secp256k1<C> {
     /// Lets you create a context with a preallocated buffer in a generic manner (sign/verify/all).
     pub fn preallocated_gen_new(buf: &'buf mut [AlignedType]) -> Result<Secp256k1<C>, Error> {
         #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Stop this from being a generic function over all contexts, to only a function generic over contexts where we can bound the lifetime precisely. Introduces a new unsafe trait. I *believe* the only code this breaks was already unsound:
* code that tried to use one of the `*Preallocated` context markers with an incorrect lifetime
* code that tried to use `preallocated_gen_new` with a non-`*Preallocated` marker, which I believe we allowed before (I just noticed this now) and almost certainly would've led to UB on drop

Fixes #543