### PR TITLE
change bitcoin-hashes feature gates to bitcoin_hashes

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -31,7 +31,7 @@ use crate::Error::{self, InvalidPublicKey, InvalidPublicKeySum, InvalidSecretKey
 use crate::{constants, from_hex, Scalar, Secp256k1, Signing, Verification};
 #[cfg(feature = "global-context")]
 use crate::{ecdsa, Message, SECP256K1};
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 use crate::{hashes, ThirtyTwoByteHash};
 
 /// Secret 256-bit key used as `x` in an ECDSA signature.
@@ -284,7 +284,7 @@ impl SecretKey {
     /// assert_eq!(sk1, sk2);
     /// # }
     /// ```
-    #[cfg(feature = "bitcoin-hashes")]
+    #[cfg(feature = "bitcoin_hashes")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
     #[inline]
     pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
@@ -383,7 +383,7 @@ impl SecretKey {
     }
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 impl<T: ThirtyTwoByteHash> From<T> for SecretKey {
     /// Converts a 32-byte hash directly to a secret key without error paths.
     fn from(t: T) -> SecretKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,8 @@
 //! * `alloc` - use the `alloc` standard Rust library to provide heap allocations.
 //! * `rand` - use `rand` library to provide random generator (e.g. to generate keys).
 //! * `rand-std` - use `rand` library with its `std` feature enabled. (Implies `rand`.)
-//! * `bitcoin-hashes` - use the `bitcoin-hashes` library.
-//! * `bitcoin-hashes-std` - use the `bitcoin-hashes` library with its `std` feature enabled (implies `bitcoin-hashes`).
+//! * `bitcoin-hashes` - use the `bitcoin_hashes` library.
+//! * `bitcoin-hashes-std` - use the `bitcoin_hashes` library with its `std` feature enabled (implies `bitcoin-hashes`).
 //! * `recovery` - enable functions that can compute the public key from signature.
 //! * `lowmemory` - optimize the library for low-memory environments.
 //! * `global-context` - enable use of global secp256k1 context (implies `std`).
@@ -183,7 +183,7 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::{fmt, mem, str};
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 pub use bitcoin_hashes as hashes;
 #[cfg(feature = "global-context")]
@@ -200,7 +200,7 @@ pub use serde;
 pub use crate::context::*;
 use crate::ffi::types::AlignedType;
 use crate::ffi::CPtr;
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 use crate::hashes::Hash;
 pub use crate::key::{PublicKey, SecretKey, *};
 pub use crate::scalar::Scalar;
@@ -213,19 +213,19 @@ pub trait ThirtyTwoByteHash {
     fn into_32(self) -> [u8; 32];
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl ThirtyTwoByteHash for hashes::sha256::Hash {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl ThirtyTwoByteHash for hashes::sha256d::Hash {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl<T: hashes::sha256t::Tag> ThirtyTwoByteHash for hashes::sha256t::Hash<T> {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
@@ -263,7 +263,7 @@ impl Message {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "bitcoin-hashes")] {
+    /// # #[cfg(feature = "bitcoin_hashes")] {
     /// use secp256k1::hashes::{sha256, Hash};
     /// use secp256k1::Message;
     ///
@@ -274,7 +274,7 @@ impl Message {
     /// assert_eq!(m1, m2);
     /// # }
     /// ```
-    #[cfg(feature = "bitcoin-hashes")]
+    #[cfg(feature = "bitcoin_hashes")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
     pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
         <H as hashes::Hash>::hash(data).into()
@@ -1037,7 +1037,7 @@ mod tests {
         assert!(SECP256K1.verify_ecdsa(&msg, &sig, &pk).is_ok());
     }
 
-    #[cfg(feature = "bitcoin-hashes")]
+    #[cfg(feature = "bitcoin_hashes")]
     #[test]
     fn test_from_hash() {
         use crate::hashes::{self, Hash};

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -45,7 +45,7 @@ macro_rules! impl_display_secret {
             }
         }
 
-        #[cfg(all(not(feature = "std"), feature = "bitcoin-hashes"))]
+        #[cfg(all(not(feature = "std"), feature = "bitcoin_hashes"))]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 use crate::hashes::{sha256, Hash, HashEngine};
@@ -63,7 +63,7 @@ macro_rules! impl_display_secret {
             }
         }
 
-        #[cfg(all(not(feature = "std"), not(feature = "bitcoin-hashes")))]
+        #[cfg(all(not(feature = "std"), not(feature = "bitcoin_hashes")))]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 write!(f, "<secret requires std or bitcoin_hashes feature to display>")


### PR DESCRIPTION
This leaves `bitcoin-hashes` in place everywhere in the documentation, but changes it to `bitcoin_hashes` on the actual feature gates, to ensure that both flags work.

It's unfortunately a bit hard to test this because the library will be self-consistent pretty-much no matter what we do ... the issue is if the user enables the wrong flag we want to make sure that all the APIs we intend to be visible are actually visible.

Fixes #562.