### PR TITLE
Add additional changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 0.25.0 - 2022-11-22
+# 0.25.0 - 2022-12-07
 
+* [Fix soundness issue with `preallocated_gen_new`](https://github.com/rust-bitcoin/rust-secp256k1/pull/548)
 * Use type system to [improve safety](https://github.com/rust-bitcoin/rust-secp256k1/pull/483).
 * [Change secp256k1-sys symbol names to 0_6_1](https://github.com/rust-bitcoin/rust-secp256k1/pull/490).
 * [Introduce `rustfmt`](https://github.com/rust-bitcoin/rust-secp256k1/pull/499) to the codebase.

--- a/src/context.rs
+++ b/src/context.rs
@@ -311,6 +311,7 @@ unsafe impl<'buf> Context for AllPreallocated<'buf> {
 /// memory that must outlive `'a`
 ///
 /// # Safety
+///
 /// This trait is used internally to gate which context markers can safely
 /// be used with the `preallocated_gen_new` function. Do not implement it
 /// on your own structures.


### PR DESCRIPTION
~Bump version to 0.25.1 ready to release~ Add changelog entry for the recently fixed unsoundness issue.

Patch 1 is an annoyingly trivial fix to docs.