### PR TITLE
add redundant features for cargo 1.41 bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ std = ["alloc", "secp256k1-sys/std"]
 # allow use of Secp256k1::new and related API that requires an allocator
 alloc = ["secp256k1-sys/alloc"]
 bitcoin-hashes = ["bitcoin_hashes"] # Feature alias because of the underscore.
-bitcoin-hashes-std = ["std", "bitcoin_hashes/std"]
-rand-std = ["std", "rand/std", "rand/std_rng"]
+bitcoin-hashes-std = ["std", "bitcoin_hashes", "bitcoin_hashes/std"]
+rand-std = ["std", "rand", "rand/std", "rand/std_rng"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std"]


### PR DESCRIPTION
It looks like cargo versions up to 1.45 have a bug that sometimes causes dependency resolution to fail. There is a straightforward, somewhat ugly fix, which this PR implements.

In #571 we implemented this and rush-merged it into 0.24.x because (a) it was breaking our CI, (b) it was clearly harmless, even if it turn out not to be the best decision. For this PR I'd like somebody other than me and Sanket to take a look and sanity check us.

If we merged this, it will also need a backport to 0.25.x.

For more details see #571 and the linked issues there.