### PR TITLE
CI: Update pins

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -16,7 +16,7 @@ fi
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.48"; then
     cargo update -p wasm-bindgen-test --precise 0.3.34
-    cargo update -p serde --precise 1.0.156
+    cargo update -p serde_test --precise 1.0.175
 fi
 
 # Test if panic in C code aborts the process (either with a real panic or with SIGILL)


### PR DESCRIPTION
Pinning is broken again, update the pins it CI so that the following sequence of commands would work

```bash
rm Cargo.lock
cargo +1.48 update -p wasm-bindgen-test --precise 0.3.34
cargo +1.48 update -p serde_test --precise 1.0.175
cargo +1.48 test --all-features
```

Note, solely out of interest, `cargo +1.48 build` does not need pinning (at the moment :)