### PR TITLE
Add a `verify` function to `PublicKey`

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -13,9 +13,11 @@ use serde::ser::SerializeTuple;
 use crate::ffi::types::c_uint;
 use crate::ffi::{self, CPtr};
 use crate::Error::{self, InvalidPublicKey, InvalidPublicKeySum, InvalidSecretKey};
-use crate::{constants, from_hex, schnorr, Message, Scalar, Secp256k1, Signing, Verification};
 #[cfg(feature = "global-context")]
-use crate::{ecdsa, SECP256K1};
+use crate::SECP256K1;
+use crate::{
+    constants, ecdsa, from_hex, schnorr, Message, Scalar, Secp256k1, Signing, Verification,
+};
 #[cfg(feature = "bitcoin_hashes")]
 use crate::{hashes, ThirtyTwoByteHash};
 
@@ -695,6 +697,16 @@ impl PublicKey {
 
             (XOnlyPublicKey(xonly_pk), parity)
         }
+    }
+
+    /// Checks that `sig` is a valid ECDSA signature for `msg` using this public key.
+    pub fn verify<C: Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        msg: &Message,
+        sig: &ecdsa::Signature,
+    ) -> Result<(), Error> {
+        secp.verify_ecdsa(msg, sig, self)
     }
 }
 


### PR DESCRIPTION
To be uniform with `XOnlyPublicKey` add a `verify` function to the `PublicKey`.

Should have been done when we did #618