### PR TITLE
Add secp256k1_schnorrsig_sign_custom in fuzzing config

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -1315,6 +1315,19 @@ mod fuzz_dummy {
         1
     }
 
+
+    // Forwards to regular schnorrsig_sign function.
+    pub unsafe fn secp256k1_schnorrsig_sign_custom(
+        cx: *const Context,
+        sig: *mut c_uchar,
+        msg: *const c_uchar,
+        _msg_len: size_t,
+        keypair: *const KeyPair,
+        _extra_params: *const SchnorrSigExtraParams,
+    ) -> c_int {
+        secp256k1_schnorrsig_sign(cx, sig, msg, keypair, ptr::null())
+    }
+
     // Extra keys
     pub unsafe fn secp256k1_keypair_create(
         cx: *const Context,


### PR DESCRIPTION
Trying to do some fuzz testing I noticed that I had omitted to add `secp256k1_schnorrsig_sign_custom` to the `fuzz_dummy` module of `secp256k1sys` crate in #440. This PR adds it. I just forwarded the call to `secp256k1_schnorrsig_sign` as I didn't have any better idea but open to suggestions.