### PR TITLE
Tracking PR for release: `secp256k1 v0.28.0` and `secp256k-sys 0.10.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-# Unreleased
+# 0.28.0 - 2023-10-23
 
-* Bump MSRV to 1.48
+* Add bindings to the ElligatorSwift implementation [#627](https://github.com/rust-bitcoin/rust-secp256k1/pull/627)
+* Depend on recent release of `bitcoin_hashes` v0.13.0 [#621](https://github.com/rust-bitcoin/rust-secp256k1/pull/621)
+* Add a verify function to `PublicKey` [#618](https://github.com/rust-bitcoin/rust-secp256k1/pull/618)
+* Add serialize function for schnorr::Signature [#607](https://github.com/rust-bitcoin/rust-secp256k1/pull/607)
+* Bump MSRV to 1.48 [#595](https://github.com/rust-bitcoin/rust-secp256k1/pull/595)
 * Remove implementations of `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` from the
   `impl_array_newtype` macro. Users will now need to derive these traits if they are wanted.
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -257,7 +257,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -178,7 +178,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/secp256k1-sys/CHANGELOG.md
+++ b/secp256k1-sys/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Unreleased
+# 0.9.0 - 2023-10-23
 
-* Bump MSRV to 1.48
+* Add bindings to the ElligatorSwift implementation [#627](https://github.com/rust-bitcoin/rust-secp256k1/pull/627)
+* Update vendored lib secp256k1 to v0.4.0 [#653](https://github.com/rust-bitcoin/rust-secp256k1/pull/653)
+* Bump MSRV to 1.48 [#595](https://github.com/rust-bitcoin/rust-secp256k1/pull/595)
 
 # 0.8.1 - 2023-03-16
 


### PR DESCRIPTION
Bump the version of `secp256k1` ready for release.

Includes changelog for the already-bumped `secp256k1-sys`, changelog for `secp256k1`, and the version bump for `secp256k1`.
