### PR TITLE
Add changelog entry for removal of ONE_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [Introduce `rustfmt`](https://github.com/rust-bitcoin/rust-secp256k1/pull/499) to the codebase.
 * [Make all raw pointer methods go through the CPtr trait](https://github.com/rust-bitcoin/rust-secp256k1/pull/507).
 * [Make comparison functions stable](https://github.com/rust-bitcoin/rust-secp256k1/pull/518).
+* [Remove](https://github.com/rust-bitcoin/rust-secp256k1/pull/512) public constant `ONE_KEY` (consider using `FromStr` as a replacement).
 
 # 0.24.1 - 2022-10-25
 


### PR DESCRIPTION
In the 0.25.0 release we removed the `ONE_KEY` const but did not mention it in the release notes. This makes upgrade harder than it should be.

In hindsight we should have deprecated the const then removed it.

Add a changelog entry to the 0.25.0 release mentioning the removal and the work around.