### PR TITLE
Document sig verify's intentional limitation

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -190,6 +190,7 @@ impl Signature {
     }
 
     /// Verifies an ECDSA signature for `msg` using `pk` and the global [`SECP256K1`] context.
+    /// The signature must be normalized or verification will fail (see [`normalize_s`]).
     #[inline]
     #[cfg(feature = "global-context")]
     #[cfg_attr(docsrs, doc(cfg(feature = "global-context")))]


### PR DESCRIPTION
This bit of documentation is similar to the secp256k1 C lib comment:

```
 * To avoid accepting malleable signatures, only ECDSA signatures in lower-S
 * form are accepted.
 ```