### PR TITLE
Use `core::error` instead of `std::error` to increase compatibility in `no_std` environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ global-context = ["std"]
 # if you are doing a no-std build, then this feature does nothing
 # and is not necessary.)
 global-context-less-secure = ["global-context"]
+core-error = []
 
 [dependencies]
 secp256k1-sys = { version = "0.8.1", default-features = false, path = "./secp256k1-sys" }

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="bitcoin-hashes global-context lowmemory rand recovery serde std alloc bitcoin-hashes-std rand-std"
+FEATURES="bitcoin-hashes global-context lowmemory rand recovery serde std alloc bitcoin-hashes-std rand-std core-error"
 
 cargo --version
 rustc --version

--- a/src/key.rs
+++ b/src/key.rs
@@ -1442,6 +1442,10 @@ impl fmt::Display for InvalidParityValue {
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for InvalidParityValue {}
 
+#[cfg(all(feature = "core-error", not(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "core-error")))]
+impl core::error::Error for InvalidParityValue {}
+
 impl From<InvalidParityValue> for Error {
     fn from(error: InvalidParityValue) -> Self { Error::InvalidParityValue(error) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(bench, feature(test))]
+// Error in no_std
+#![cfg_attr(feature = "core-error", feature(error_in_core))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -352,6 +354,25 @@ impl fmt::Display for Error {
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::IncorrectSignature => None,
+            Error::InvalidMessage => None,
+            Error::InvalidPublicKey => None,
+            Error::InvalidSignature => None,
+            Error::InvalidSecretKey => None,
+            Error::InvalidSharedSecret => None,
+            Error::InvalidRecoveryId => None,
+            Error::InvalidTweak => None,
+            Error::NotEnoughMemory => None,
+            Error::InvalidPublicKeySum => None,
+            Error::InvalidParityValue(error) => Some(error),
+        }
+    }
+}
+#[cfg(all(feature = "core-error", not(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "core-error")))]
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Error::IncorrectSignature => None,
             Error::InvalidMessage => None,


### PR DESCRIPTION
There is a `thiserror` fork called `thiserror-core` which allows it to be used in `no_std` environments.

I added a new feature flag `core-error` which enables the currently not yet stabilized `error_in_core` feature.
This enables the `thiserror-core` crate to work fine.