### PR TITLE
Rename hashes methods

### DIFF
--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -11,7 +11,7 @@ fn verify<C: Verification>(
     pubkey: [u8; 33],
 ) -> Result<bool, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
@@ -24,7 +24,7 @@ fn sign<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::Signature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa(&msg, &seckey))
 }

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -11,7 +11,7 @@ fn recover<C: Verification>(
     recovery_id: u8,
 ) -> Result<PublicKey, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let id = ecdsa::RecoveryId::from_i32(recovery_id as i32)?;
     let sig = ecdsa::RecoverableSignature::from_compact(&sig, id)?;
 
@@ -24,7 +24,7 @@ fn sign_recovery<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::RecoverableSignature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(&msg)?;
+    let msg = Message::from_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa_recoverable(&msg, &seckey))
 }

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -259,7 +259,7 @@ mod tests {
         engine.input(&xy.as_ref()[..32]);
         let secret_bh = sha256::Hash::from_engine(engine);
 
-        assert_eq!(secret_bh.as_inner(), secret_sys.as_ref());
+        assert_eq!(secret_bh.as_byte_array(), secret_sys.as_ref());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,19 +216,19 @@ pub trait ThirtyTwoByteHash {
 #[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl ThirtyTwoByteHash for hashes::sha256::Hash {
-    fn into_32(self) -> [u8; 32] { self.into_inner() }
+    fn into_32(self) -> [u8; 32] { self.to_byte_array() }
 }
 
 #[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl ThirtyTwoByteHash for hashes::sha256d::Hash {
-    fn into_32(self) -> [u8; 32] { self.into_inner() }
+    fn into_32(self) -> [u8; 32] { self.to_byte_array() }
 }
 
 #[cfg(feature = "bitcoin_hashes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoin-hashes")))]
 impl<T: hashes::sha256t::Tag> ThirtyTwoByteHash for hashes::sha256t::Hash<T> {
-    fn into_32(self) -> [u8; 32] { self.into_inner() }
+    fn into_32(self) -> [u8; 32] { self.to_byte_array() }
 }
 
 /// A (hashed) message input to an ECDSA signature.
@@ -1046,12 +1046,12 @@ mod tests {
 
         let hash = hashes::sha256::Hash::hash(test_bytes);
         let msg = Message::from(hash);
-        assert_eq!(msg.0, hash.into_inner());
+        assert_eq!(msg.0, hash.to_byte_array());
         assert_eq!(msg, Message::from_hashed_data::<hashes::sha256::Hash>(test_bytes));
 
         let hash = hashes::sha256d::Hash::hash(test_bytes);
         let msg = Message::from(hash);
-        assert_eq!(msg.0, hash.into_inner());
+        assert_eq!(msg.0, hash.to_byte_array());
         assert_eq!(msg, Message::from_hashed_data::<hashes::sha256d::Hash>(test_bytes));
     }
 }


### PR DESCRIPTION
## This is not a merge candidate

This branch is just so we can get `rust-bitcoin` building with the `hashes` changes in place in https://github.com/rust-bitcoin/rust-bitcoin/pull/1577

We just changed a few method names on hash types in `hashes`, use the new method names. Includes a few `as_ref` calls needed so this branch will build with `rust-bitcoin` master branch.
