### PR TITLE
Fix CI

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -71,7 +71,6 @@ use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
 color = "Auto"
-required_version = "1.5.1"
 unstable_features = false
 disable_all_formatting = false
 skip_children = false

--- a/src/key.rs
+++ b/src/key.rs
@@ -89,7 +89,7 @@ impl AsRef<[u8; constants::SECRET_KEY_SIZE]> for SecretKey {
     /// please consider using it to do comparisons of secret keys.
     #[inline]
     fn as_ref(&self) -> &[u8; constants::SECRET_KEY_SIZE] {
-        let &SecretKey(ref dat) = self;
+        let SecretKey(dat) = self;
         dat
     }
 }
@@ -108,7 +108,7 @@ impl ffi::CPtr for SecretKey {
     type Target = u8;
 
     fn as_c_ptr(&self) -> *const Self::Target {
-        let &SecretKey(ref dat) = self;
+        let SecretKey(dat) = self;
         dat.as_ptr()
     }
 
@@ -2200,7 +2200,7 @@ mod test {
         ];
         static SK_STR: &str = "01010101010101010001020304050607ffff0000ffff00006363636363636363";
 
-        let sk = KeyPair::from_seckey_slice(&SECP256K1, &SK_BYTES).unwrap();
+        let sk = KeyPair::from_seckey_slice(SECP256K1, &SK_BYTES).unwrap();
         #[rustfmt::skip]
         assert_tokens(&sk.compact(), &[
             Token::Tuple{ len: 32 },
@@ -2378,11 +2378,9 @@ mod test {
             99, 99, 99, 99, 99, 99, 99, 99
         ];
 
-        static PK_STR: &'static str = "\
-            18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166\
-        ";
+        static PK_STR: &str = "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
 
-        let kp = KeyPair::from_seckey_slice(&crate::SECP256K1, &SK_BYTES).unwrap();
+        let kp = KeyPair::from_seckey_slice(crate::SECP256K1, &SK_BYTES).unwrap();
         let (pk, _parity) = XOnlyPublicKey::from_keypair(&kp);
 
         #[rustfmt::skip]
@@ -2418,7 +2416,7 @@ mod test {
         let sec_key_str = "4242424242424242424242424242424242424242424242424242424242424242";
         let keypair = KeyPair::from_seckey_str(&ctx, sec_key_str).unwrap();
 
-        serde_test::assert_tokens(&keypair.readable(), &[Token::String(&sec_key_str)]);
+        serde_test::assert_tokens(&keypair.readable(), &[Token::String(sec_key_str)]);
 
         let sec_key_bytes = keypair.secret_key().secret_bytes();
         let tokens = std::iter::once(Token::Tuple { len: 32 })


### PR DESCRIPTION
Currently CI is broken because we use the latest version of `rustfmt` and `clippy` in CI. We can resolve the `rustfmt` issue permanently by removing the `required_version` config option. We also need to fix the latest clippy warnings.

Done as a single patch so that all patches pass CI.
