### PR TITLE
Clean up the hashes dependency/feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ default = ["std"]
 std = ["alloc", "secp256k1-sys/std"]
 # allow use of Secp256k1::new and related API that requires an allocator
 alloc = ["secp256k1-sys/alloc"]
-bitcoin-hashes = ["bitcoin_hashes"] # Feature alias because of the underscore.
-bitcoin-hashes-std = ["std", "bitcoin_hashes", "bitcoin_hashes/std"]
+hashes-std = ["std", "hashes/std"]
 rand-std = ["std", "rand", "rand/std", "rand/std_rng"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
@@ -40,8 +39,8 @@ secp256k1-sys = { version = "0.8.1", default-features = false, path = "./secp256
 serde = { version = "1.0.103", default-features = false, optional = true }
 
 # You likely only want to enable these if you explicitly do not want to use "std", otherwise enable
-# the respective -std feature e.g., bitcoin-hashes-std
-bitcoin_hashes = { version = "0.12", default-features = false, optional = true }
+# the respective -std feature e.g., hashes-std
+hashes = { package = "bitcoin_hashes", version = "0.12", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -57,11 +56,11 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [[example]]
 name = "sign_verify_recovery"
-required-features = ["recovery", "bitcoin-hashes-std"]
+required-features = ["recovery", "hashes-std"]
 
 [[example]]
 name = "sign_verify"
-required-features = ["bitcoin-hashes-std"]
+required-features = ["hashes-std"]
 
 [[example]]
 name = "generate_keys"

--- a/contrib/_test.sh
+++ b/contrib/_test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 REPO_DIR=$(git rev-parse --show-toplevel)
-FEATURES="bitcoin-hashes global-context lowmemory rand recovery serde std alloc bitcoin-hashes-std rand-std"
+FEATURES="hashes global-context lowmemory rand recovery serde std alloc hashes-std rand-std"
 
 cargo --version
 rustc --version
@@ -62,16 +62,16 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     fi
 
     # Examples
-    cargo run --locked --example sign_verify --features=bitcoin-hashes-std
-    cargo run --locked --example sign_verify_recovery --features=recovery,bitcoin-hashes-std
+    cargo run --locked --example sign_verify --features=hashes-std
+    cargo run --locked --example sign_verify_recovery --features=recovery,hashes-std
     cargo run --locked --example generate_keys --features=rand-std
 fi
 
 if [ "$DO_LINT" = true ]
 then
     cargo clippy --locked --all-features --all-targets -- -D warnings
-    cargo clippy --locked --example sign_verify --features=bitcoin-hashes-std -- -D warnings
-    cargo clippy --locked --example sign_verify_recovery --features=recovery,bitcoin-hashes-std -- -D warnings
+    cargo clippy --locked --example sign_verify --features=hashes-std -- -D warnings
+    cargo clippy --locked --example sign_verify_recovery --features=recovery,hashes-std -- -D warnings
     cargo clippy --locked --example generate_keys --features=rand-std -- -D warnings
 fi
 

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -1,7 +1,7 @@
-extern crate bitcoin_hashes;
+extern crate hashes;
 extern crate secp256k1;
 
-use bitcoin_hashes::{sha256, Hash};
+use hashes::{sha256, Hash};
 use secp256k1::{ecdsa, Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verification};
 
 fn verify<C: Verification>(

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -1,7 +1,7 @@
-extern crate bitcoin_hashes;
+extern crate hashes;
 extern crate secp256k1;
 
-use bitcoin_hashes::{sha256, Hash};
+use hashes::{sha256, Hash};
 use secp256k1::{ecdsa, Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verification};
 
 fn recover<C: Verification>(

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -110,7 +110,7 @@ impl AsRef<[u8]> for SharedSecret {
 ///
 /// # Examples
 /// ```
-/// # #[cfg(all(feature = "bitcoin-hashes-std", feature = "rand-std"))] {
+/// # #[cfg(all(feature = "hashes-std", feature = "rand-std"))] {
 /// # use secp256k1::{ecdh, rand, Secp256k1, PublicKey, SecretKey};
 /// # use secp256k1::hashes::{Hash, sha512};
 ///
@@ -225,9 +225,9 @@ mod tests {
 
     #[test]
     #[cfg(not(secp256k1_fuzz))]
-    #[cfg(all(feature = "bitcoin-hashes-std", feature = "rand-std"))]
-    fn bitcoin_hashes_and_sys_generate_same_secret() {
-        use bitcoin_hashes::{sha256, Hash, HashEngine};
+    #[cfg(all(feature = "hashes-std", feature = "rand-std"))]
+    fn hashes_and_sys_generate_same_secret() {
+        use hashes::{sha256, Hash, HashEngine};
 
         use crate::ecdh::shared_secret_point;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -18,7 +18,7 @@ use crate::SECP256K1;
 use crate::{
     constants, ecdsa, from_hex, schnorr, Message, Scalar, Secp256k1, Signing, Verification,
 };
-#[cfg(feature = "bitcoin_hashes")]
+#[cfg(feature = "hashes")]
 use crate::{hashes, ThirtyTwoByteHash};
 
 /// Secret 256-bit key used as `x` in an ECDSA signature.
@@ -255,12 +255,12 @@ impl SecretKey {
 
     /// Constructs a [`SecretKey`] by hashing `data` with hash algorithm `H`.
     ///
-    /// Requires the feature `bitcoin_hashes` to be enabled.
+    /// Requires the feature `hashes` to be enabled.
     ///
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature="bitcoin_hashes")] {
+    /// # #[cfg(feature="hashes")] {
     /// use secp256k1::hashes::{sha256, Hash};
     /// use secp256k1::SecretKey;
     ///
@@ -271,7 +271,7 @@ impl SecretKey {
     /// assert_eq!(sk1, sk2);
     /// # }
     /// ```
-    #[cfg(feature = "bitcoin_hashes")]
+    #[cfg(feature = "hashes")]
     #[inline]
     pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
         <H as hashes::Hash>::hash(data).into()
@@ -368,7 +368,7 @@ impl SecretKey {
     }
 }
 
-#[cfg(feature = "bitcoin_hashes")]
+#[cfg(feature = "hashes")]
 impl<T: ThirtyTwoByteHash> From<T> for SecretKey {
     /// Converts a 32-byte hash directly to a secret key without error paths.
     fn from(t: T) -> SecretKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! trigger any assertion failures in the upstream library.
 //!
 //! ```rust
-//! # #[cfg(all(feature = "rand-std", feature = "bitcoin-hashes-std"))] {
+//! # #[cfg(all(feature = "rand-std", feature = "hashes-std"))] {
 //! use secp256k1::rand::rngs::OsRng;
 //! use secp256k1::{Secp256k1, Message};
 //! use secp256k1::hashes::sha256;
@@ -45,7 +45,7 @@
 //! If the "global-context" feature is enabled you have access to an alternate API.
 //!
 //! ```rust
-//! # #[cfg(all(feature = "global-context", feature = "bitcoin-hashes-std", feature = "rand-std"))] {
+//! # #[cfg(all(feature = "global-context", feature = "hashes-std", feature = "rand-std"))] {
 //! use secp256k1::{generate_keypair, Message};
 //! use secp256k1::hashes::sha256;
 //!
@@ -57,7 +57,7 @@
 //! # }
 //! ```
 //!
-//! The above code requires `rust-secp256k1` to be compiled with the `rand-std` and `bitcoin-hashes-std`
+//! The above code requires `rust-secp256k1` to be compiled with the `rand-std` and `hashes-std`
 //! feature enabled, to get access to [`generate_keypair`](struct.Secp256k1.html#method.generate_keypair)
 //! Alternately, keys and messages can be parsed from slices, like
 //!
@@ -69,7 +69,7 @@
 //! let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
 //! let public_key = PublicKey::from_secret_key(&secp, &secret_key);
 //! // This is unsafe unless the supplied byte slice is the output of a cryptographic hash function.
-//! // See the above example for how to use this library together with `bitcoin-hashes-std`.
+//! // See the above example for how to use this library together with `hashes-std`.
 //! let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 //!
 //! let sig = secp.sign_ecdsa(&message, &secret_key);
@@ -127,8 +127,8 @@
 //! * `alloc` - use the `alloc` standard Rust library to provide heap allocations.
 //! * `rand` - use `rand` library to provide random generator (e.g. to generate keys).
 //! * `rand-std` - use `rand` library with its `std` feature enabled. (Implies `rand`.)
-//! * `bitcoin-hashes` - use the `bitcoin_hashes` library.
-//! * `bitcoin-hashes-std` - use the `bitcoin_hashes` library with its `std` feature enabled (implies `bitcoin-hashes`).
+//! * `hashes` - use the `hashes` library.
+//! * `hashes-std` - use the `hashes` library with its `std` feature enabled (implies `hashes`).
 //! * `recovery` - enable functions that can compute the public key from signature.
 //! * `lowmemory` - optimize the library for low-memory environments.
 //! * `global-context` - enable use of global secp256k1 context (implies `std`).
@@ -151,6 +151,9 @@ extern crate core;
 #[cfg(bench)]
 extern crate test;
 
+#[cfg(feature = "hashes")]
+pub extern crate hashes;
+
 #[macro_use]
 mod macros;
 #[macro_use]
@@ -170,8 +173,6 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::{fmt, mem, str};
 
-#[cfg(feature = "bitcoin_hashes")]
-pub use bitcoin_hashes as hashes;
 #[cfg(feature = "global-context")]
 pub use context::global::SECP256K1;
 #[cfg(feature = "rand")]
@@ -183,7 +184,7 @@ pub use serde;
 pub use crate::context::*;
 use crate::ffi::types::AlignedType;
 use crate::ffi::CPtr;
-#[cfg(feature = "bitcoin_hashes")]
+#[cfg(feature = "hashes")]
 use crate::hashes::Hash;
 pub use crate::key::{PublicKey, SecretKey, *};
 pub use crate::scalar::Scalar;
@@ -196,17 +197,17 @@ pub trait ThirtyTwoByteHash {
     fn into_32(self) -> [u8; 32];
 }
 
-#[cfg(feature = "bitcoin_hashes")]
+#[cfg(feature = "hashes")]
 impl ThirtyTwoByteHash for hashes::sha256::Hash {
     fn into_32(self) -> [u8; 32] { self.to_byte_array() }
 }
 
-#[cfg(feature = "bitcoin_hashes")]
+#[cfg(feature = "hashes")]
 impl ThirtyTwoByteHash for hashes::sha256d::Hash {
     fn into_32(self) -> [u8; 32] { self.to_byte_array() }
 }
 
-#[cfg(feature = "bitcoin_hashes")]
+#[cfg(feature = "hashes")]
 impl<T: hashes::sha256t::Tag> ThirtyTwoByteHash for hashes::sha256t::Hash<T> {
     fn into_32(self) -> [u8; 32] { self.to_byte_array() }
 }
@@ -268,12 +269,12 @@ impl Message {
 
     /// Constructs a [`Message`] by hashing `data` with hash algorithm `H`.
     ///
-    /// Requires the feature `bitcoin-hashes` to be enabled.
+    /// Requires the feature `hashes` to be enabled.
     ///
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "bitcoin_hashes")] {
+    /// # #[cfg(feature = "hashes")] {
     /// use secp256k1::hashes::{sha256, Hash};
     /// use secp256k1::Message;
     ///
@@ -284,7 +285,7 @@ impl Message {
     /// assert_eq!(m1, m2);
     /// # }
     /// ```
-    #[cfg(feature = "bitcoin_hashes")]
+    #[cfg(feature = "hashes")]
     pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
         <H as hashes::Hash>::hash(data).into()
     }
@@ -1042,7 +1043,7 @@ mod tests {
         assert!(SECP256K1.verify_ecdsa(&msg, &sig, &pk).is_ok());
     }
 
-    #[cfg(feature = "bitcoin_hashes")]
+    #[cfg(feature = "hashes")]
     #[test]
     fn test_from_hash() {
         use crate::hashes::{self, Hash};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@ use core::{fmt, mem, str};
 
 #[cfg(feature = "global-context")]
 pub use context::global::SECP256K1;
+#[cfg(feature = "hashes")]
+use hashes::Hash;
 #[cfg(feature = "rand")]
 pub use rand;
 pub use secp256k1_sys as ffi;
@@ -184,8 +186,6 @@ pub use serde;
 pub use crate::context::*;
 use crate::ffi::types::AlignedType;
 use crate::ffi::CPtr;
-#[cfg(feature = "hashes")]
-use crate::hashes::Hash;
 pub use crate::key::{PublicKey, SecretKey, *};
 pub use crate::scalar::Scalar;
 
@@ -1046,16 +1046,16 @@ mod tests {
     #[cfg(feature = "hashes")]
     #[test]
     fn test_from_hash() {
-        use crate::hashes::{self, Hash};
+        use hashes::{sha256, sha256d, Hash};
 
         let test_bytes = "Hello world!".as_bytes();
 
-        let hash = hashes::sha256::Hash::hash(test_bytes);
+        let hash = sha256::Hash::hash(test_bytes);
         let msg = Message::from(hash);
         assert_eq!(msg.0, hash.to_byte_array());
         assert_eq!(msg, Message::from_hashed_data::<hashes::sha256::Hash>(test_bytes));
 
-        let hash = hashes::sha256d::Hash::hash(test_bytes);
+        let hash = sha256d::Hash::hash(test_bytes);
         let msg = Message::from(hash);
         assert_eq!(msg.0, hash.to_byte_array());
         assert_eq!(msg, Message::from_hashed_data::<hashes::sha256d::Hash>(test_bytes));

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -32,7 +32,7 @@ macro_rules! impl_display_secret {
             }
         }
 
-        #[cfg(all(not(feature = "std"), feature = "bitcoin_hashes"))]
+        #[cfg(all(not(feature = "std"), feature = "hashes"))]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 use crate::hashes::{sha256, Hash, HashEngine};
@@ -50,10 +50,10 @@ macro_rules! impl_display_secret {
             }
         }
 
-        #[cfg(all(not(feature = "std"), not(feature = "bitcoin_hashes")))]
+        #[cfg(all(not(feature = "std"), not(feature = "hashes")))]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                write!(f, "<secret requires std or bitcoin_hashes feature to display>")
+                write!(f, "<secret requires std or hashes feature to display>")
             }
         }
     };

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -35,7 +35,7 @@ macro_rules! impl_display_secret {
         #[cfg(all(not(feature = "std"), feature = "hashes"))]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                use crate::hashes::{sha256, Hash, HashEngine};
+                use hashes::{sha256, Hash, HashEngine};
 
                 let tag = "rust-secp256k1DEBUG";
 


### PR DESCRIPTION
Use the more terse `hashes` by way of the `package` field in the manifest.
    
Allows us to remove the ugly feature alias "bitcoin-hashes" -> "bitcoin_hashes" and removes all the bother with the underscore.
