### PR TITLE
CI: Modify regex

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -20,7 +20,7 @@ if cargo --version | grep "1\.48"; then
 fi
 
 # Test if panic in C code aborts the process (either with a real panic or with SIGILL)
-cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at '\[libsecp256k1\]"
+cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at .*?'\[libsecp256k1\]"
 
 # Make all cargo invocations verbose
 export CARGO_TERM_VERBOSE=true


### PR DESCRIPTION
Found while working on #635 

The out of the test `test_panic_raw_ctx_should_terminate_abnormally` seems to have changed with a recent update of `cargo` causing our `grep` call to fail.

The error now looks like
```
thread 'tests::test_panic_raw_ctx_should_terminate_abnormally' panicked at secp256k1-sys/src/lib.rs:904:5:
[libsecp256k1] illegal argument.
!rustsecp256k1_v0_8_1_fe_is_zero(&ge->x)
```

Based solely on this output and the fact that our `grep` statement used to work I conclude that the output now includes new line information.

Modify the regex to do non-greedy comparison against everything before the `[libsecp256k1]` bit.