### PR TITLE
Remove unnecessary cast

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -59,7 +59,7 @@ impl Signature {
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_c_ptr(),
-                data.len() as usize,
+                data.len(),
             ) == 1
             {
                 Ok(Signature(ret))
@@ -105,7 +105,7 @@ impl Signature {
                 ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_c_ptr(),
-                data.len() as usize,
+                data.len(),
             ) == 1
             {
                 Ok(Signature(ret))

--- a/src/key.rs
+++ b/src/key.rs
@@ -486,7 +486,7 @@ impl PublicKey {
                 ffi::secp256k1_context_no_precomp,
                 &mut pk,
                 data.as_c_ptr(),
-                data.len() as usize,
+                data.len(),
             ) == 1
             {
                 Ok(PublicKey(pk))


### PR DESCRIPTION
A recent update to clippy introduced a new class of warning.

Clippy emits:

 warning: casting to the same type is unnecessary (`usize` -> `usize`)

As suggested remove the unnecessary cast.