### PR TITLE
Implement new global context

### DIFF
--- a/examples/generate_keys.rs
+++ b/examples/generate_keys.rs
@@ -1,16 +1,17 @@
+#![cfg(feature = "std")]
+
 extern crate secp256k1;
 
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{PublicKey, SecretKey};
 
 fn main() {
-    let secp = Secp256k1::new();
     let mut rng = rand::thread_rng();
     // First option:
-    let (seckey, pubkey) = secp.generate_keypair(&mut rng);
+    let (seckey, pubkey) = secp256k1::generate_keypair(&mut rng);
 
-    assert_eq!(pubkey, PublicKey::from_secret_key(&secp, &seckey));
+    assert_eq!(pubkey, PublicKey::from_secret_key(&seckey));
 
     // Second option:
     let seckey = SecretKey::new(&mut rng);
-    let _pubkey = PublicKey::from_secret_key(&secp, &seckey);
+    let _pubkey = PublicKey::from_secret_key(&seckey);
 }

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -195,9 +195,8 @@ mod tests {
     #[test]
     #[cfg(feature = "rand-std")]
     fn ecdh() {
-        let s = Secp256k1::signing_only();
-        let (sk1, pk1) = s.generate_keypair(&mut rand::thread_rng());
-        let (sk2, pk2) = s.generate_keypair(&mut rand::thread_rng());
+        let (sk1, pk1) = crate::generate_keypair(&mut rand::thread_rng());
+        let (sk2, pk2) = crate::generate_keypair(&mut rand::thread_rng());
 
         let sec1 = SharedSecret::new(&pk2, &sk1);
         let sec2 = SharedSecret::new(&pk1, &sk2);
@@ -231,9 +230,8 @@ mod tests {
 
         use crate::ecdh::shared_secret_point;
 
-        let s = Secp256k1::signing_only();
-        let (sk1, _) = s.generate_keypair(&mut rand::thread_rng());
-        let (_, pk2) = s.generate_keypair(&mut rand::thread_rng());
+        let (sk1, _) = crate::generate_keypair(&mut rand::thread_rng());
+        let (_, pk2) = crate::generate_keypair(&mut rand::thread_rng());
 
         let secret_sys = SharedSecret::new(&pk2, &sk1);
 

--- a/src/ecdsa/global.rs
+++ b/src/ecdsa/global.rs
@@ -1,0 +1,86 @@
+//! Drop in replacement for all the methods currently implemented on the global context (SECP256K1).
+
+use core::ptr;
+
+use super::Signature;
+use crate::ffi::CPtr;
+use crate::{ffi, Error, Message, PublicKey, SecretKey};
+
+/// Constructs a signature for `msg` using the secret key `sk` and RFC6979 nonce
+pub fn sign_ecdsa(msg: &Message, sk: &SecretKey) -> Signature {
+    sign_ecdsa_with_noncedata_pointer(msg, sk, None)
+}
+
+/// Constructs a signature for `msg` using the secret key `sk` and RFC6979 nonce
+/// and includes 32 bytes of noncedata in the nonce generation via inclusion in
+/// one of the hash operations during nonce generation. This is useful when multiple
+/// signatures are needed for the same Message and SecretKey while still using RFC6979.
+/// Requires a signing-capable context.
+pub fn sign_ecdsa_with_noncedata(msg: &Message, sk: &SecretKey, noncedata: &[u8; 32]) -> Signature {
+    sign_ecdsa_with_noncedata_pointer(msg, sk, Some(noncedata))
+}
+
+/// Checks that `sig` is a valid ECDSA signature for `msg` using the public
+/// key `pubkey`. Returns `Ok(())` on success. Note that this function cannot
+/// be used for Bitcoin consensus checking since there may exist signatures
+/// which OpenSSL would verify but not libsecp256k1, or vice-versa. Requires a
+/// verify-capable context.
+///
+/// ```rust
+/// # #[cfg(feature = "rand-std")] {
+/// # use secp256k1::{rand, Secp256k1, Message, Error};
+/// #
+/// # let secp = Secp256k1::new();
+/// # let (secret_key, public_key) = secp.generate_keypair(&mut rand::thread_rng());
+/// #
+/// let message = Message::from_slice(&[0xab; 32]).expect("32 bytes");
+/// let sig = secp.sign_ecdsa(&message, &secret_key);
+/// assert_eq!(secp.verify_ecdsa(&message, &sig, &public_key), Ok(()));
+///
+/// let message = Message::from_slice(&[0xcd; 32]).expect("32 bytes");
+/// assert_eq!(secp.verify_ecdsa(&message, &sig, &public_key), Err(Error::IncorrectSignature));
+/// # }
+/// ```
+#[inline]
+pub fn verify_ecdsa(msg: &Message, sig: &Signature, pk: &PublicKey) -> Result<(), Error> {
+    unsafe {
+        crate::context::_global::with_global_verify_context(|ctx| {
+            if ffi::secp256k1_ecdsa_verify(ctx, sig.as_c_ptr(), msg.as_c_ptr(), pk.as_c_ptr()) == 0
+            {
+                Err(Error::IncorrectSignature)
+            } else {
+                Ok(())
+            }
+        })
+    }
+}
+
+fn sign_ecdsa_with_noncedata_pointer(
+    msg: &Message,
+    sk: &SecretKey,
+    noncedata: Option<&[u8; 32]>,
+) -> Signature {
+    unsafe {
+        let mut ret = ffi::Signature::new();
+        let noncedata_ptr = match noncedata {
+            Some(arr) => arr.as_c_ptr() as *const _,
+            None => ptr::null(),
+        };
+        crate::context::_global::with_global_signing_context(|ctx| {
+            // We can assume the return value because it's not possible to construct
+            // an invalid signature from a valid `Message` and `SecretKey`
+            assert_eq!(
+                ffi::secp256k1_ecdsa_sign(
+                    ctx,
+                    &mut ret,
+                    msg.as_c_ptr(),
+                    sk.as_c_ptr(),
+                    ffi::secp256k1_nonce_function_rfc6979,
+                    noncedata_ptr
+                ),
+                1
+            );
+        });
+        Signature::from(ret)
+    }
+}

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -3,6 +3,8 @@
 //! Structs and functionality related to the ECDSA signature algorithm.
 //!
 
+#[cfg(feature = "std")]
+pub mod global;
 #[cfg(feature = "recovery")]
 mod recovery;
 pub mod serialized_signature;
@@ -13,8 +15,6 @@ use core::{fmt, ptr, str};
 pub use self::recovery::{RecoverableSignature, RecoveryId};
 pub use self::serialized_signature::SerializedSignature;
 use crate::ffi::CPtr;
-#[cfg(feature = "global-context")]
-use crate::SECP256K1;
 use crate::{
     ffi, from_hex, Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verification,
 };
@@ -190,12 +190,12 @@ impl Signature {
         ret
     }
 
-    /// Verifies an ECDSA signature for `msg` using `pk` and the global [`SECP256K1`] context.
+    /// Verifies an ECDSA signature for `msg` using `pk` and the global signing context.
     /// The signature must be normalized or verification will fail (see [`Signature::normalize_s`]).
     #[inline]
     #[cfg(feature = "global-context")]
     pub fn verify(&self, msg: &Message, pk: &PublicKey) -> Result<(), Error> {
-        SECP256K1.verify_ecdsa(msg, self, pk)
+        crate::ecdsa::global::verify_ecdsa(msg, self, pk)
     }
 }
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -229,7 +229,7 @@ mod tests {
         let msg = Message::from_slice(&msg).unwrap();
 
         // Try key generation
-        let (sk, pk) = full.generate_keypair(&mut rand::thread_rng());
+        let (sk, pk) = crate::generate_keypair(&mut rand::thread_rng());
 
         // Try signing
         assert_eq!(sign.sign_ecdsa_recoverable(&msg, &sk), full.sign_ecdsa_recoverable(&msg, &sk));
@@ -309,7 +309,7 @@ mod tests {
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
         let msg = Message::from_slice(&msg).unwrap();
 
-        let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
+        let (sk, pk) = crate::generate_keypair(&mut rand::thread_rng());
 
         let sigr = s.sign_ecdsa_recoverable(&msg, &sk);
         let sig = sigr.to_standard();
@@ -331,7 +331,7 @@ mod tests {
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
         let msg = Message::from_slice(&msg).unwrap();
 
-        let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
+        let (sk, pk) = crate::generate_keypair(&mut rand::thread_rng());
 
         let sig = s.sign_ecdsa_recoverable(&msg, &sk);
 
@@ -349,7 +349,7 @@ mod tests {
 
         let noncedata = [42u8; 32];
 
-        let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
+        let (sk, pk) = crate::generate_keypair(&mut rand::thread_rng());
 
         let sig = s.sign_ecdsa_recoverable_with_noncedata(&msg, &sk, &noncedata);
 

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -341,6 +341,9 @@ mod tests {
         let sk = SecretKey::from_keypair(&keypair);
         assert_eq!(SecretKey::from_str(sk_str).unwrap(), sk);
         let pk = crate::key::PublicKey::from_keypair(&keypair);
+        #[cfg(feature = "std")]
+        assert_eq!(crate::key::PublicKey::from_secret_key(&sk), pk);
+        #[cfg(not(feature = "std"))]
         assert_eq!(crate::key::PublicKey::from_secret_key(&secp, &sk), pk);
         let (xpk, _parity) = keypair.x_only_public_key();
         assert_eq!(XOnlyPublicKey::from(pk), xpk);


### PR DESCRIPTION
Draft for feedback please!

This is an attempt at implementing the epic multiple global contexts suggested by @Kixunil: https://github.com/rust-bitcoin/rust-secp256k1/pull/539#issuecomment-1328237989

Any deviation from the "spec" is unintentional except that I set the swap bit and active context bit in a different place.

