### PR TITLE
release 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.28.1 - 2024-01-03
+
+* Update secp265k1-sys to 0.9.2 (contains some fixes for WASM and [a FFI binding fix](https://github.com/rust-bitcoin/rust-secp256k1/pull/6700))
+* Various improvements to the `SerializedSignature` type [#658](https://github.com/rust-bitcoin/rust-secp256k1/pull/658) [#659](https://github.com/rust-bitcoin/rust-secp256k1/pull/659)
+
 # 0.28.0 - 2023-10-23
 
 * Add bindings to the ElligatorSwift implementation [#627](https://github.com/rust-bitcoin/rust-secp256k1/pull/627)

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -257,7 +257,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -178,7 +178,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.28.0"
+version = "0.28.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"
@@ -35,7 +35,7 @@ global-context = ["std"]
 global-context-less-secure = ["global-context"]
 
 [dependencies]
-secp256k1-sys = { version = "0.9.1", default-features = false, path = "./secp256k1-sys" }
+secp256k1-sys = { version = "0.9.2", default-features = false, path = "./secp256k1-sys" }
 serde = { version = "1.0.103", default-features = false, optional = true }
 
 # You likely only want to enable these if you explicitly do not want to use "std", otherwise enable


### PR DESCRIPTION
We need a new rust-secp release to deal with the new rust-secp-sys release.