### PR TITLE
Fix broken stuff

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,16 +105,13 @@ jobs:
   WASM:
     name: WASM
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain: [stable, beta, nightly, 1.48.0]
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v3
       - name: Install clang
         run: sudo apt-get install -y clang
       - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@stable
       - name: Running WASM tests
         env:
           DO_WASM: true

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -13,18 +13,17 @@ if cargo --version | grep nightly; then
     NIGHTLY=true
 fi
 
+# Pin dependencies as required if we are using MSRV toolchain.
+if cargo --version | grep "1\.48"; then
+    cargo update -p wasm-bindgen-test --precise 0.3.34
+    cargo update -p serde --precise 1.0.156
+fi
+
 # Test if panic in C code aborts the process (either with a real panic or with SIGILL)
 cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at '\[libsecp256k1\]"
 
 # Make all cargo invocations verbose
 export CARGO_TERM_VERBOSE=true
-
-# Pin dependencies as required if we are using MSRV toolchain.
-if cargo --version | grep "1\.48"; then
-    # 1.0.157 uses syn 2.0 which requires edition 2021
-    cargo update -p serde_json --precise 1.0.99
-    cargo update -p serde --precise 1.0.156
-fi
 
 # Defaults / sanity checks
 cargo build --all


### PR DESCRIPTION
Goodness me, I made a mess.

Commit `0e0dcb7f CI: Pin dependencies required for MSRV build` is totally wrong, why did it get through CI?
    
Fix broken stuff in the CI script by doing:
    
- `serde_json` is not a dependency of `secp256k1`, remove the pinning
- Put the pinning _before_ any call to `cargo`
- Pin the transient dependency `wasm-bindgen-test`

And then `Revert "WIP: Add toolchain matrix to job"`

Fix: #626 