### PR TITLE
Fix unit test import statements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,11 +546,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
-    #[allow(unused_imports)] // When building with no default features.
     use super::*;
-    use crate::{constants, ecdsa, from_hex, Error, Message};
-    #[cfg(feature = "alloc")]
-    use crate::{ffi, PublicKey, Secp256k1, SecretKey};
 
     macro_rules! hex {
         ($hex:expr) => {{


### PR DESCRIPTION
In `lib.rs` unit tests we are getting build warnings because of how we are importing things, just import with `super::*` unconditionally and be done with it.

This patch is the only good one out of #661.