### PR TITLE
Guard code with bitcoin_hashes not bitcoin-hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 # You likely only want to enable these if you explicitly do not want to use "std", otherwise enable
 # the respective -std feature e.g., bitcoin-hashes-std
-bitcoin_hashes = { version = "0.11", default-features = false, optional = true }
+bitcoin_hashes = { version = "0.11", default-features = false, optional = true } # Alias "bitcoin-hashes" available.
 rand = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="bitcoin-hashes global-context lowmemory rand recovery serde std alloc bitcoin-hashes-std rand-std"
+FEATURES="bitcoin_hashes global-context lowmemory rand recovery serde std alloc bitcoin-hashes-std rand-std"
 
 cargo --version
 rustc --version

--- a/src/key.rs
+++ b/src/key.rs
@@ -31,7 +31,7 @@ use crate::Error::{self, InvalidPublicKey, InvalidPublicKeySum, InvalidSecretKey
 use crate::{constants, from_hex, Scalar, Secp256k1, Signing, Verification};
 #[cfg(feature = "global-context")]
 use crate::{ecdsa, Message, SECP256K1};
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 use crate::{hashes, ThirtyTwoByteHash};
 
 /// Secret 256-bit key used as `x` in an ECDSA signature.
@@ -268,12 +268,12 @@ impl SecretKey {
 
     /// Constructs a [`SecretKey`] by hashing `data` with hash algorithm `H`.
     ///
-    /// Requires the feature `bitcoin_hashes` to be enabled.
+    /// Requires the feature `bitcoin-hashes` to be enabled.
     ///
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature="bitcoin_hashes")] {
+    /// # #[cfg(feature="bitcoin-hashes")] {
     /// use secp256k1::hashes::{sha256, Hash};
     /// use secp256k1::SecretKey;
     ///
@@ -284,7 +284,7 @@ impl SecretKey {
     /// assert_eq!(sk1, sk2);
     /// # }
     /// ```
-    #[cfg(feature = "bitcoin-hashes")]
+    #[cfg(feature = "bitcoin_hashes")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
     #[inline]
     pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
@@ -383,7 +383,7 @@ impl SecretKey {
     }
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 impl<T: ThirtyTwoByteHash> From<T> for SecretKey {
     /// Converts a 32-byte hash directly to a secret key without error paths.
     fn from(t: T) -> SecretKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::{fmt, mem, str};
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 pub use bitcoin_hashes as hashes;
 #[cfg(feature = "global-context")]
@@ -200,7 +200,7 @@ pub use serde;
 pub use crate::context::*;
 use crate::ffi::types::AlignedType;
 use crate::ffi::CPtr;
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 use crate::hashes::Hash;
 pub use crate::key::{PublicKey, SecretKey, *};
 pub use crate::scalar::Scalar;
@@ -213,19 +213,19 @@ pub trait ThirtyTwoByteHash {
     fn into_32(self) -> [u8; 32];
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl ThirtyTwoByteHash for hashes::sha256::Hash {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl ThirtyTwoByteHash for hashes::sha256d::Hash {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
 }
 
-#[cfg(feature = "bitcoin-hashes")]
+#[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl<T: hashes::sha256t::Tag> ThirtyTwoByteHash for hashes::sha256t::Hash<T> {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
@@ -274,7 +274,7 @@ impl Message {
     /// assert_eq!(m1, m2);
     /// # }
     /// ```
-    #[cfg(feature = "bitcoin-hashes")]
+    #[cfg(feature = "bitcoin_hashes")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
     pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
         <H as hashes::Hash>::hash(data).into()
@@ -1037,7 +1037,7 @@ mod tests {
         assert!(SECP256K1.verify_ecdsa(&msg, &sig, &pk).is_ok());
     }
 
-    #[cfg(feature = "bitcoin-hashes")]
+    #[cfg(feature = "bitcoin_hashes")]
     #[test]
     fn test_from_hash() {
         use crate::hashes::{self, Hash};

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -45,7 +45,7 @@ macro_rules! impl_display_secret {
             }
         }
 
-        #[cfg(all(not(feature = "std"), feature = "bitcoin-hashes"))]
+        #[cfg(all(not(feature = "std"), feature = "bitcoin_hashes"))]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 use crate::hashes::{sha256, Hash, HashEngine};
@@ -63,7 +63,7 @@ macro_rules! impl_display_secret {
             }
         }
 
-        #[cfg(all(not(feature = "std"), not(feature = "bitcoin-hashes")))]
+        #[cfg(all(not(feature = "std"), not(feature = "bitcoin_hashes")))]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 write!(f, "<secret requires std or bitcoin_hashes feature to display>")


### PR DESCRIPTION
We (I) recently added a feature alias "bitcoin-hashes" to try to make the use of the library more ergonomic, in doing so we also used "bitcoin-hashes" to feature guard code - this has negative consequences because it leads to a situation where a devs typical workflow of enabling a feature by using its dependency name breaks because one can enable "bitcoin_hashes" and not get the feature gated code. We already have a whole mess because of "std" so the only people using "bitcoin_hashes" should be those doing "no-std" builds but still this was a regression.

Originally the goal was to shield users from the historical mistake of using the underscore that cannot be fixed. This is still an admirable goal, hence in docs and example code keep using "bitcoin-hashes" as the feature. And since we re-export `bitcoin_hashes` both here in secp and in bitcoin new users will hopefully just use `secp256k1::hashes` and slowly start to forget about `bitcoin_hashes` :)