### PR TITLE
Update CHANGELOG for release of v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.25.0 - 2022-12-07
 
 * [Fix soundness issue with `preallocated_gen_new`](https://github.com/rust-bitcoin/rust-secp256k1/pull/548)
+* Update to `secp256k1-sys` [v0.7.0](https://github.com/rust-bitcoin/rust-secp256k1/pull/549)
 * Use type system to [improve safety](https://github.com/rust-bitcoin/rust-secp256k1/pull/483).
 * [Change secp256k1-sys symbol names to 0_6_1](https://github.com/rust-bitcoin/rust-secp256k1/pull/490).
 * [Introduce `rustfmt`](https://github.com/rust-bitcoin/rust-secp256k1/pull/499) to the codebase.


### PR DESCRIPTION
We just did a new release of `secp256k1-sys` needed for release of v0.25.0

Update the CHANGELOG to include secp-sys version bump.