### PR TITLE
Derive Hash for Scalar

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -22,7 +22,7 @@ use crate::constants;
 // Internal represenation is big endian to match what `libsecp256k1` uses.
 // Also easier to implement comparison.
 // Debug impl omitted for now, the bytes may be secret
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Scalar([u8; 32]);
 impl_pretty_debug!(Scalar);
 impl_non_secure_erase!(Scalar, 0, [0u8; 32]);


### PR DESCRIPTION
Unless there is some safety concern I cannot see, having Scalar implementing Hash would be useful.