### PR TITLE
Patch out any instances of printf in upstream

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -20,11 +20,16 @@ fn main() {
                .include("depend/secp256k1/include")
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
+               .flag_if_supported("-Wno-unused-parameter") // patching out printf causes this warning
                .define("SECP256K1_API", Some(""))
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"))
                .define("ENABLE_MODULE_EXTRAKEYS", Some("1"))
-               .define("ENABLE_MODULE_ELLSWIFT", Some("1"));
+               .define("ENABLE_MODULE_ELLSWIFT", Some("1"))
+               // upstream sometimes introduces calls to printf, which we cannot compile
+               // with WASM due to its lack of libc. printf is never necessary and we can
+               // just #define it away.
+               .define("printf(...)", Some(""));
 
     if cfg!(feature = "lowmemory") {
         base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume negligible memory

--- a/secp256k1-sys/depend/secp256k1/src/util.h
+++ b/secp256k1-sys/depend/secp256k1/src/util.h
@@ -145,11 +145,9 @@ static const rustsecp256k1_v0_9_0_callback default_error_callback = {
 #endif
 
 static SECP256K1_INLINE void *checked_malloc(const rustsecp256k1_v0_9_0_callback* cb, size_t size) {
-    void *ret = malloc(size);
-    if (ret == NULL) {
-        rustsecp256k1_v0_9_0_callback_call(cb, "Out of memory");
-    }
-    return ret;
+    (void) cb;
+    (void) size;
+    return NULL;
 }
 
 #if defined(__BIGGEST_ALIGNMENT__)

--- a/secp256k1-sys/depend/secp256k1/src/util.h
+++ b/secp256k1-sys/depend/secp256k1/src/util.h
@@ -8,9 +8,7 @@
 #define SECP256K1_UTIL_H
 
 #include "../include/secp256k1.h"
-extern int rustsecp256k1_v0_9_0_ecdsa_signature_parse_compact(
-        const rustsecp256k1_v0_9_0_context *ctx,
-        rustsecp256k1_v0_9_0_ecdsa_signature *sig, const unsigned char *input64);
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/secp256k1-sys/depend/util.h.patch
+++ b/secp256k1-sys/depend/util.h.patch
@@ -1,6 +1,0 @@
-10c10,12
-< 
----
-> extern int secp256k1_ecdsa_signature_parse_compact(
->         const secp256k1_context *ctx,
->         secp256k1_ecdsa_signature *sig, const unsigned char *input64);

--- a/secp256k1-sys/depend/util.h.patch
+++ b/secp256k1-sys/depend/util.h.patch
@@ -1,0 +1,10 @@
+148,152c148,150
+<     void *ret = malloc(size);
+<     if (ret == NULL) {
+<         secp256k1_callback_call(cb, "Out of memory");
+<     }
+<     return ret;
+---
+>     (void) cb;
+>     (void) size;
+>     return NULL;

--- a/secp256k1-sys/vendor-libsecp.sh
+++ b/secp256k1-sys/vendor-libsecp.sh
@@ -97,6 +97,7 @@ echo "$SOURCE_REV" >> ./secp256k1-HEAD-revision.txt
 patch "$DIR/include/secp256k1.h" "./secp256k1.h.patch"
 patch "$DIR/src/secp256k1.c" "./secp256k1.c.patch"
 patch "$DIR/src/scratch_impl.h" "./scratch_impl.h.patch"
+patch "$DIR/src/util.h" "./util.h.patch"
 
 # Fix a linking error while cross-compiling to windowns with mingw
 patch "$DIR/contrib/lax_der_parsing.c" "./lax_der_parsing.c.patch"

--- a/secp256k1-sys/vendor-libsecp.sh
+++ b/secp256k1-sys/vendor-libsecp.sh
@@ -97,7 +97,6 @@ echo "$SOURCE_REV" >> ./secp256k1-HEAD-revision.txt
 patch "$DIR/include/secp256k1.h" "./secp256k1.h.patch"
 patch "$DIR/src/secp256k1.c" "./secp256k1.c.patch"
 patch "$DIR/src/scratch_impl.h" "./scratch_impl.h.patch"
-patch "$DIR/src/util.h" "./util.h.patch"
 
 # Fix a linking error while cross-compiling to windowns with mingw
 patch "$DIR/contrib/lax_der_parsing.c" "./lax_der_parsing.c.patch"


### PR DESCRIPTION
Rather than using a new patchfile, just `#define` it away. Also includes a commit which removes one of the existing patchfiles, which I discovered was out of date while auditing the others to see if they could be replaced by `#define`s. (No, they cannot.)

Fixes #660