### PR TITLE
Rework GitHub actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,64 +3,111 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  Nightly:
-    name: Nightly - ASan + Bench + Docs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Crate
-        uses: actions/checkout@v2
-      - name: Install clang for ASan
-        run: sudo apt-get install -y clang
-      - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rust-src
-      - name: Check formatting
-        env:
-          DO_FMT: true
-        run: ./contrib/test.sh
-      - name: Running address sanitizer
-        env:
-          DO_ASAN: true
-        run: ./contrib/test.sh
-      - name: Running benchmarks
-        env:
-          DO_BENCH: true
-        run: ./contrib/test.sh
-      - name: Building docs
-        env:
-          DO_DOCS: true
-        run: ./contrib/test.sh
-
-  Tests:
-    name: Tests
+  Stable:
+    name: Test - stable toolchain
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        rust: [stable, beta, nightly, 1.48.0]
+      fail-fast: false
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - name: Running cargo
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Running test script
+        env:
+          DO_LINT: true
+          DO_DOCS: true
+          DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  Beta:
+    name: Test - beta toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@beta
+      - name: Running test script
+        run: ./contrib/test.sh
+
+  Nightly:
+    name: Test - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install src
+        run: rustup component add rust-src
+      - name: Running test script
+        env:
+          DO_FMT: true
+          DO_BENCH: true
+          DO_DOCSRS: true
+          DO_ASAN: true
+        run: ./contrib/test.sh
+
+  MSRV:
+    name: Test - 1.48.0 toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@1.48.0
+      - name: Running test script
         env:
           DO_FEATURE_MATRIX: true
         run: ./contrib/test.sh
+
+  Arch32bit:
+    name: Test 32-bit version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Add architecture i386
+        run: sudo dpkg --add-architecture i386
+      - name: Install i686 gcc
+        run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib
+      - name: Install target
+        run: rustup target add i686-unknown-linux-gnu
+      - name: Run test on i686
+        run: cargo test --target i686-unknown-linux-gnu
+
+  Cross:
+    name: Cross test
+    if: ${{ !github.event.act }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install target
+        run: rustup target add s390x-unknown-linux-gnu
+      - name: install cross
+        run: cargo install cross --locked
+      - name: run cross test
+        run: cross test --target s390x-unknown-linux-gnu
 
   WASM:
     name: WASM
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install clang
         run: sudo apt-get install -y clang
       - name: Checkout Toolchain
@@ -69,19 +116,3 @@ jobs:
         env:
           DO_WASM: true
         run: ./contrib/test.sh
-
-  Clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features=rand-std,recovery,lowmemory,global-context --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,21 +58,13 @@ jobs:
   WASM:
     name: WASM
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable, beta, nightly] # wasm-pack doesn't support rust 1.41.1
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
       - name: Install clang
         run: sudo apt-get install -y clang
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rust-src
+        uses: dtolnay/rust-toolchain@stable
       - name: Running WASM tests
         env:
           DO_WASM: true

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -58,9 +58,23 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     cargo run --example generate_keys --features=rand-std
 fi
 
+if [ "$DO_LINT" = true ]
+then
+    cargo clippy --all-features --all-targets -- -D warnings
+    cargo clippy --example sign_verify --features=bitcoin-hashes-std -- -D warnings
+    cargo clippy --example sign_verify_recovery --features=recovery,bitcoin-hashes-std -- -D warnings
+    cargo clippy --example generate_keys --features=rand-std -- -D warnings
+fi
+
 # Build the docs if told to (this only works with the nightly toolchain)
+if [ "$DO_DOCSRS" = true ]; then
+    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
+fi
+
+# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
+# above this checks that we feature guarded docs imports correctly.
 if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs" cargo rustdoc --features="$FEATURES" -- -D rustdoc::broken-intra-doc-links -D warnings || exit 1
+    RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
 fi
 
 # Webassembly stuff


### PR DESCRIPTION
Rework the github actions script in line with `rust-bitcoin`, notably:

- Only run WASM test using stable toolchain (is this ok? cargo-cult-programmed from rust-bitcoin)
- Use dtonlay runner
- Split jobs up by toolchain
- Add Arch32bit job
- Add Cross test job
- Run linter as part of the test script
- Test docs build using stable toolchain and nightly toolchain
