### PR TITLE
Add toolchain matrix to WASM job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,13 +105,16 @@ jobs:
   WASM:
     name: WASM
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, beta, nightly, 1.48.0]
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v3
       - name: Install clang
         run: sudo apt-get install -y clang
       - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@${{ matrix.toolchain }}
       - name: Running WASM tests
         env:
           DO_WASM: true


### PR DESCRIPTION
Recently I changed CI to use the dtolnay runner and in doing so introduced a regression (knowingly) whereby we only ran the WASM tests with the stable toolchain.

Run the WASM tests with multiple toolchains
- stable
- beta
- 1.48.0
- nightly