### PR TITLE
Fix CI

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -20,7 +20,9 @@ if cargo --version | grep "1\.48"; then
 fi
 
 # Test if panic in C code aborts the process (either with a real panic or with SIGILL)
-cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 | tee /dev/stderr | grep "SIGILL\\|panicked at '\[libsecp256k1\]"
+cargo test -- --ignored --exact 'tests::test_panic_raw_ctx_should_terminate_abnormally' 2>&1 \
+    | tee /dev/stderr \
+    | grep "SIGILL\\|\[libsecp256k1] illegal argument. !rustsecp256k1_v0_._._fe_is_zero(&ge->x)"
 
 # Make all cargo invocations verbose
 export CARGO_TERM_VERBOSE=true

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -16,7 +16,7 @@ fi
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.48"; then
     cargo update -p wasm-bindgen-test --precise 0.3.34
-    cargo update -p serde --precise 1.0.156
+    cargo update -p serde_test --precise 1.0.175
 fi
 
 # Test if panic in C code aborts the process (either with a real panic or with SIGILL)

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -27,7 +27,6 @@
 //!     * Requires linking with `libc` for calling `printf`.
 //!
 
-#![feature(lang_items)]
 #![feature(start)]
 #![feature(core_intrinsics)]
 #![feature(panic_info_message)]

--- a/src/key.rs
+++ b/src/key.rs
@@ -1036,6 +1036,8 @@ impl serde::Serialize for KeyPair {
 }
 
 #[cfg(feature = "serde")]
+#[allow(unused_variables)] // For `data` under some feature combinations (the unconditional panic below).
+#[allow(unreachable_code)] // For `KeyPair::from_seckey_slice` after unconditional panic.
 impl<'de> serde::Deserialize<'de> for KeyPair {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         if d.is_human_readable() {

--- a/src/key.rs
+++ b/src/key.rs
@@ -1053,7 +1053,7 @@ impl<'de> serde::Deserialize<'de> for KeyPair {
                 let ctx = Secp256k1::signing_only();
 
                 #[cfg(not(any(feature = "global-context", feature = "alloc")))]
-                let ctx: Secp256k1<crate::SignOnlyPreallocated> = panic!("The previous implementation was panicking too, please enable the global-context feature of rust-secp256k1");
+                let ctx: Secp256k1<crate::SignOnlyPreallocated> = panic!("cannot deserialize key pair without a context (please enable either the global-context or alloc feature)");
 
                 #[allow(clippy::needless_borrow)]
                 KeyPair::from_seckey_slice(&ctx, data)


### PR DESCRIPTION
CI has a bunch of things broken.

This is #640 followed by #639 followed by  a few addition fixes to get CI green again. Includes clippy warnings in feature gated code which is not strictly necessary and a fix to a panic message, also not strictly necessary.

