### PR TITLE
Backport and bump version to 0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.22.2 - 2022-12-05
+
+* Backport [fix soundness issue with `preallocated_gen_new`](https://github.com/rust-bitcoin/rust-secp256k1/pull/548)
+
 # 0.22.1 - 2022-03-10
 
 * [Reintroduce](https://github.com/rust-bitcoin/rust-secp256k1/pull/417) accidentally removed possibility to create `SharedSecret` from byte serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.22.1"
+version = "0.22.2"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/context.rs
+++ b/src/context.rs
@@ -301,6 +301,12 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
 
 /// Trait marking that a particular context object internally points to
 /// memory that must outlive `'a`
+///
+/// # Safety
+///
+/// This trait is used internally to gate which context markers can safely
+/// be used with the `preallocated_gen_new` function. Do not implement it
+/// on your own structures.
 pub unsafe trait PreallocatedContext<'a> {}
 
 unsafe impl<'buf> PreallocatedContext<'buf> for AllPreallocated<'buf> {}

--- a/src/context.rs
+++ b/src/context.rs
@@ -299,8 +299,16 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
     }
 }
 
-impl<'buf, C: Context + 'buf> Secp256k1<C> {
-    /// Lets you create a context with preallocated buffer in a generic manner(sign/verify/all)
+/// Trait marking that a particular context object internally points to
+/// memory that must outlive `'a`
+pub unsafe trait PreallocatedContext<'a> {}
+
+unsafe impl<'buf> PreallocatedContext<'buf> for AllPreallocated<'buf> {}
+unsafe impl<'buf> PreallocatedContext<'buf> for SignOnlyPreallocated<'buf> {}
+unsafe impl<'buf> PreallocatedContext<'buf> for VerifyOnlyPreallocated<'buf> {}
+
+impl<'buf, C: Context + PreallocatedContext<'buf>> Secp256k1<C> {
+    /// Lets you create a context with a preallocated buffer in a generic manner (sign/verify/all).
     pub fn preallocated_gen_new(buf: &'buf mut [AlignedType]) -> Result<Secp256k1<C>, Error> {
         #[cfg(target_arch = "wasm32")]
         ffi::types::sanity_checks_for_wasm();


### PR DESCRIPTION
Backport https://github.com/rust-bitcoin/rust-secp256k1/pull/548 and bump version ready for release.