### PR TITLE
Depend on hashes v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Bump MSRV to 1.48
 * Remove implementations of `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` from the
   `impl_array_newtype` macro. Users will now need to derive these traits if they are wanted.
+* Depend on newly released `hashes v0.13.0`.
 
 # 0.27.0 - 2023-03-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.103", default-features = false, optional = true }
 
 # You likely only want to enable these if you explicitly do not want to use "std", otherwise enable
 # the respective -std feature e.g., hashes-std
-hashes = { package = "bitcoin_hashes", version = "0.12", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", version = "0.13", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Draft because needs lock files updating (and `hashes` release).

We just released a new version of `bitcoin_hashes`, lets use it.

No code changes required.