### PR TITLE
backport: fix rand-std feature for old cargo versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.24.2"
+version = "0.24.3"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"
@@ -23,7 +23,7 @@ std = ["alloc", "secp256k1-sys/std"]
 # allow use of Secp256k1::new and related API that requires an allocator
 alloc = ["secp256k1-sys/alloc"]
 bitcoin-hashes-std = ["bitcoin_hashes/std"]
-rand-std = ["rand/std", "rand/std_rng"]
+rand-std = ["rand", "rand/std", "rand/std_rng"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std"]


### PR DESCRIPTION
There is a bugfix https://github.com/rust-lang/cargo/pull/8395 which appears in cargo 1.46, after our MSRV of 1.41. This means that under 1.41, users of the rand-std feature may nondeterministically see compilation fail.

In particular, users of rust-bitcoin 0.29 seem to have started seeing failures starting on 2023-01-12, where the 'rand-std' feature would be enabled in this library but 'rand' was not.

This commit simply makes the 'rand' dependency explicit, to avoid the nondeterministic bug in cargo's feature resolver.

Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/1546