### PR TITLE
Patch the bitcoin_hashes dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ global-context = ["std"]
 # and is not necessary.)
 global-context-less-secure = ["global-context"]
 
+[patch.crates-io]
+# This is the commit that we imported hashes into rust-bitcoin.
+bitcoin_hashes = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "b9643bf3e9b21e4e2207ea210d1d57ffa014d271" }
+
 [dependencies]
 secp256k1-sys = { version = "0.8.0", default-features = false, path = "./secp256k1-sys" }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ global-context = ["std"]
 global-context-less-secure = ["global-context"]
 
 [patch.crates-io]
-# This is the commit that we imported hashes into rust-bitcoin.
-bitcoin_hashes = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "b9643bf3e9b21e4e2207ea210d1d57ffa014d271" }
+# Arbitrary commit during dev of v0.12.0 (and rust-bitcoin v0.30.0)
+bitcoin_hashes = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "f90338021bda8be8c648cdd0e9276ccad54eef9a" }
 
 [dependencies]
 secp256k1-sys = { version = "0.8.0", default-features = false, path = "./secp256k1-sys" }

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -11,7 +11,7 @@ fn verify<C: Verification>(
     pubkey: [u8; 33],
 ) -> Result<bool, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
@@ -24,7 +24,7 @@ fn sign<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::Signature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa(&msg, &seckey))
 }

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -11,7 +11,7 @@ fn recover<C: Verification>(
     recovery_id: u8,
 ) -> Result<PublicKey, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let id = ecdsa::RecoveryId::from_i32(recovery_id as i32)?;
     let sig = ecdsa::RecoverableSignature::from_compact(&sig, id)?;
 
@@ -24,7 +24,7 @@ fn sign_recovery<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::RecoverableSignature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa_recoverable(&msg, &seckey))
 }


### PR DESCRIPTION
Currently we have a hole in our dependency graph that is making it impossible to patch `bitcoin_hashes` with breaking changes.

  bitcoin -> secp -> hashes
  bitcoin -> hashes

Make `secp256k1` depend on a dev version of `hashes` - done as two separate patches, one for the initial import of `hashes` into `rust-bitcoin` and one for the current version.

With this applied, when patching `hashes` with a breaking change, we will be able to build the code still.
