### PR TITLE
Improve `Message` constructors

### DIFF
--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -11,7 +11,7 @@ fn verify<C: Verification>(
     pubkey: [u8; 33],
 ) -> Result<bool, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(msg.as_ref())?;
+    let msg = Message::from_digest_slice(msg.as_ref())?;
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
@@ -24,7 +24,7 @@ fn sign<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::Signature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(msg.as_ref())?;
+    let msg = Message::from_digest_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa(&msg, &seckey))
 }

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -11,7 +11,7 @@ fn recover<C: Verification>(
     recovery_id: u8,
 ) -> Result<PublicKey, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(msg.as_ref())?;
+    let msg = Message::from_digest_slice(msg.as_ref())?;
     let id = ecdsa::RecoveryId::from_i32(recovery_id as i32)?;
     let sig = ecdsa::RecoverableSignature::from_compact(&sig, id)?;
 
@@ -24,7 +24,7 @@ fn sign_recovery<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::RecoverableSignature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_slice(msg.as_ref())?;
+    let msg = Message::from_digest_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
     Ok(secp.sign_ecdsa_recoverable(&msg, &seckey))
 }

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -92,7 +92,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     secp.randomize(&mut FakeRng);
     let secret_key = SecretKey::new(&mut FakeRng);
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
-    let message = Message::from_slice(&[0xab; 32]).expect("32 bytes");
+    let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
     let sig = secp.sign_ecdsa(&message, &secret_key);
     assert!(secp.verify_ecdsa(&message, &sig, &public_key).is_ok());
