### PR TITLE
Backport and bump secp256k1 0.23.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+# 0.23.5 - 2022-12-05
+
+* Backport [fix soundness issue with `preallocated_gen_new`](https://github.com/rust-bitcoin/rust-secp256k1/pull/548)
+
 # 0.23.4 - 2022-07-14
 
 * [Disable automatic rerandomization of contexts under WASM](https://github.com/rust-bitcoin/rust-secp256k1/pull/474)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.23.4"
+version = "0.23.5"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/context.rs
+++ b/src/context.rs
@@ -297,8 +297,16 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
     }
 }
 
-impl<'buf, C: Context + 'buf> Secp256k1<C> {
-    /// Lets you create a context with preallocated buffer in a generic manner(sign/verify/all)
+/// Trait marking that a particular context object internally points to
+/// memory that must outlive `'a`
+pub unsafe trait PreallocatedContext<'a> {}
+
+unsafe impl<'buf> PreallocatedContext<'buf> for AllPreallocated<'buf> {}
+unsafe impl<'buf> PreallocatedContext<'buf> for SignOnlyPreallocated<'buf> {}
+unsafe impl<'buf> PreallocatedContext<'buf> for VerifyOnlyPreallocated<'buf> {}
+
+impl<'buf, C: Context + PreallocatedContext<'buf>> Secp256k1<C> {
+    /// Lets you create a context with a preallocated buffer in a generic manner (sign/verify/all).
     pub fn preallocated_gen_new(buf: &'buf mut [AlignedType]) -> Result<Secp256k1<C>, Error> {
         #[cfg(target_arch = "wasm32")]
         ffi::types::sanity_checks_for_wasm();

--- a/src/context.rs
+++ b/src/context.rs
@@ -299,6 +299,12 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
 
 /// Trait marking that a particular context object internally points to
 /// memory that must outlive `'a`
+///
+/// # Safety
+///
+/// This trait is used internally to gate which context markers can safely
+/// be used with the `preallocated_gen_new` function. Do not implement it
+/// on your own structures.
 pub unsafe trait PreallocatedContext<'a> {}
 
 unsafe impl<'buf> PreallocatedContext<'buf> for AllPreallocated<'buf> {}

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -45,7 +45,7 @@ impl PartialEq for SerializedSignature {
 impl AsRef<[u8]> for SerializedSignature {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        &*self
+        self
     }
 }
 


### PR DESCRIPTION
Backport https://github.com/rust-bitcoin/rust-secp256k1/pull/548 and bump version ready for release.

### Note

Patch one fixes a trivial clippy issue so we lint cleanly on every patch.