### PR TITLE
Introduce SPDX license identifiers

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -1,16 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2019 by
-//   Elichai Turkel
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # secp256k1 no-std test.
 //! This binary is a short smallest rust code to produce a working binary *without libstd*.

--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -1,16 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2015 by
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Build script
 

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -1,17 +1,5 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
+
 //! # secp256k1-sys FFI bindings
 //! Direct bindings to the underlying C library functions. These should
 //! not be needed for most users.

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -1,17 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 /// Implement methods and traits for types that contain an inner array.
 #[macro_export]

--- a/secp256k1-sys/src/recovery.rs
+++ b/secp256k1-sys/src/recovery.rs
@@ -1,17 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # FFI of the recovery module
 

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 #![allow(non_camel_case_types)]
 
 pub type c_int = i32;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,17 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Constants related to the API and the underlying curve.
 //!

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ptr::NonNull;

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -1,16 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2015 by
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Support for shared secret computations.
 //!

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Structs and functionality related to the ECDSA signature algorithm.
 //!
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -1,17 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Provides a signing function that allows recovering the public key from the
 //! signature.

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Implements [`SerializedSignature`] and related types.
 //!
 //! DER-serialized signatures have the issue that they can have different lengths.

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,17 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Public and secret keys.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Rust bindings for Pieter Wuille's secp256k1 library, which is used for
 //! fast and accurate manipulation of ECDSA signatures on the secp256k1

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,17 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2014 by
-//   Dawid Ciężarkiewicz
-//   Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 /// Implement methods and traits for types that contain an inner array.
 #[macro_export]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Provides [`Scalar`] and related types.
 //!
 //! In elliptic curve cryptography scalars are non-point values that can be used to multiply

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Support for schnorr signatures.
 //!
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,16 +1,4 @@
-// Bitcoin secp256k1 bindings
-// Written in 2021 by
-//   Maxim Orlovsky <orlovsky@pandoracore.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Helpers for displaying secret values
 

--- a/src/serde_util.rs
+++ b/src/serde_util.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 use core::fmt;
 use core::marker::PhantomData;
 use core::str::{self, FromStr};


### PR DESCRIPTION
Licenses are boring as hell, so is are all the comments at the top of each file. This patch makes no comment on the merit of license comments in each file, rather this patch reduces the license comment to the minimum possible with no loss of meaning - an SPDX license identifier.

Note also please that we remove the "written by" comments as well for the following reasons (discussed recently on rust-bitcoin repo):

- they are not descriptive because many devs contributed
- they have a tendency to include the wrong date because of cut'n'pasta
- all this info is in the git history

ref: https://spdx.dev/ids/#how


cc elichai because this PR removes your name but you were not explicitly part of the conversation on `rust-bitcoin` about this topic. Here is the issue: https://github.com/rust-bitcoin/rust-bitcoin/issues/1816 also for more on SPDX see https://github.com/rust-bitcoin/rust-bitcoin/pull/1076