@@ -119,7 +119,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     {
         let secp_alloc = Secp256k1::new();
         let public_key = PublicKey::from_secret_key(&secp_alloc, &secret_key);
-        let message = Message::from_slice(&[0xab; 32]).expect("32 bytes");
+        let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
         let sig = secp_alloc.sign_ecdsa(&message, &secret_key);
         assert!(secp_alloc.verify_ecdsa(&message, &sig, &public_key).is_ok());

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -371,11 +371,11 @@ impl<C: Verification> Secp256k1<C> {
     /// # let secp = Secp256k1::new();
     /// # let (secret_key, public_key) = secp.generate_keypair(&mut rand::thread_rng());
     /// #
-    /// let message = Message::from_slice(&[0xab; 32]).expect("32 bytes");
+    /// let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
     /// let sig = secp.sign_ecdsa(&message, &secret_key);
     /// assert_eq!(secp.verify_ecdsa(&message, &sig, &public_key), Ok(()));
     ///
-    /// let message = Message::from_slice(&[0xcd; 32]).expect("32 bytes");
+    /// let message = Message::from_digest_slice(&[0xcd; 32]).expect("32 bytes");
     /// assert_eq!(secp.verify_ecdsa(&message, &sig, &public_key), Err(Error::IncorrectSignature));
     /// # }
     /// ```

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -226,7 +226,7 @@ mod tests {
         let full = Secp256k1::new();
 
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from_digest_slice(&msg).unwrap();
 
         // Try key generation
         let (sk, pk) = full.generate_keypair(&mut rand::thread_rng());
@@ -258,7 +258,7 @@ mod tests {
         s.randomize(&mut rand::thread_rng());
 
         let sk = SecretKey::from_slice(&ONE).unwrap();
-        let msg = Message::from_slice(&ONE).unwrap();
+        let msg = Message::from_digest_slice(&ONE).unwrap();
 
         let sig = s.sign_ecdsa_recoverable(&msg, &sk);
 
@@ -283,7 +283,7 @@ mod tests {
         s.randomize(&mut rand::thread_rng());
 
         let sk = SecretKey::from_slice(&ONE).unwrap();
-        let msg = Message::from_slice(&ONE).unwrap();
+        let msg = Message::from_digest_slice(&ONE).unwrap();
         let noncedata = [42u8; 32];
 
         let sig = s.sign_ecdsa_recoverable_with_noncedata(&msg, &sk, &noncedata);
@@ -307,7 +307,7 @@ mod tests {
         s.randomize(&mut rand::thread_rng());
 
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from_digest_slice(&msg).unwrap();
 
         let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
 
@@ -315,7 +315,7 @@ mod tests {
         let sig = sigr.to_standard();
 
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from_digest_slice(&msg).unwrap();
         assert_eq!(s.verify_ecdsa(&msg, &sig, &pk), Err(Error::IncorrectSignature));
 
         let recovered_key = s.recover_ecdsa(&msg, &sigr).unwrap();
@@ -329,7 +329,7 @@ mod tests {
         s.randomize(&mut rand::thread_rng());
 
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from_digest_slice(&msg).unwrap();
 
         let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
 
@@ -345,7 +345,7 @@ mod tests {
         s.randomize(&mut rand::thread_rng());
 
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from_digest_slice(&msg).unwrap();
 
         let noncedata = [42u8; 32];
 
@@ -362,7 +362,7 @@ mod tests {
         let mut s = Secp256k1::new();
         s.randomize(&mut rand::thread_rng());
 
-        let msg = Message::from_slice(&[0x55; 32]).unwrap();
+        let msg = Message::from_digest_slice(&[0x55; 32]).unwrap();
 
         // Zero is not a valid sig
         let sig = RecoverableSignature::from_compact(&[0; 64], RecoveryId(0)).unwrap();
@@ -433,7 +433,7 @@ mod benches {
     pub fn bench_recover(bh: &mut Bencher) {
         let s = Secp256k1::new();
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from_digest_slice(&msg).unwrap();
         let (sk, _) = s.generate_keypair(&mut rand::thread_rng());
         let sig = s.sign_ecdsa_recoverable(&msg, &sk);
 

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -248,7 +248,7 @@ mod tests {
 
         for _ in 0..100 {
             let msg = crate::random_32_bytes(&mut rand::thread_rng());
-            let msg = Message::from_slice(&msg).unwrap();
+            let msg = Message::from_digest_slice(&msg).unwrap();
 
             let sig = sign(&secp, &msg, &kp, &mut rng);
 
@@ -263,7 +263,7 @@ mod tests {
         let secp = Secp256k1::new();
 
         let hex_msg = hex_32!("E48441762FB75010B2AA31A512B62B4148AA3FB08EB0765D76B252559064A614");
-        let msg = Message::from_slice(&hex_msg).unwrap();
+        let msg = Message::from_digest_slice(&hex_msg).unwrap();
         let sk = KeyPair::from_seckey_str(
             &secp,
             "688C77BC2D5AAFF5491CF309D4753B732135470D05B7B2CD21ADD0744FE97BEF",
@@ -285,7 +285,7 @@ mod tests {
         let secp = Secp256k1::new();
 
         let hex_msg = hex_32!("E48441762FB75010B2AA31A512B62B4148AA3FB08EB0765D76B252559064A614");
-        let msg = Message::from_slice(&hex_msg).unwrap();
+        let msg = Message::from_digest_slice(&hex_msg).unwrap();
         let sig = Signature::from_str("6470FD1303DDA4FDA717B9837153C24A6EAB377183FC438F939E0ED2B620E9EE5077C4A8B8DCA28963D772A94F5F0DDF598E1C47C137F91933274C7C3EDADCE8").unwrap();
         let pubkey = XOnlyPublicKey::from_str(
             "B33CC9EDC096D0A83416964BD3C6247B8FECD256E4EFA7870D2C854BDEB33390",
@@ -464,7 +464,7 @@ mod tests {
 
         let s = Secp256k1::new();
 
-        let msg = Message::from_slice(&[1; 32]).unwrap();
+        let msg = Message::from_digest_slice(&[1; 32]).unwrap();
         let keypair = KeyPair::from_seckey_slice(&s, &[2; 32]).unwrap();
         let aux = [3u8; 32];
         let sig = s.sign_schnorr_with_aux_rand(&msg, &keypair, &aux);


### PR DESCRIPTION
Observe:
    
- The word "hash" can be a verb or a noun, its usage in function names is therefore at times ambiguous.
- The function name `from_slice` gives no indication as to what the slice input is.
    
Improve Message constructors by doing:
    
- Add a constructor `Message::from_digest` that takes a 32 byte array as input.
- Rename `Message::from_slice` to `Message::from_digest_slice` (deprecate `from_slice` and add `from_digest_slice`)
- Improve the docs while we are at it.


### Note

The original PR conflate 2 separate issues, the `Message` constructor naming clarity issue and the upgrade difficulty issue, PR is now only a solution to the first. The second will be done as a separate PR.