### PR TITLE
Remove wildcard re-exports

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,3 +116,18 @@ jobs:
         env:
           DO_WASM: true
         run: ./contrib/test.sh
+
+  API:
+    name: Check for changes to the public API
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-public-api
+        run: cargo install --locked cargo-public-api
+      - name: Running API checker script
+        run: ./contrib/check-for-api-changes.sh

--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -1,5 +1,7 @@
+impl<'a> core::convert::From<&'a secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::PublicKey
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::SecretKey
+impl<'a> core::convert::TryFrom<&'a secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl<'a> core::iter::traits::collect::IntoIterator for &'a secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'buf> core::clone::Clone for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::clone::Clone for secp256k1::SignOnlyPreallocated<'buf>
@@ -10,12 +12,12 @@ impl<'buf> core::cmp::Eq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -25,12 +27,12 @@ impl<'buf> core::hash::Hash for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -60,10 +62,12 @@ impl<'buf> secp256k1::Signing for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Signing for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<C> core::marker::Freeze for secp256k1::Secp256k1<C>
 impl<C> core::marker::Unpin for secp256k1::Secp256k1<C> where C: core::marker::Unpin
 impl<C> core::panic::unwind_safe::RefUnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::RefUnwindSafe
 impl<C> core::panic::unwind_safe::UnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::UnwindSafe
 impl core::borrow::Borrow<[u8]> for secp256k1::ecdh::SharedSecret
+impl core::borrow::Borrow<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::clone::Clone for secp256k1::All
 impl core::clone::Clone for secp256k1::ecdh::SharedSecret
 impl core::clone::Clone for secp256k1::ecdsa::RecoverableSignature
@@ -112,6 +116,9 @@ impl core::cmp::Eq for secp256k1::VerifyOnly
 impl core::cmp::Eq for secp256k1::XOnlyPublicKey
 impl core::cmp::Ord for secp256k1::All
 impl core::cmp::Ord for secp256k1::ecdh::SharedSecret
+impl core::cmp::Ord for secp256k1::ecdsa::RecoverableSignature
+impl core::cmp::Ord for secp256k1::ecdsa::RecoveryId
+impl core::cmp::Ord for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::cmp::Ord for secp256k1::ecdsa::Signature
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwift
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwiftParty
@@ -127,50 +134,58 @@ impl core::cmp::Ord for secp256k1::schnorr::Signature
 impl core::cmp::Ord for secp256k1::SignOnly
 impl core::cmp::Ord for secp256k1::VerifyOnly
 impl core::cmp::Ord for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialEq<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialEq<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialEq<secp256k1::ecdsa::RecoverableSignature> for secp256k1::ecdsa::RecoverableSignature
-impl core::cmp::PartialEq<secp256k1::ecdsa::RecoveryId> for secp256k1::ecdsa::RecoveryId
-impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
-impl core::cmp::PartialEq<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialEq<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialEq<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialEq<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialEq<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialEq<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialEq<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialEq<secp256k1::scalar::OutOfRangeError> for secp256k1::scalar::OutOfRangeError
-impl core::cmp::PartialEq<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialEq<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialEq<secp256k1::SecretKey> for secp256k1::SecretKey
-impl core::cmp::PartialEq<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialEq<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialEq<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialOrd<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialOrd<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialOrd<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialOrd<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialOrd<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialOrd<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialOrd<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialOrd<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialOrd<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialOrd<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialOrd<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialOrd<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialOrd<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialOrd<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq for secp256k1::All
+impl core::cmp::PartialEq for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialEq for secp256k1::ecdsa::RecoverableSignature
+impl core::cmp::PartialEq for secp256k1::ecdsa::RecoveryId
+impl core::cmp::PartialEq for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for secp256k1::ecdsa::Signature
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialEq for secp256k1::Error
+impl core::cmp::PartialEq for secp256k1::InvalidParityValue
+impl core::cmp::PartialEq for secp256k1::Keypair
+impl core::cmp::PartialEq for secp256k1::Message
+impl core::cmp::PartialEq for secp256k1::Parity
+impl core::cmp::PartialEq for secp256k1::PublicKey
+impl core::cmp::PartialEq for secp256k1::scalar::OutOfRangeError
+impl core::cmp::PartialEq for secp256k1::scalar::Scalar
+impl core::cmp::PartialEq for secp256k1::schnorr::Signature
+impl core::cmp::PartialEq for secp256k1::SecretKey
+impl core::cmp::PartialEq for secp256k1::SignOnly
+impl core::cmp::PartialEq for secp256k1::VerifyOnly
+impl core::cmp::PartialEq for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialEq<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::All
+impl core::cmp::PartialOrd for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialOrd for secp256k1::ecdsa::RecoverableSignature
+impl core::cmp::PartialOrd for secp256k1::ecdsa::RecoveryId
+impl core::cmp::PartialOrd for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::ecdsa::Signature
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialOrd for secp256k1::Error
+impl core::cmp::PartialOrd for secp256k1::InvalidParityValue
+impl core::cmp::PartialOrd for secp256k1::Keypair
+impl core::cmp::PartialOrd for secp256k1::Message
+impl core::cmp::PartialOrd for secp256k1::Parity
+impl core::cmp::PartialOrd for secp256k1::PublicKey
+impl core::cmp::PartialOrd for secp256k1::scalar::Scalar
+impl core::cmp::PartialOrd for secp256k1::schnorr::Signature
+impl core::cmp::PartialOrd for secp256k1::SignOnly
+impl core::cmp::PartialOrd for secp256k1::VerifyOnly
+impl core::cmp::PartialOrd for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialOrd<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::AsRef<[u8; 32]> for secp256k1::Message
 impl core::convert::AsRef<[u8; 32]> for secp256k1::SecretKey
 impl core::convert::AsRef<[u8; 64]> for secp256k1::schnorr::Signature
 impl core::convert::AsRef<[u8]> for secp256k1::ecdh::SharedSecret
 impl core::convert::AsRef<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::convert::From<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::From<secp256k1::InvalidParityValue> for secp256k1::Error
 impl core::convert::From<secp256k1::Keypair> for secp256k1::PublicKey
 impl core::convert::From<secp256k1::Keypair> for secp256k1::SecretKey
@@ -183,6 +198,7 @@ impl core::convert::From<secp256k1_sys::recovery::RecoverableSignature> for secp
 impl core::convert::From<secp256k1_sys::Signature> for secp256k1::ecdsa::Signature
 impl core::convert::From<secp256k1_sys::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
 impl core::convert::TryFrom<i32> for secp256k1::Parity
+impl core::convert::TryFrom<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl core::convert::TryFrom<u8> for secp256k1::Parity
 impl core::default::Default for secp256k1::Secp256k1<secp256k1::All>
 impl core::error::Error for secp256k1::Error
@@ -230,6 +246,7 @@ impl core::fmt::LowerHex for secp256k1::XOnlyPublicKey
 impl core::hash::Hash for secp256k1::All
 impl core::hash::Hash for secp256k1::ecdh::SharedSecret
 impl core::hash::Hash for secp256k1::ecdsa::RecoverableSignature
+impl core::hash::Hash for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::hash::Hash for secp256k1::ecdsa::Signature
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwift
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwiftParty
@@ -241,6 +258,7 @@ impl core::hash::Hash for secp256k1::Message
 impl core::hash::Hash for secp256k1::Parity
 impl core::hash::Hash for secp256k1::PublicKey
 impl core::hash::Hash for secp256k1::scalar::OutOfRangeError
+impl core::hash::Hash for secp256k1::scalar::Scalar
 impl core::hash::Hash for secp256k1::schnorr::Signature
 impl core::hash::Hash for secp256k1::SignOnly
 impl core::hash::Hash for secp256k1::VerifyOnly
@@ -272,6 +290,30 @@ impl core::marker::Copy for secp256k1::SecretKey
 impl core::marker::Copy for secp256k1::SignOnly
 impl core::marker::Copy for secp256k1::VerifyOnly
 impl core::marker::Copy for secp256k1::XOnlyPublicKey
+impl core::marker::Freeze for secp256k1::All
+impl core::marker::Freeze for secp256k1::ecdh::SharedSecret
+impl core::marker::Freeze for secp256k1::ecdsa::RecoverableSignature
+impl core::marker::Freeze for secp256k1::ecdsa::RecoveryId
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::IntoIter
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::marker::Freeze for secp256k1::ecdsa::Signature
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwift
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftParty
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::marker::Freeze for secp256k1::Error
+impl core::marker::Freeze for secp256k1::global::GlobalContext
+impl core::marker::Freeze for secp256k1::InvalidParityValue
+impl core::marker::Freeze for secp256k1::Keypair
+impl core::marker::Freeze for secp256k1::Message
+impl core::marker::Freeze for secp256k1::Parity
+impl core::marker::Freeze for secp256k1::PublicKey
+impl core::marker::Freeze for secp256k1::scalar::OutOfRangeError
+impl core::marker::Freeze for secp256k1::scalar::Scalar
+impl core::marker::Freeze for secp256k1::schnorr::Signature
+impl core::marker::Freeze for secp256k1::SecretKey
+impl core::marker::Freeze for secp256k1::SignOnly
+impl core::marker::Freeze for secp256k1::VerifyOnly
+impl core::marker::Freeze for secp256k1::XOnlyPublicKey
 impl core::marker::Send for secp256k1::All
 impl core::marker::Send for secp256k1::ecdh::SharedSecret
 impl core::marker::Send for secp256k1::ecdsa::RecoverableSignature
@@ -296,26 +338,6 @@ impl core::marker::Send for secp256k1::SecretKey
 impl core::marker::Send for secp256k1::SignOnly
 impl core::marker::Send for secp256k1::VerifyOnly
 impl core::marker::Send for secp256k1::XOnlyPublicKey
-impl core::marker::StructuralEq for secp256k1::All
-impl core::marker::StructuralEq for secp256k1::ecdh::SharedSecret
-impl core::marker::StructuralEq for secp256k1::ecdsa::RecoverableSignature
-impl core::marker::StructuralEq for secp256k1::ecdsa::RecoveryId
-impl core::marker::StructuralEq for secp256k1::ecdsa::Signature
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwift
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftParty
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::marker::StructuralEq for secp256k1::Error
-impl core::marker::StructuralEq for secp256k1::InvalidParityValue
-impl core::marker::StructuralEq for secp256k1::Keypair
-impl core::marker::StructuralEq for secp256k1::Message
-impl core::marker::StructuralEq for secp256k1::Parity
-impl core::marker::StructuralEq for secp256k1::PublicKey
-impl core::marker::StructuralEq for secp256k1::scalar::OutOfRangeError
-impl core::marker::StructuralEq for secp256k1::scalar::Scalar
-impl core::marker::StructuralEq for secp256k1::schnorr::Signature
-impl core::marker::StructuralEq for secp256k1::SignOnly
-impl core::marker::StructuralEq for secp256k1::VerifyOnly
-impl core::marker::StructuralEq for secp256k1::XOnlyPublicKey
 impl core::marker::StructuralPartialEq for secp256k1::All
 impl core::marker::StructuralPartialEq for secp256k1::ecdh::SharedSecret
 impl core::marker::StructuralPartialEq for secp256k1::ecdsa::RecoverableSignature
@@ -384,7 +406,7 @@ impl core::marker::Unpin for secp256k1::SecretKey
 impl core::marker::Unpin for secp256k1::SignOnly
 impl core::marker::Unpin for secp256k1::VerifyOnly
 impl core::marker::Unpin for secp256k1::XOnlyPublicKey
-impl core::ops::bit::BitXor<secp256k1::Parity> for secp256k1::Parity
+impl core::ops::bit::BitXor for secp256k1::Parity
 impl core::ops::deref::Deref for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::ops::deref::Deref for secp256k1::global::GlobalContext
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::All
@@ -445,7 +467,7 @@ impl core::str::traits::FromStr for secp256k1::SecretKey
 impl core::str::traits::FromStr for secp256k1::XOnlyPublicKey
 impl<C: secp256k1::Context> core::clone::Clone for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::cmp::Eq for secp256k1::Secp256k1<C>
-impl<C: secp256k1::Context> core::cmp::PartialEq<secp256k1::Secp256k1<C>> for secp256k1::Secp256k1<C>
+impl<C: secp256k1::Context> core::cmp::PartialEq for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::fmt::Debug for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Send for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Sync for secp256k1::Secp256k1<C>
@@ -475,6 +497,7 @@ impl secp256k1::ecdsa::serialized_signature::IntoIter
 impl secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl secp256k1::ecdsa::Signature
 impl secp256k1::ellswift::ElligatorSwift
+impl secp256k1::ellswift::ElligatorSwiftSharedSecret
 impl secp256k1::Keypair
 impl secp256k1::Message
 impl secp256k1::Parity
@@ -513,6 +536,9 @@ impl<T: bitcoin_hashes::sha256t::Tag> secp256k1::ThirtyTwoByteHash for bitcoin_h
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::Message
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::SecretKey
 #[non_exhaustive] pub struct secp256k1::scalar::OutOfRangeError
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::as_secret_bytes(&self) -> &[u8; 32]
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::from_secret_bytes(bytes: [u8; 32]) -> Self
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::to_secret_bytes(self) -> [u8; 32]
 pub const secp256k1::All::DESCRIPTION: &'static str
 pub const secp256k1::All::FLAGS: secp256k1_sys::types::c_uint
 pub const secp256k1::AllPreallocated<'buf>::DESCRIPTION: &'static str
@@ -593,18 +619,22 @@ pub fn secp256k1::ecdsa::RecoverableSignature::as_mut_c_ptr(&mut self) -> *mut S
 pub fn secp256k1::ecdsa::RecoverableSignature::as_mut_ptr(&mut self) -> *mut secp256k1_sys::recovery::RecoverableSignature
 pub fn secp256k1::ecdsa::RecoverableSignature::as_ptr(&self) -> *const secp256k1_sys::recovery::RecoverableSignature
 pub fn secp256k1::ecdsa::RecoverableSignature::clone(&self) -> secp256k1::ecdsa::RecoverableSignature
+pub fn secp256k1::ecdsa::RecoverableSignature::cmp(&self, other: &secp256k1::ecdsa::RecoverableSignature) -> core::cmp::Ordering
 pub fn secp256k1::ecdsa::RecoverableSignature::eq(&self, other: &secp256k1::ecdsa::RecoverableSignature) -> bool
 pub fn secp256k1::ecdsa::RecoverableSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::ecdsa::RecoverableSignature::from_compact(data: &[u8], recid: secp256k1::ecdsa::RecoveryId) -> core::result::Result<secp256k1::ecdsa::RecoverableSignature, secp256k1::Error>
 pub fn secp256k1::ecdsa::RecoverableSignature::from(sig: secp256k1_sys::recovery::RecoverableSignature) -> secp256k1::ecdsa::RecoverableSignature
 pub fn secp256k1::ecdsa::RecoverableSignature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn secp256k1::ecdsa::RecoverableSignature::partial_cmp(&self, other: &secp256k1::ecdsa::RecoverableSignature) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::RecoverableSignature::recover(&self, msg: &secp256k1::Message) -> core::result::Result<secp256k1::PublicKey, secp256k1::Error>
 pub fn secp256k1::ecdsa::RecoverableSignature::serialize_compact(&self) -> (secp256k1::ecdsa::RecoveryId, [u8; 64])
 pub fn secp256k1::ecdsa::RecoverableSignature::to_standard(&self) -> secp256k1::ecdsa::Signature
 pub fn secp256k1::ecdsa::RecoveryId::clone(&self) -> secp256k1::ecdsa::RecoveryId
+pub fn secp256k1::ecdsa::RecoveryId::cmp(&self, other: &secp256k1::ecdsa::RecoveryId) -> core::cmp::Ordering
 pub fn secp256k1::ecdsa::RecoveryId::eq(&self, other: &secp256k1::ecdsa::RecoveryId) -> bool
 pub fn secp256k1::ecdsa::RecoveryId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::ecdsa::RecoveryId::from_i32(id: i32) -> core::result::Result<secp256k1::ecdsa::RecoveryId, secp256k1::Error>
+pub fn secp256k1::ecdsa::RecoveryId::partial_cmp(&self, other: &secp256k1::ecdsa::RecoveryId) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::RecoveryId::to_i32(self) -> i32
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::as_slice(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::clone(&self) -> secp256k1::ecdsa::serialized_signature::IntoIter
@@ -614,15 +644,23 @@ pub fn secp256k1::ecdsa::serialized_signature::IntoIter::next(&mut self) -> core
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::capacity(&self) -> usize
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::clone(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::cmp::Ordering
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from_signature(sig: &secp256k1::ecdsa::Signature) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: &'a secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::is_empty(&self) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<secp256k1::ecdsa::Signature, secp256k1::Error>
 pub fn secp256k1::ecdsa::Signature::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ecdsa::Signature::as_mut_c_ptr(&mut self) -> *mut Self::Target
@@ -646,6 +684,8 @@ pub fn secp256k1::ecdsa::Signature::partial_cmp(&self, other: &secp256k1::ecdsa:
 pub fn secp256k1::ecdsa::Signature::serialize_compact(&self) -> [u8; 64]
 pub fn secp256k1::ecdsa::Signature::serialize_der(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
 pub fn secp256k1::ecdsa::Signature::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn secp256k1::ecdsa::Signature::try_from(value: &'a secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn secp256k1::ecdsa::Signature::try_from(value: secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn secp256k1::ecdsa::Signature::verify(&self, msg: &secp256k1::Message, pk: &secp256k1::PublicKey) -> core::result::Result<(), secp256k1::Error>
 pub fn secp256k1::ellswift::ElligatorSwift::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::as_mut_c_ptr(&mut self) -> *mut Self::Target
@@ -797,6 +837,7 @@ pub fn secp256k1::scalar::Scalar::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn secp256k1::scalar::Scalar::from_be_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from_le_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from(value: secp256k1::SecretKey) -> Self
+pub fn secp256k1::scalar::Scalar::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn secp256k1::scalar::Scalar::index(&self, index: I) -> &Self::Output
 pub fn secp256k1::scalar::Scalar::non_secure_erase(&mut self)
 pub fn secp256k1::scalar::Scalar::partial_cmp(&self, other: &secp256k1::scalar::Scalar) -> core::option::Option<core::cmp::Ordering>
@@ -930,7 +971,9 @@ pub fn secp256k1::XOnlyPublicKey::serialize(&self) -> [u8; 32]
 pub fn secp256k1::XOnlyPublicKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn secp256k1::XOnlyPublicKey::tweak_add_check<V: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<V>, tweaked_key: &Self, tweaked_parity: secp256k1::Parity, tweak: secp256k1::scalar::Scalar) -> bool
 pub fn secp256k1::XOnlyPublicKey::verify<C: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &secp256k1::schnorr::Signature) -> core::result::Result<(), secp256k1::Error>
+pub fn [u8]::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
 pub fn u8::from(parity: secp256k1::Parity) -> u8
+pub fn [u8]::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
 pub macro secp256k1::impl_array_newtype!
 pub mod secp256k1
 pub mod secp256k1::constants
@@ -992,6 +1035,7 @@ pub type secp256k1::ecdsa::serialized_signature::IntoIter::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::IntoIter = secp256k1::ecdsa::serialized_signature::IntoIter
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Target = [u8]
+pub type secp256k1::ecdsa::Signature::Error = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Err = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Target = secp256k1_sys::Signature
 pub type secp256k1::ellswift::ElligatorSwift::Err = secp256k1::Error

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -1,5 +1,7 @@
+impl<'a> core::convert::From<&'a secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::PublicKey
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::SecretKey
+impl<'a> core::convert::TryFrom<&'a secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl<'a> core::iter::traits::collect::IntoIterator for &'a secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'buf> core::clone::Clone for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::clone::Clone for secp256k1::SignOnlyPreallocated<'buf>
@@ -10,12 +12,12 @@ impl<'buf> core::cmp::Eq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -25,12 +27,12 @@ impl<'buf> core::hash::Hash for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -60,10 +62,12 @@ impl<'buf> secp256k1::Signing for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Signing for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<C> core::marker::Freeze for secp256k1::Secp256k1<C>
 impl<C> core::marker::Unpin for secp256k1::Secp256k1<C> where C: core::marker::Unpin
 impl<C> core::panic::unwind_safe::RefUnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::RefUnwindSafe
 impl<C> core::panic::unwind_safe::UnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::UnwindSafe
 impl core::borrow::Borrow<[u8]> for secp256k1::ecdh::SharedSecret
+impl core::borrow::Borrow<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::clone::Clone for secp256k1::All
 impl core::clone::Clone for secp256k1::ecdh::SharedSecret
 impl core::clone::Clone for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -107,6 +111,7 @@ impl core::cmp::Eq for secp256k1::VerifyOnly
 impl core::cmp::Eq for secp256k1::XOnlyPublicKey
 impl core::cmp::Ord for secp256k1::All
 impl core::cmp::Ord for secp256k1::ecdh::SharedSecret
+impl core::cmp::Ord for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::cmp::Ord for secp256k1::ecdsa::Signature
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwift
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwiftParty
@@ -122,48 +127,54 @@ impl core::cmp::Ord for secp256k1::schnorr::Signature
 impl core::cmp::Ord for secp256k1::SignOnly
 impl core::cmp::Ord for secp256k1::VerifyOnly
 impl core::cmp::Ord for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialEq<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialEq<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
-impl core::cmp::PartialEq<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialEq<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialEq<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialEq<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialEq<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialEq<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialEq<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialEq<secp256k1::scalar::OutOfRangeError> for secp256k1::scalar::OutOfRangeError
-impl core::cmp::PartialEq<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialEq<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialEq<secp256k1::SecretKey> for secp256k1::SecretKey
-impl core::cmp::PartialEq<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialEq<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialEq<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialOrd<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialOrd<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialOrd<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialOrd<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialOrd<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialOrd<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialOrd<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialOrd<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialOrd<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialOrd<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialOrd<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialOrd<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialOrd<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialOrd<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq for secp256k1::All
+impl core::cmp::PartialEq for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialEq for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for secp256k1::ecdsa::Signature
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialEq for secp256k1::Error
+impl core::cmp::PartialEq for secp256k1::InvalidParityValue
+impl core::cmp::PartialEq for secp256k1::Keypair
+impl core::cmp::PartialEq for secp256k1::Message
+impl core::cmp::PartialEq for secp256k1::Parity
+impl core::cmp::PartialEq for secp256k1::PublicKey
+impl core::cmp::PartialEq for secp256k1::scalar::OutOfRangeError
+impl core::cmp::PartialEq for secp256k1::scalar::Scalar
+impl core::cmp::PartialEq for secp256k1::schnorr::Signature
+impl core::cmp::PartialEq for secp256k1::SecretKey
+impl core::cmp::PartialEq for secp256k1::SignOnly
+impl core::cmp::PartialEq for secp256k1::VerifyOnly
+impl core::cmp::PartialEq for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialEq<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::All
+impl core::cmp::PartialOrd for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialOrd for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::ecdsa::Signature
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialOrd for secp256k1::Error
+impl core::cmp::PartialOrd for secp256k1::InvalidParityValue
+impl core::cmp::PartialOrd for secp256k1::Keypair
+impl core::cmp::PartialOrd for secp256k1::Message
+impl core::cmp::PartialOrd for secp256k1::Parity
+impl core::cmp::PartialOrd for secp256k1::PublicKey
+impl core::cmp::PartialOrd for secp256k1::scalar::Scalar
+impl core::cmp::PartialOrd for secp256k1::schnorr::Signature
+impl core::cmp::PartialOrd for secp256k1::SignOnly
+impl core::cmp::PartialOrd for secp256k1::VerifyOnly
+impl core::cmp::PartialOrd for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialOrd<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::AsRef<[u8; 32]> for secp256k1::Message
 impl core::convert::AsRef<[u8; 32]> for secp256k1::SecretKey
 impl core::convert::AsRef<[u8; 64]> for secp256k1::schnorr::Signature
 impl core::convert::AsRef<[u8]> for secp256k1::ecdh::SharedSecret
 impl core::convert::AsRef<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::convert::From<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::From<secp256k1::InvalidParityValue> for secp256k1::Error
 impl core::convert::From<secp256k1::Keypair> for secp256k1::PublicKey
 impl core::convert::From<secp256k1::Keypair> for secp256k1::SecretKey
@@ -175,6 +186,7 @@ impl core::convert::From<secp256k1_sys::PublicKey> for secp256k1::PublicKey
 impl core::convert::From<secp256k1_sys::Signature> for secp256k1::ecdsa::Signature
 impl core::convert::From<secp256k1_sys::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
 impl core::convert::TryFrom<i32> for secp256k1::Parity
+impl core::convert::TryFrom<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl core::convert::TryFrom<u8> for secp256k1::Parity
 impl core::default::Default for secp256k1::Secp256k1<secp256k1::All>
 impl core::fmt::Debug for secp256k1::All
@@ -215,6 +227,7 @@ impl core::fmt::LowerHex for secp256k1::schnorr::Signature
 impl core::fmt::LowerHex for secp256k1::XOnlyPublicKey
 impl core::hash::Hash for secp256k1::All
 impl core::hash::Hash for secp256k1::ecdh::SharedSecret
+impl core::hash::Hash for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::hash::Hash for secp256k1::ecdsa::Signature
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwift
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwiftParty
@@ -226,6 +239,7 @@ impl core::hash::Hash for secp256k1::Message
 impl core::hash::Hash for secp256k1::Parity
 impl core::hash::Hash for secp256k1::PublicKey
 impl core::hash::Hash for secp256k1::scalar::OutOfRangeError
+impl core::hash::Hash for secp256k1::scalar::Scalar
 impl core::hash::Hash for secp256k1::schnorr::Signature
 impl core::hash::Hash for secp256k1::SignOnly
 impl core::hash::Hash for secp256k1::VerifyOnly
@@ -254,6 +268,27 @@ impl core::marker::Copy for secp256k1::SecretKey
 impl core::marker::Copy for secp256k1::SignOnly
 impl core::marker::Copy for secp256k1::VerifyOnly
 impl core::marker::Copy for secp256k1::XOnlyPublicKey
+impl core::marker::Freeze for secp256k1::All
+impl core::marker::Freeze for secp256k1::ecdh::SharedSecret
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::IntoIter
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::marker::Freeze for secp256k1::ecdsa::Signature
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwift
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftParty
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::marker::Freeze for secp256k1::Error
+impl core::marker::Freeze for secp256k1::InvalidParityValue
+impl core::marker::Freeze for secp256k1::Keypair
+impl core::marker::Freeze for secp256k1::Message
+impl core::marker::Freeze for secp256k1::Parity
+impl core::marker::Freeze for secp256k1::PublicKey
+impl core::marker::Freeze for secp256k1::scalar::OutOfRangeError
+impl core::marker::Freeze for secp256k1::scalar::Scalar
+impl core::marker::Freeze for secp256k1::schnorr::Signature
+impl core::marker::Freeze for secp256k1::SecretKey
+impl core::marker::Freeze for secp256k1::SignOnly
+impl core::marker::Freeze for secp256k1::VerifyOnly
+impl core::marker::Freeze for secp256k1::XOnlyPublicKey
 impl core::marker::Send for secp256k1::All
 impl core::marker::Send for secp256k1::ecdh::SharedSecret
 impl core::marker::Send for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -275,24 +310,6 @@ impl core::marker::Send for secp256k1::SecretKey
 impl core::marker::Send for secp256k1::SignOnly
 impl core::marker::Send for secp256k1::VerifyOnly
 impl core::marker::Send for secp256k1::XOnlyPublicKey
-impl core::marker::StructuralEq for secp256k1::All
-impl core::marker::StructuralEq for secp256k1::ecdh::SharedSecret
-impl core::marker::StructuralEq for secp256k1::ecdsa::Signature
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwift
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftParty
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::marker::StructuralEq for secp256k1::Error
-impl core::marker::StructuralEq for secp256k1::InvalidParityValue
-impl core::marker::StructuralEq for secp256k1::Keypair
-impl core::marker::StructuralEq for secp256k1::Message
-impl core::marker::StructuralEq for secp256k1::Parity
-impl core::marker::StructuralEq for secp256k1::PublicKey
-impl core::marker::StructuralEq for secp256k1::scalar::OutOfRangeError
-impl core::marker::StructuralEq for secp256k1::scalar::Scalar
-impl core::marker::StructuralEq for secp256k1::schnorr::Signature
-impl core::marker::StructuralEq for secp256k1::SignOnly
-impl core::marker::StructuralEq for secp256k1::VerifyOnly
-impl core::marker::StructuralEq for secp256k1::XOnlyPublicKey
 impl core::marker::StructuralPartialEq for secp256k1::All
 impl core::marker::StructuralPartialEq for secp256k1::ecdh::SharedSecret
 impl core::marker::StructuralPartialEq for secp256k1::ecdsa::Signature
@@ -353,7 +370,7 @@ impl core::marker::Unpin for secp256k1::SecretKey
 impl core::marker::Unpin for secp256k1::SignOnly
 impl core::marker::Unpin for secp256k1::VerifyOnly
 impl core::marker::Unpin for secp256k1::XOnlyPublicKey
-impl core::ops::bit::BitXor<secp256k1::Parity> for secp256k1::Parity
+impl core::ops::bit::BitXor for secp256k1::Parity
 impl core::ops::deref::Deref for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::All
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::ecdh::SharedSecret
@@ -407,7 +424,7 @@ impl core::str::traits::FromStr for secp256k1::SecretKey
 impl core::str::traits::FromStr for secp256k1::XOnlyPublicKey
 impl<C: secp256k1::Context> core::clone::Clone for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::cmp::Eq for secp256k1::Secp256k1<C>
-impl<C: secp256k1::Context> core::cmp::PartialEq<secp256k1::Secp256k1<C>> for secp256k1::Secp256k1<C>
+impl<C: secp256k1::Context> core::cmp::PartialEq for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::fmt::Debug for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Send for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Sync for secp256k1::Secp256k1<C>
@@ -427,6 +444,7 @@ impl secp256k1::ecdsa::serialized_signature::IntoIter
 impl secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl secp256k1::ecdsa::Signature
 impl secp256k1::ellswift::ElligatorSwift
+impl secp256k1::ellswift::ElligatorSwiftSharedSecret
 impl secp256k1::Keypair
 impl secp256k1::Message
 impl secp256k1::Parity
@@ -452,6 +470,9 @@ impl secp256k1::Verification for secp256k1::VerifyOnly
 impl secp256k1::XOnlyPublicKey
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::Message
 #[non_exhaustive] pub struct secp256k1::scalar::OutOfRangeError
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::as_secret_bytes(&self) -> &[u8; 32]
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::from_secret_bytes(bytes: [u8; 32]) -> Self
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::to_secret_bytes(self) -> [u8; 32]
 pub const secp256k1::All::DESCRIPTION: &'static str
 pub const secp256k1::All::FLAGS: secp256k1_sys::types::c_uint
 pub const secp256k1::AllPreallocated<'buf>::DESCRIPTION: &'static str
@@ -529,15 +550,23 @@ pub fn secp256k1::ecdsa::serialized_signature::IntoIter::next(&mut self) -> core
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::capacity(&self) -> usize
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::clone(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::cmp::Ordering
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from_signature(sig: &secp256k1::ecdsa::Signature) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: &'a secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::is_empty(&self) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<secp256k1::ecdsa::Signature, secp256k1::Error>
 pub fn secp256k1::ecdsa::Signature::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ecdsa::Signature::as_mut_c_ptr(&mut self) -> *mut Self::Target
@@ -559,6 +588,8 @@ pub fn secp256k1::ecdsa::Signature::normalize_s(&mut self)
 pub fn secp256k1::ecdsa::Signature::partial_cmp(&self, other: &secp256k1::ecdsa::Signature) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::Signature::serialize_compact(&self) -> [u8; 64]
 pub fn secp256k1::ecdsa::Signature::serialize_der(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::Signature::try_from(value: &'a secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn secp256k1::ecdsa::Signature::try_from(value: secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn secp256k1::ellswift::ElligatorSwift::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::as_mut_c_ptr(&mut self) -> *mut Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::clone(&self) -> secp256k1::ellswift::ElligatorSwift
@@ -692,6 +723,7 @@ pub fn secp256k1::scalar::Scalar::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn secp256k1::scalar::Scalar::from_be_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from_le_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from(value: secp256k1::SecretKey) -> Self
+pub fn secp256k1::scalar::Scalar::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn secp256k1::scalar::Scalar::index(&self, index: I) -> &Self::Output
 pub fn secp256k1::scalar::Scalar::non_secure_erase(&mut self)
 pub fn secp256k1::scalar::Scalar::partial_cmp(&self, other: &secp256k1::scalar::Scalar) -> core::option::Option<core::cmp::Ordering>
@@ -805,7 +837,9 @@ pub fn secp256k1::XOnlyPublicKey::public_key(&self, parity: secp256k1::Parity) -
 pub fn secp256k1::XOnlyPublicKey::serialize(&self) -> [u8; 32]
 pub fn secp256k1::XOnlyPublicKey::tweak_add_check<V: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<V>, tweaked_key: &Self, tweaked_parity: secp256k1::Parity, tweak: secp256k1::scalar::Scalar) -> bool
 pub fn secp256k1::XOnlyPublicKey::verify<C: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &secp256k1::schnorr::Signature) -> core::result::Result<(), secp256k1::Error>
+pub fn [u8]::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
 pub fn u8::from(parity: secp256k1::Parity) -> u8
+pub fn [u8]::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
 pub macro secp256k1::impl_array_newtype!
 pub mod secp256k1
 pub mod secp256k1::constants
@@ -860,6 +894,7 @@ pub type secp256k1::ecdsa::serialized_signature::IntoIter::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::IntoIter = secp256k1::ecdsa::serialized_signature::IntoIter
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Target = [u8]
+pub type secp256k1::ecdsa::Signature::Error = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Err = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Target = secp256k1_sys::Signature
 pub type secp256k1::ellswift::ElligatorSwift::Err = secp256k1::Error

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -1,5 +1,7 @@
+impl<'a> core::convert::From<&'a secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::PublicKey
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::SecretKey
+impl<'a> core::convert::TryFrom<&'a secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl<'a> core::iter::traits::collect::IntoIterator for &'a secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'buf> core::clone::Clone for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::clone::Clone for secp256k1::SignOnlyPreallocated<'buf>
@@ -10,12 +12,12 @@ impl<'buf> core::cmp::Eq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -25,12 +27,12 @@ impl<'buf> core::hash::Hash for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -60,10 +62,12 @@ impl<'buf> secp256k1::Signing for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Signing for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<C> core::marker::Freeze for secp256k1::Secp256k1<C>
 impl<C> core::marker::Unpin for secp256k1::Secp256k1<C> where C: core::marker::Unpin
 impl<C> core::panic::unwind_safe::RefUnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::RefUnwindSafe
 impl<C> core::panic::unwind_safe::UnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::UnwindSafe
 impl core::borrow::Borrow<[u8]> for secp256k1::ecdh::SharedSecret
+impl core::borrow::Borrow<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::clone::Clone for secp256k1::All
 impl core::clone::Clone for secp256k1::ecdh::SharedSecret
 impl core::clone::Clone for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -107,6 +111,7 @@ impl core::cmp::Eq for secp256k1::VerifyOnly
 impl core::cmp::Eq for secp256k1::XOnlyPublicKey
 impl core::cmp::Ord for secp256k1::All
 impl core::cmp::Ord for secp256k1::ecdh::SharedSecret
+impl core::cmp::Ord for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::cmp::Ord for secp256k1::ecdsa::Signature
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwift
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwiftParty
@@ -122,48 +127,54 @@ impl core::cmp::Ord for secp256k1::schnorr::Signature
 impl core::cmp::Ord for secp256k1::SignOnly
 impl core::cmp::Ord for secp256k1::VerifyOnly
 impl core::cmp::Ord for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialEq<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialEq<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
-impl core::cmp::PartialEq<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialEq<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialEq<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialEq<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialEq<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialEq<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialEq<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialEq<secp256k1::scalar::OutOfRangeError> for secp256k1::scalar::OutOfRangeError
-impl core::cmp::PartialEq<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialEq<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialEq<secp256k1::SecretKey> for secp256k1::SecretKey
-impl core::cmp::PartialEq<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialEq<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialEq<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialOrd<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialOrd<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialOrd<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialOrd<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialOrd<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialOrd<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialOrd<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialOrd<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialOrd<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialOrd<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialOrd<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialOrd<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialOrd<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialOrd<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq for secp256k1::All
+impl core::cmp::PartialEq for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialEq for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for secp256k1::ecdsa::Signature
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialEq for secp256k1::Error
+impl core::cmp::PartialEq for secp256k1::InvalidParityValue
+impl core::cmp::PartialEq for secp256k1::Keypair
+impl core::cmp::PartialEq for secp256k1::Message
+impl core::cmp::PartialEq for secp256k1::Parity
+impl core::cmp::PartialEq for secp256k1::PublicKey
+impl core::cmp::PartialEq for secp256k1::scalar::OutOfRangeError
+impl core::cmp::PartialEq for secp256k1::scalar::Scalar
+impl core::cmp::PartialEq for secp256k1::schnorr::Signature
+impl core::cmp::PartialEq for secp256k1::SecretKey
+impl core::cmp::PartialEq for secp256k1::SignOnly
+impl core::cmp::PartialEq for secp256k1::VerifyOnly
+impl core::cmp::PartialEq for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialEq<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::All
+impl core::cmp::PartialOrd for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialOrd for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::ecdsa::Signature
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialOrd for secp256k1::Error
+impl core::cmp::PartialOrd for secp256k1::InvalidParityValue
+impl core::cmp::PartialOrd for secp256k1::Keypair
+impl core::cmp::PartialOrd for secp256k1::Message
+impl core::cmp::PartialOrd for secp256k1::Parity
+impl core::cmp::PartialOrd for secp256k1::PublicKey
+impl core::cmp::PartialOrd for secp256k1::scalar::Scalar
+impl core::cmp::PartialOrd for secp256k1::schnorr::Signature
+impl core::cmp::PartialOrd for secp256k1::SignOnly
+impl core::cmp::PartialOrd for secp256k1::VerifyOnly
+impl core::cmp::PartialOrd for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialOrd<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::AsRef<[u8; 32]> for secp256k1::Message
 impl core::convert::AsRef<[u8; 32]> for secp256k1::SecretKey
 impl core::convert::AsRef<[u8; 64]> for secp256k1::schnorr::Signature
 impl core::convert::AsRef<[u8]> for secp256k1::ecdh::SharedSecret
 impl core::convert::AsRef<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::convert::From<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::From<secp256k1::InvalidParityValue> for secp256k1::Error
 impl core::convert::From<secp256k1::Keypair> for secp256k1::PublicKey
 impl core::convert::From<secp256k1::Keypair> for secp256k1::SecretKey
@@ -175,6 +186,7 @@ impl core::convert::From<secp256k1_sys::PublicKey> for secp256k1::PublicKey
 impl core::convert::From<secp256k1_sys::Signature> for secp256k1::ecdsa::Signature
 impl core::convert::From<secp256k1_sys::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
 impl core::convert::TryFrom<i32> for secp256k1::Parity
+impl core::convert::TryFrom<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl core::convert::TryFrom<u8> for secp256k1::Parity
 impl core::default::Default for secp256k1::Secp256k1<secp256k1::All>
 impl core::error::Error for secp256k1::Error
@@ -218,6 +230,7 @@ impl core::fmt::LowerHex for secp256k1::schnorr::Signature
 impl core::fmt::LowerHex for secp256k1::XOnlyPublicKey
 impl core::hash::Hash for secp256k1::All
 impl core::hash::Hash for secp256k1::ecdh::SharedSecret
+impl core::hash::Hash for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::hash::Hash for secp256k1::ecdsa::Signature
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwift
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwiftParty
@@ -229,6 +242,7 @@ impl core::hash::Hash for secp256k1::Message
 impl core::hash::Hash for secp256k1::Parity
 impl core::hash::Hash for secp256k1::PublicKey
 impl core::hash::Hash for secp256k1::scalar::OutOfRangeError
+impl core::hash::Hash for secp256k1::scalar::Scalar
 impl core::hash::Hash for secp256k1::schnorr::Signature
 impl core::hash::Hash for secp256k1::SignOnly
 impl core::hash::Hash for secp256k1::VerifyOnly
@@ -257,6 +271,27 @@ impl core::marker::Copy for secp256k1::SecretKey
 impl core::marker::Copy for secp256k1::SignOnly
 impl core::marker::Copy for secp256k1::VerifyOnly
 impl core::marker::Copy for secp256k1::XOnlyPublicKey
+impl core::marker::Freeze for secp256k1::All
+impl core::marker::Freeze for secp256k1::ecdh::SharedSecret
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::IntoIter
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::marker::Freeze for secp256k1::ecdsa::Signature
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwift
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftParty
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::marker::Freeze for secp256k1::Error
+impl core::marker::Freeze for secp256k1::InvalidParityValue
+impl core::marker::Freeze for secp256k1::Keypair
+impl core::marker::Freeze for secp256k1::Message
+impl core::marker::Freeze for secp256k1::Parity
+impl core::marker::Freeze for secp256k1::PublicKey
+impl core::marker::Freeze for secp256k1::scalar::OutOfRangeError
+impl core::marker::Freeze for secp256k1::scalar::Scalar
+impl core::marker::Freeze for secp256k1::schnorr::Signature
+impl core::marker::Freeze for secp256k1::SecretKey
+impl core::marker::Freeze for secp256k1::SignOnly
+impl core::marker::Freeze for secp256k1::VerifyOnly
+impl core::marker::Freeze for secp256k1::XOnlyPublicKey
 impl core::marker::Send for secp256k1::All
 impl core::marker::Send for secp256k1::ecdh::SharedSecret
 impl core::marker::Send for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -278,24 +313,6 @@ impl core::marker::Send for secp256k1::SecretKey
 impl core::marker::Send for secp256k1::SignOnly
 impl core::marker::Send for secp256k1::VerifyOnly
 impl core::marker::Send for secp256k1::XOnlyPublicKey
-impl core::marker::StructuralEq for secp256k1::All
-impl core::marker::StructuralEq for secp256k1::ecdh::SharedSecret
-impl core::marker::StructuralEq for secp256k1::ecdsa::Signature
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwift
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftParty
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::marker::StructuralEq for secp256k1::Error
-impl core::marker::StructuralEq for secp256k1::InvalidParityValue
-impl core::marker::StructuralEq for secp256k1::Keypair
-impl core::marker::StructuralEq for secp256k1::Message
-impl core::marker::StructuralEq for secp256k1::Parity
-impl core::marker::StructuralEq for secp256k1::PublicKey
-impl core::marker::StructuralEq for secp256k1::scalar::OutOfRangeError
-impl core::marker::StructuralEq for secp256k1::scalar::Scalar
-impl core::marker::StructuralEq for secp256k1::schnorr::Signature
-impl core::marker::StructuralEq for secp256k1::SignOnly
-impl core::marker::StructuralEq for secp256k1::VerifyOnly
-impl core::marker::StructuralEq for secp256k1::XOnlyPublicKey
 impl core::marker::StructuralPartialEq for secp256k1::All
 impl core::marker::StructuralPartialEq for secp256k1::ecdh::SharedSecret
 impl core::marker::StructuralPartialEq for secp256k1::ecdsa::Signature
@@ -356,7 +373,7 @@ impl core::marker::Unpin for secp256k1::SecretKey
 impl core::marker::Unpin for secp256k1::SignOnly
 impl core::marker::Unpin for secp256k1::VerifyOnly
 impl core::marker::Unpin for secp256k1::XOnlyPublicKey
-impl core::ops::bit::BitXor<secp256k1::Parity> for secp256k1::Parity
+impl core::ops::bit::BitXor for secp256k1::Parity
 impl core::ops::deref::Deref for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::All
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::ecdh::SharedSecret
@@ -410,7 +427,7 @@ impl core::str::traits::FromStr for secp256k1::SecretKey
 impl core::str::traits::FromStr for secp256k1::XOnlyPublicKey
 impl<C: secp256k1::Context> core::clone::Clone for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::cmp::Eq for secp256k1::Secp256k1<C>
-impl<C: secp256k1::Context> core::cmp::PartialEq<secp256k1::Secp256k1<C>> for secp256k1::Secp256k1<C>
+impl<C: secp256k1::Context> core::cmp::PartialEq for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::fmt::Debug for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Send for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Sync for secp256k1::Secp256k1<C>
@@ -430,6 +447,7 @@ impl secp256k1::ecdsa::serialized_signature::IntoIter
 impl secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl secp256k1::ecdsa::Signature
 impl secp256k1::ellswift::ElligatorSwift
+impl secp256k1::ellswift::ElligatorSwiftSharedSecret
 impl secp256k1::Keypair
 impl secp256k1::Message
 impl secp256k1::Parity
@@ -455,6 +473,9 @@ impl secp256k1::Verification for secp256k1::VerifyOnly
 impl secp256k1::XOnlyPublicKey
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::Message
 #[non_exhaustive] pub struct secp256k1::scalar::OutOfRangeError
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::as_secret_bytes(&self) -> &[u8; 32]
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::from_secret_bytes(bytes: [u8; 32]) -> Self
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::to_secret_bytes(self) -> [u8; 32]
 pub const secp256k1::All::DESCRIPTION: &'static str
 pub const secp256k1::All::FLAGS: secp256k1_sys::types::c_uint
 pub const secp256k1::AllPreallocated<'buf>::DESCRIPTION: &'static str
@@ -532,15 +553,23 @@ pub fn secp256k1::ecdsa::serialized_signature::IntoIter::next(&mut self) -> core
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::capacity(&self) -> usize
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::clone(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::cmp::Ordering
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from_signature(sig: &secp256k1::ecdsa::Signature) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: &'a secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::is_empty(&self) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<secp256k1::ecdsa::Signature, secp256k1::Error>
 pub fn secp256k1::ecdsa::Signature::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ecdsa::Signature::as_mut_c_ptr(&mut self) -> *mut Self::Target
@@ -562,6 +591,8 @@ pub fn secp256k1::ecdsa::Signature::normalize_s(&mut self)
 pub fn secp256k1::ecdsa::Signature::partial_cmp(&self, other: &secp256k1::ecdsa::Signature) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::Signature::serialize_compact(&self) -> [u8; 64]
 pub fn secp256k1::ecdsa::Signature::serialize_der(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::Signature::try_from(value: &'a secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn secp256k1::ecdsa::Signature::try_from(value: secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn secp256k1::ellswift::ElligatorSwift::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::as_mut_c_ptr(&mut self) -> *mut Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::clone(&self) -> secp256k1::ellswift::ElligatorSwift
@@ -696,6 +727,7 @@ pub fn secp256k1::scalar::Scalar::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn secp256k1::scalar::Scalar::from_be_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from_le_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from(value: secp256k1::SecretKey) -> Self
+pub fn secp256k1::scalar::Scalar::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn secp256k1::scalar::Scalar::index(&self, index: I) -> &Self::Output
 pub fn secp256k1::scalar::Scalar::non_secure_erase(&mut self)
 pub fn secp256k1::scalar::Scalar::partial_cmp(&self, other: &secp256k1::scalar::Scalar) -> core::option::Option<core::cmp::Ordering>
@@ -809,7 +841,9 @@ pub fn secp256k1::XOnlyPublicKey::public_key(&self, parity: secp256k1::Parity) -
 pub fn secp256k1::XOnlyPublicKey::serialize(&self) -> [u8; 32]
 pub fn secp256k1::XOnlyPublicKey::tweak_add_check<V: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<V>, tweaked_key: &Self, tweaked_parity: secp256k1::Parity, tweak: secp256k1::scalar::Scalar) -> bool
 pub fn secp256k1::XOnlyPublicKey::verify<C: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &secp256k1::schnorr::Signature) -> core::result::Result<(), secp256k1::Error>
+pub fn [u8]::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
 pub fn u8::from(parity: secp256k1::Parity) -> u8
+pub fn [u8]::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
 pub macro secp256k1::impl_array_newtype!
 pub mod secp256k1
 pub mod secp256k1::constants
@@ -864,6 +898,7 @@ pub type secp256k1::ecdsa::serialized_signature::IntoIter::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::IntoIter = secp256k1::ecdsa::serialized_signature::IntoIter
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Target = [u8]
+pub type secp256k1::ecdsa::Signature::Error = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Err = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Target = secp256k1_sys::Signature
 pub type secp256k1::ellswift::ElligatorSwift::Err = secp256k1::Error

--- a/api/global-context.txt
+++ b/api/global-context.txt
@@ -1,5 +1,7 @@
+impl<'a> core::convert::From<&'a secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::PublicKey
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::SecretKey
+impl<'a> core::convert::TryFrom<&'a secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl<'a> core::iter::traits::collect::IntoIterator for &'a secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'buf> core::clone::Clone for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::clone::Clone for secp256k1::SignOnlyPreallocated<'buf>
@@ -10,12 +12,12 @@ impl<'buf> core::cmp::Eq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -25,12 +27,12 @@ impl<'buf> core::hash::Hash for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -60,10 +62,12 @@ impl<'buf> secp256k1::Signing for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Signing for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<C> core::marker::Freeze for secp256k1::Secp256k1<C>
 impl<C> core::marker::Unpin for secp256k1::Secp256k1<C> where C: core::marker::Unpin
 impl<C> core::panic::unwind_safe::RefUnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::RefUnwindSafe
 impl<C> core::panic::unwind_safe::UnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::UnwindSafe
 impl core::borrow::Borrow<[u8]> for secp256k1::ecdh::SharedSecret
+impl core::borrow::Borrow<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::clone::Clone for secp256k1::All
 impl core::clone::Clone for secp256k1::ecdh::SharedSecret
 impl core::clone::Clone for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -108,6 +112,7 @@ impl core::cmp::Eq for secp256k1::VerifyOnly
 impl core::cmp::Eq for secp256k1::XOnlyPublicKey
 impl core::cmp::Ord for secp256k1::All
 impl core::cmp::Ord for secp256k1::ecdh::SharedSecret
+impl core::cmp::Ord for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::cmp::Ord for secp256k1::ecdsa::Signature
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwift
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwiftParty
@@ -123,48 +128,54 @@ impl core::cmp::Ord for secp256k1::schnorr::Signature
 impl core::cmp::Ord for secp256k1::SignOnly
 impl core::cmp::Ord for secp256k1::VerifyOnly
 impl core::cmp::Ord for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialEq<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialEq<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
-impl core::cmp::PartialEq<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialEq<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialEq<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialEq<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialEq<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialEq<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialEq<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialEq<secp256k1::scalar::OutOfRangeError> for secp256k1::scalar::OutOfRangeError
-impl core::cmp::PartialEq<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialEq<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialEq<secp256k1::SecretKey> for secp256k1::SecretKey
-impl core::cmp::PartialEq<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialEq<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialEq<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialOrd<secp256k1::All> for secp256k1::All
-impl core::cmp::PartialOrd<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialOrd<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialOrd<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialOrd<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialOrd<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialOrd<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialOrd<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialOrd<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialOrd<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialOrd<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialOrd<secp256k1::SignOnly> for secp256k1::SignOnly
-impl core::cmp::PartialOrd<secp256k1::VerifyOnly> for secp256k1::VerifyOnly
-impl core::cmp::PartialOrd<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq for secp256k1::All
+impl core::cmp::PartialEq for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialEq for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for secp256k1::ecdsa::Signature
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialEq for secp256k1::Error
+impl core::cmp::PartialEq for secp256k1::InvalidParityValue
+impl core::cmp::PartialEq for secp256k1::Keypair
+impl core::cmp::PartialEq for secp256k1::Message
+impl core::cmp::PartialEq for secp256k1::Parity
+impl core::cmp::PartialEq for secp256k1::PublicKey
+impl core::cmp::PartialEq for secp256k1::scalar::OutOfRangeError
+impl core::cmp::PartialEq for secp256k1::scalar::Scalar
+impl core::cmp::PartialEq for secp256k1::schnorr::Signature
+impl core::cmp::PartialEq for secp256k1::SecretKey
+impl core::cmp::PartialEq for secp256k1::SignOnly
+impl core::cmp::PartialEq for secp256k1::VerifyOnly
+impl core::cmp::PartialEq for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialEq<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::All
+impl core::cmp::PartialOrd for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialOrd for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::ecdsa::Signature
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialOrd for secp256k1::Error
+impl core::cmp::PartialOrd for secp256k1::InvalidParityValue
+impl core::cmp::PartialOrd for secp256k1::Keypair
+impl core::cmp::PartialOrd for secp256k1::Message
+impl core::cmp::PartialOrd for secp256k1::Parity
+impl core::cmp::PartialOrd for secp256k1::PublicKey
+impl core::cmp::PartialOrd for secp256k1::scalar::Scalar
+impl core::cmp::PartialOrd for secp256k1::schnorr::Signature
+impl core::cmp::PartialOrd for secp256k1::SignOnly
+impl core::cmp::PartialOrd for secp256k1::VerifyOnly
+impl core::cmp::PartialOrd for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialOrd<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::AsRef<[u8; 32]> for secp256k1::Message
 impl core::convert::AsRef<[u8; 32]> for secp256k1::SecretKey
 impl core::convert::AsRef<[u8; 64]> for secp256k1::schnorr::Signature
 impl core::convert::AsRef<[u8]> for secp256k1::ecdh::SharedSecret
 impl core::convert::AsRef<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::convert::From<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::From<secp256k1::InvalidParityValue> for secp256k1::Error
 impl core::convert::From<secp256k1::Keypair> for secp256k1::PublicKey
 impl core::convert::From<secp256k1::Keypair> for secp256k1::SecretKey
@@ -176,6 +187,7 @@ impl core::convert::From<secp256k1_sys::PublicKey> for secp256k1::PublicKey
 impl core::convert::From<secp256k1_sys::Signature> for secp256k1::ecdsa::Signature
 impl core::convert::From<secp256k1_sys::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
 impl core::convert::TryFrom<i32> for secp256k1::Parity
+impl core::convert::TryFrom<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl core::convert::TryFrom<u8> for secp256k1::Parity
 impl core::default::Default for secp256k1::Secp256k1<secp256k1::All>
 impl core::error::Error for secp256k1::Error
@@ -220,6 +232,7 @@ impl core::fmt::LowerHex for secp256k1::schnorr::Signature
 impl core::fmt::LowerHex for secp256k1::XOnlyPublicKey
 impl core::hash::Hash for secp256k1::All
 impl core::hash::Hash for secp256k1::ecdh::SharedSecret
+impl core::hash::Hash for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::hash::Hash for secp256k1::ecdsa::Signature
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwift
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwiftParty
@@ -231,6 +244,7 @@ impl core::hash::Hash for secp256k1::Message
 impl core::hash::Hash for secp256k1::Parity
 impl core::hash::Hash for secp256k1::PublicKey
 impl core::hash::Hash for secp256k1::scalar::OutOfRangeError
+impl core::hash::Hash for secp256k1::scalar::Scalar
 impl core::hash::Hash for secp256k1::schnorr::Signature
 impl core::hash::Hash for secp256k1::SignOnly
 impl core::hash::Hash for secp256k1::VerifyOnly
@@ -260,6 +274,28 @@ impl core::marker::Copy for secp256k1::SecretKey
 impl core::marker::Copy for secp256k1::SignOnly
 impl core::marker::Copy for secp256k1::VerifyOnly
 impl core::marker::Copy for secp256k1::XOnlyPublicKey
+impl core::marker::Freeze for secp256k1::All
+impl core::marker::Freeze for secp256k1::ecdh::SharedSecret
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::IntoIter
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::marker::Freeze for secp256k1::ecdsa::Signature
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwift
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftParty
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::marker::Freeze for secp256k1::Error
+impl core::marker::Freeze for secp256k1::global::GlobalContext
+impl core::marker::Freeze for secp256k1::InvalidParityValue
+impl core::marker::Freeze for secp256k1::Keypair
+impl core::marker::Freeze for secp256k1::Message
+impl core::marker::Freeze for secp256k1::Parity
+impl core::marker::Freeze for secp256k1::PublicKey
+impl core::marker::Freeze for secp256k1::scalar::OutOfRangeError
+impl core::marker::Freeze for secp256k1::scalar::Scalar
+impl core::marker::Freeze for secp256k1::schnorr::Signature
+impl core::marker::Freeze for secp256k1::SecretKey
+impl core::marker::Freeze for secp256k1::SignOnly
+impl core::marker::Freeze for secp256k1::VerifyOnly
+impl core::marker::Freeze for secp256k1::XOnlyPublicKey
 impl core::marker::Send for secp256k1::All
 impl core::marker::Send for secp256k1::ecdh::SharedSecret
 impl core::marker::Send for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -282,24 +318,6 @@ impl core::marker::Send for secp256k1::SecretKey
 impl core::marker::Send for secp256k1::SignOnly
 impl core::marker::Send for secp256k1::VerifyOnly
 impl core::marker::Send for secp256k1::XOnlyPublicKey
-impl core::marker::StructuralEq for secp256k1::All
-impl core::marker::StructuralEq for secp256k1::ecdh::SharedSecret
-impl core::marker::StructuralEq for secp256k1::ecdsa::Signature
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwift
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftParty
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::marker::StructuralEq for secp256k1::Error
-impl core::marker::StructuralEq for secp256k1::InvalidParityValue
-impl core::marker::StructuralEq for secp256k1::Keypair
-impl core::marker::StructuralEq for secp256k1::Message
-impl core::marker::StructuralEq for secp256k1::Parity
-impl core::marker::StructuralEq for secp256k1::PublicKey
-impl core::marker::StructuralEq for secp256k1::scalar::OutOfRangeError
-impl core::marker::StructuralEq for secp256k1::scalar::Scalar
-impl core::marker::StructuralEq for secp256k1::schnorr::Signature
-impl core::marker::StructuralEq for secp256k1::SignOnly
-impl core::marker::StructuralEq for secp256k1::VerifyOnly
-impl core::marker::StructuralEq for secp256k1::XOnlyPublicKey
 impl core::marker::StructuralPartialEq for secp256k1::All
 impl core::marker::StructuralPartialEq for secp256k1::ecdh::SharedSecret
 impl core::marker::StructuralPartialEq for secp256k1::ecdsa::Signature
@@ -362,7 +380,7 @@ impl core::marker::Unpin for secp256k1::SecretKey
 impl core::marker::Unpin for secp256k1::SignOnly
 impl core::marker::Unpin for secp256k1::VerifyOnly
 impl core::marker::Unpin for secp256k1::XOnlyPublicKey
-impl core::ops::bit::BitXor<secp256k1::Parity> for secp256k1::Parity
+impl core::ops::bit::BitXor for secp256k1::Parity
 impl core::ops::deref::Deref for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::ops::deref::Deref for secp256k1::global::GlobalContext
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::All
@@ -419,7 +437,7 @@ impl core::str::traits::FromStr for secp256k1::SecretKey
 impl core::str::traits::FromStr for secp256k1::XOnlyPublicKey
 impl<C: secp256k1::Context> core::clone::Clone for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::cmp::Eq for secp256k1::Secp256k1<C>
-impl<C: secp256k1::Context> core::cmp::PartialEq<secp256k1::Secp256k1<C>> for secp256k1::Secp256k1<C>
+impl<C: secp256k1::Context> core::cmp::PartialEq for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::fmt::Debug for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Send for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Sync for secp256k1::Secp256k1<C>
@@ -439,6 +457,7 @@ impl secp256k1::ecdsa::serialized_signature::IntoIter
 impl secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl secp256k1::ecdsa::Signature
 impl secp256k1::ellswift::ElligatorSwift
+impl secp256k1::ellswift::ElligatorSwiftSharedSecret
 impl secp256k1::Keypair
 impl secp256k1::Message
 impl secp256k1::Parity
@@ -464,6 +483,9 @@ impl secp256k1::Verification for secp256k1::VerifyOnly
 impl secp256k1::XOnlyPublicKey
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::Message
 #[non_exhaustive] pub struct secp256k1::scalar::OutOfRangeError
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::as_secret_bytes(&self) -> &[u8; 32]
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::from_secret_bytes(bytes: [u8; 32]) -> Self
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::to_secret_bytes(self) -> [u8; 32]
 pub const secp256k1::All::DESCRIPTION: &'static str
 pub const secp256k1::All::FLAGS: secp256k1_sys::types::c_uint
 pub const secp256k1::AllPreallocated<'buf>::DESCRIPTION: &'static str
@@ -541,15 +563,23 @@ pub fn secp256k1::ecdsa::serialized_signature::IntoIter::next(&mut self) -> core
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::capacity(&self) -> usize
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::clone(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::cmp::Ordering
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from_signature(sig: &secp256k1::ecdsa::Signature) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: &'a secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::is_empty(&self) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<secp256k1::ecdsa::Signature, secp256k1::Error>
 pub fn secp256k1::ecdsa::Signature::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ecdsa::Signature::as_mut_c_ptr(&mut self) -> *mut Self::Target
@@ -571,6 +601,8 @@ pub fn secp256k1::ecdsa::Signature::normalize_s(&mut self)
 pub fn secp256k1::ecdsa::Signature::partial_cmp(&self, other: &secp256k1::ecdsa::Signature) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::Signature::serialize_compact(&self) -> [u8; 64]
 pub fn secp256k1::ecdsa::Signature::serialize_der(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::Signature::try_from(value: &'a secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn secp256k1::ecdsa::Signature::try_from(value: secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn secp256k1::ecdsa::Signature::verify(&self, msg: &secp256k1::Message, pk: &secp256k1::PublicKey) -> core::result::Result<(), secp256k1::Error>
 pub fn secp256k1::ellswift::ElligatorSwift::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::as_mut_c_ptr(&mut self) -> *mut Self::Target
@@ -711,6 +743,7 @@ pub fn secp256k1::scalar::Scalar::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn secp256k1::scalar::Scalar::from_be_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from_le_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from(value: secp256k1::SecretKey) -> Self
+pub fn secp256k1::scalar::Scalar::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn secp256k1::scalar::Scalar::index(&self, index: I) -> &Self::Output
 pub fn secp256k1::scalar::Scalar::non_secure_erase(&mut self)
 pub fn secp256k1::scalar::Scalar::partial_cmp(&self, other: &secp256k1::scalar::Scalar) -> core::option::Option<core::cmp::Ordering>
@@ -826,7 +859,9 @@ pub fn secp256k1::XOnlyPublicKey::public_key(&self, parity: secp256k1::Parity) -
 pub fn secp256k1::XOnlyPublicKey::serialize(&self) -> [u8; 32]
 pub fn secp256k1::XOnlyPublicKey::tweak_add_check<V: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<V>, tweaked_key: &Self, tweaked_parity: secp256k1::Parity, tweak: secp256k1::scalar::Scalar) -> bool
 pub fn secp256k1::XOnlyPublicKey::verify<C: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &secp256k1::schnorr::Signature) -> core::result::Result<(), secp256k1::Error>
+pub fn [u8]::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
 pub fn u8::from(parity: secp256k1::Parity) -> u8
+pub fn [u8]::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
 pub macro secp256k1::impl_array_newtype!
 pub mod secp256k1
 pub mod secp256k1::constants
@@ -885,6 +920,7 @@ pub type secp256k1::ecdsa::serialized_signature::IntoIter::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::IntoIter = secp256k1::ecdsa::serialized_signature::IntoIter
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Target = [u8]
+pub type secp256k1::ecdsa::Signature::Error = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Err = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Target = secp256k1_sys::Signature
 pub type secp256k1::ellswift::ElligatorSwift::Err = secp256k1::Error

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -1,5 +1,7 @@
+impl<'a> core::convert::From<&'a secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::PublicKey
 impl<'a> core::convert::From<&'a secp256k1::Keypair> for secp256k1::SecretKey
+impl<'a> core::convert::TryFrom<&'a secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl<'a> core::iter::traits::collect::IntoIterator for &'a secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl<'buf> core::clone::Clone for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::clone::Clone for secp256k1::SignOnlyPreallocated<'buf>
@@ -10,12 +12,12 @@ impl<'buf> core::cmp::Eq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::cmp::Ord for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialEq<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::AllPreallocated<'buf>> for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::SignOnlyPreallocated<'buf>> for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::cmp::PartialOrd<secp256k1::VerifyOnlyPreallocated<'buf>> for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::cmp::PartialOrd for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::fmt::Debug for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -25,12 +27,12 @@ impl<'buf> core::hash::Hash for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Copy for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::AllPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::SignOnlyPreallocated<'buf>
+impl<'buf> core::marker::Freeze for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::Send for secp256k1::VerifyOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::AllPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::SignOnlyPreallocated<'buf>
-impl<'buf> core::marker::StructuralEq for secp256k1::VerifyOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::AllPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> core::marker::StructuralPartialEq for secp256k1::VerifyOnlyPreallocated<'buf>
@@ -60,10 +62,12 @@ impl<'buf> secp256k1::Signing for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Signing for secp256k1::SignOnlyPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::AllPreallocated<'buf>
 impl<'buf> secp256k1::Verification for secp256k1::VerifyOnlyPreallocated<'buf>
+impl<C> core::marker::Freeze for secp256k1::Secp256k1<C>
 impl<C> core::marker::Unpin for secp256k1::Secp256k1<C> where C: core::marker::Unpin
 impl<C> core::panic::unwind_safe::RefUnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::RefUnwindSafe
 impl<C> core::panic::unwind_safe::UnwindSafe for secp256k1::Secp256k1<C> where C: core::panic::unwind_safe::UnwindSafe
 impl core::borrow::Borrow<[u8]> for secp256k1::ecdh::SharedSecret
+impl core::borrow::Borrow<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::clone::Clone for secp256k1::ecdh::SharedSecret
 impl core::clone::Clone for secp256k1::ecdsa::serialized_signature::IntoIter
 impl core::clone::Clone for secp256k1::ecdsa::serialized_signature::SerializedSignature
@@ -100,6 +104,7 @@ impl core::cmp::Eq for secp256k1::schnorr::Signature
 impl core::cmp::Eq for secp256k1::SecretKey
 impl core::cmp::Eq for secp256k1::XOnlyPublicKey
 impl core::cmp::Ord for secp256k1::ecdh::SharedSecret
+impl core::cmp::Ord for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::cmp::Ord for secp256k1::ecdsa::Signature
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwift
 impl core::cmp::Ord for secp256k1::ellswift::ElligatorSwiftParty
@@ -113,42 +118,48 @@ impl core::cmp::Ord for secp256k1::PublicKey
 impl core::cmp::Ord for secp256k1::scalar::Scalar
 impl core::cmp::Ord for secp256k1::schnorr::Signature
 impl core::cmp::Ord for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialEq<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
-impl core::cmp::PartialEq<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialEq<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialEq<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialEq<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialEq<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialEq<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialEq<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialEq<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialEq<secp256k1::scalar::OutOfRangeError> for secp256k1::scalar::OutOfRangeError
-impl core::cmp::PartialEq<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialEq<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialEq<secp256k1::SecretKey> for secp256k1::SecretKey
-impl core::cmp::PartialEq<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
-impl core::cmp::PartialOrd<secp256k1::ecdh::SharedSecret> for secp256k1::ecdh::SharedSecret
-impl core::cmp::PartialOrd<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::Signature
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwift> for secp256k1::ellswift::ElligatorSwift
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftParty> for secp256k1::ellswift::ElligatorSwiftParty
-impl core::cmp::PartialOrd<secp256k1::ellswift::ElligatorSwiftSharedSecret> for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::cmp::PartialOrd<secp256k1::Error> for secp256k1::Error
-impl core::cmp::PartialOrd<secp256k1::InvalidParityValue> for secp256k1::InvalidParityValue
-impl core::cmp::PartialOrd<secp256k1::Keypair> for secp256k1::Keypair
-impl core::cmp::PartialOrd<secp256k1::Message> for secp256k1::Message
-impl core::cmp::PartialOrd<secp256k1::Parity> for secp256k1::Parity
-impl core::cmp::PartialOrd<secp256k1::PublicKey> for secp256k1::PublicKey
-impl core::cmp::PartialOrd<secp256k1::scalar::Scalar> for secp256k1::scalar::Scalar
-impl core::cmp::PartialOrd<secp256k1::schnorr::Signature> for secp256k1::schnorr::Signature
-impl core::cmp::PartialOrd<secp256k1::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialEq for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for secp256k1::ecdsa::Signature
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialEq for secp256k1::Error
+impl core::cmp::PartialEq for secp256k1::InvalidParityValue
+impl core::cmp::PartialEq for secp256k1::Keypair
+impl core::cmp::PartialEq for secp256k1::Message
+impl core::cmp::PartialEq for secp256k1::Parity
+impl core::cmp::PartialEq for secp256k1::PublicKey
+impl core::cmp::PartialEq for secp256k1::scalar::OutOfRangeError
+impl core::cmp::PartialEq for secp256k1::scalar::Scalar
+impl core::cmp::PartialEq for secp256k1::schnorr::Signature
+impl core::cmp::PartialEq for secp256k1::SecretKey
+impl core::cmp::PartialEq for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialEq<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialEq<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::ecdh::SharedSecret
+impl core::cmp::PartialOrd for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd for secp256k1::ecdsa::Signature
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwift
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftParty
+impl core::cmp::PartialOrd for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::cmp::PartialOrd for secp256k1::Error
+impl core::cmp::PartialOrd for secp256k1::InvalidParityValue
+impl core::cmp::PartialOrd for secp256k1::Keypair
+impl core::cmp::PartialOrd for secp256k1::Message
+impl core::cmp::PartialOrd for secp256k1::Parity
+impl core::cmp::PartialOrd for secp256k1::PublicKey
+impl core::cmp::PartialOrd for secp256k1::scalar::Scalar
+impl core::cmp::PartialOrd for secp256k1::schnorr::Signature
+impl core::cmp::PartialOrd for secp256k1::XOnlyPublicKey
+impl core::cmp::PartialOrd<secp256k1::ecdsa::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::AsRef<[u8; 32]> for secp256k1::Message
 impl core::convert::AsRef<[u8; 32]> for secp256k1::SecretKey
 impl core::convert::AsRef<[u8; 64]> for secp256k1::schnorr::Signature
 impl core::convert::AsRef<[u8]> for secp256k1::ecdh::SharedSecret
 impl core::convert::AsRef<[u8]> for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::convert::From<secp256k1::ecdsa::Signature> for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::convert::From<secp256k1::InvalidParityValue> for secp256k1::Error
 impl core::convert::From<secp256k1::Keypair> for secp256k1::PublicKey
 impl core::convert::From<secp256k1::Keypair> for secp256k1::SecretKey
@@ -160,6 +171,7 @@ impl core::convert::From<secp256k1_sys::PublicKey> for secp256k1::PublicKey
 impl core::convert::From<secp256k1_sys::Signature> for secp256k1::ecdsa::Signature
 impl core::convert::From<secp256k1_sys::XOnlyPublicKey> for secp256k1::XOnlyPublicKey
 impl core::convert::TryFrom<i32> for secp256k1::Parity
+impl core::convert::TryFrom<secp256k1::ecdsa::serialized_signature::SerializedSignature> for secp256k1::ecdsa::Signature
 impl core::convert::TryFrom<u8> for secp256k1::Parity
 impl core::fmt::Debug for secp256k1::ecdh::SharedSecret
 impl core::fmt::Debug for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -195,6 +207,7 @@ impl core::fmt::LowerHex for secp256k1::PublicKey
 impl core::fmt::LowerHex for secp256k1::schnorr::Signature
 impl core::fmt::LowerHex for secp256k1::XOnlyPublicKey
 impl core::hash::Hash for secp256k1::ecdh::SharedSecret
+impl core::hash::Hash for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::hash::Hash for secp256k1::ecdsa::Signature
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwift
 impl core::hash::Hash for secp256k1::ellswift::ElligatorSwiftParty
@@ -206,6 +219,7 @@ impl core::hash::Hash for secp256k1::Message
 impl core::hash::Hash for secp256k1::Parity
 impl core::hash::Hash for secp256k1::PublicKey
 impl core::hash::Hash for secp256k1::scalar::OutOfRangeError
+impl core::hash::Hash for secp256k1::scalar::Scalar
 impl core::hash::Hash for secp256k1::schnorr::Signature
 impl core::hash::Hash for secp256k1::XOnlyPublicKey
 impl core::iter::traits::collect::IntoIterator for secp256k1::ecdsa::serialized_signature::SerializedSignature
@@ -229,6 +243,24 @@ impl core::marker::Copy for secp256k1::scalar::Scalar
 impl core::marker::Copy for secp256k1::schnorr::Signature
 impl core::marker::Copy for secp256k1::SecretKey
 impl core::marker::Copy for secp256k1::XOnlyPublicKey
+impl core::marker::Freeze for secp256k1::ecdh::SharedSecret
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::IntoIter
+impl core::marker::Freeze for secp256k1::ecdsa::serialized_signature::SerializedSignature
+impl core::marker::Freeze for secp256k1::ecdsa::Signature
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwift
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftParty
+impl core::marker::Freeze for secp256k1::ellswift::ElligatorSwiftSharedSecret
+impl core::marker::Freeze for secp256k1::Error
+impl core::marker::Freeze for secp256k1::InvalidParityValue
+impl core::marker::Freeze for secp256k1::Keypair
+impl core::marker::Freeze for secp256k1::Message
+impl core::marker::Freeze for secp256k1::Parity
+impl core::marker::Freeze for secp256k1::PublicKey
+impl core::marker::Freeze for secp256k1::scalar::OutOfRangeError
+impl core::marker::Freeze for secp256k1::scalar::Scalar
+impl core::marker::Freeze for secp256k1::schnorr::Signature
+impl core::marker::Freeze for secp256k1::SecretKey
+impl core::marker::Freeze for secp256k1::XOnlyPublicKey
 impl core::marker::Send for secp256k1::ecdh::SharedSecret
 impl core::marker::Send for secp256k1::ecdsa::serialized_signature::IntoIter
 impl core::marker::Send for secp256k1::ecdsa::serialized_signature::SerializedSignature
@@ -247,21 +279,6 @@ impl core::marker::Send for secp256k1::scalar::Scalar
 impl core::marker::Send for secp256k1::schnorr::Signature
 impl core::marker::Send for secp256k1::SecretKey
 impl core::marker::Send for secp256k1::XOnlyPublicKey
-impl core::marker::StructuralEq for secp256k1::ecdh::SharedSecret
-impl core::marker::StructuralEq for secp256k1::ecdsa::Signature
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwift
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftParty
-impl core::marker::StructuralEq for secp256k1::ellswift::ElligatorSwiftSharedSecret
-impl core::marker::StructuralEq for secp256k1::Error
-impl core::marker::StructuralEq for secp256k1::InvalidParityValue
-impl core::marker::StructuralEq for secp256k1::Keypair
-impl core::marker::StructuralEq for secp256k1::Message
-impl core::marker::StructuralEq for secp256k1::Parity
-impl core::marker::StructuralEq for secp256k1::PublicKey
-impl core::marker::StructuralEq for secp256k1::scalar::OutOfRangeError
-impl core::marker::StructuralEq for secp256k1::scalar::Scalar
-impl core::marker::StructuralEq for secp256k1::schnorr::Signature
-impl core::marker::StructuralEq for secp256k1::XOnlyPublicKey
 impl core::marker::StructuralPartialEq for secp256k1::ecdh::SharedSecret
 impl core::marker::StructuralPartialEq for secp256k1::ecdsa::Signature
 impl core::marker::StructuralPartialEq for secp256k1::ellswift::ElligatorSwift
@@ -313,7 +330,7 @@ impl core::marker::Unpin for secp256k1::scalar::Scalar
 impl core::marker::Unpin for secp256k1::schnorr::Signature
 impl core::marker::Unpin for secp256k1::SecretKey
 impl core::marker::Unpin for secp256k1::XOnlyPublicKey
-impl core::ops::bit::BitXor<secp256k1::Parity> for secp256k1::Parity
+impl core::ops::bit::BitXor for secp256k1::Parity
 impl core::ops::deref::Deref for secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::ecdh::SharedSecret
 impl core::panic::unwind_safe::RefUnwindSafe for secp256k1::ecdsa::serialized_signature::IntoIter
@@ -360,7 +377,7 @@ impl core::str::traits::FromStr for secp256k1::schnorr::Signature
 impl core::str::traits::FromStr for secp256k1::SecretKey
 impl core::str::traits::FromStr for secp256k1::XOnlyPublicKey
 impl<C: secp256k1::Context> core::cmp::Eq for secp256k1::Secp256k1<C>
-impl<C: secp256k1::Context> core::cmp::PartialEq<secp256k1::Secp256k1<C>> for secp256k1::Secp256k1<C>
+impl<C: secp256k1::Context> core::cmp::PartialEq for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::fmt::Debug for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Send for secp256k1::Secp256k1<C>
 impl<C: secp256k1::Context> core::marker::Sync for secp256k1::Secp256k1<C>
@@ -377,6 +394,7 @@ impl secp256k1::ecdsa::serialized_signature::IntoIter
 impl secp256k1::ecdsa::serialized_signature::SerializedSignature
 impl secp256k1::ecdsa::Signature
 impl secp256k1::ellswift::ElligatorSwift
+impl secp256k1::ellswift::ElligatorSwiftSharedSecret
 impl secp256k1::Keypair
 impl secp256k1::Message
 impl secp256k1::Parity
@@ -395,6 +413,9 @@ impl secp256k1_sys::CPtr for secp256k1::XOnlyPublicKey
 impl secp256k1::XOnlyPublicKey
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::Message
 #[non_exhaustive] pub struct secp256k1::scalar::OutOfRangeError
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::as_secret_bytes(&self) -> &[u8; 32]
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::from_secret_bytes(bytes: [u8; 32]) -> Self
+pub const fn secp256k1::ellswift::ElligatorSwiftSharedSecret::to_secret_bytes(self) -> [u8; 32]
 pub const secp256k1::AllPreallocated<'buf>::DESCRIPTION: &'static str
 pub const secp256k1::AllPreallocated<'buf>::FLAGS: secp256k1_sys::types::c_uint
 pub const secp256k1::constants::COMPACT_SIGNATURE_SIZE: usize = 64usize
@@ -457,15 +478,23 @@ pub fn secp256k1::ecdsa::serialized_signature::IntoIter::next(&mut self) -> core
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
 pub fn secp256k1::ecdsa::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::capacity(&self) -> usize
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::clone(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::cmp::Ordering
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from_signature(sig: &secp256k1::ecdsa::Signature) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: &'a secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::from(value: secp256k1::ecdsa::Signature) -> Self
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::is_empty(&self) -> bool
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<secp256k1::ecdsa::Signature, secp256k1::Error>
 pub fn secp256k1::ecdsa::Signature::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ecdsa::Signature::as_mut_c_ptr(&mut self) -> *mut Self::Target
@@ -487,6 +516,8 @@ pub fn secp256k1::ecdsa::Signature::normalize_s(&mut self)
 pub fn secp256k1::ecdsa::Signature::partial_cmp(&self, other: &secp256k1::ecdsa::Signature) -> core::option::Option<core::cmp::Ordering>
 pub fn secp256k1::ecdsa::Signature::serialize_compact(&self) -> [u8; 64]
 pub fn secp256k1::ecdsa::Signature::serialize_der(&self) -> secp256k1::ecdsa::serialized_signature::SerializedSignature
+pub fn secp256k1::ecdsa::Signature::try_from(value: &'a secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn secp256k1::ecdsa::Signature::try_from(value: secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn secp256k1::ellswift::ElligatorSwift::as_c_ptr(&self) -> *const Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::as_mut_c_ptr(&mut self) -> *mut Self::Target
 pub fn secp256k1::ellswift::ElligatorSwift::clone(&self) -> secp256k1::ellswift::ElligatorSwift
@@ -620,6 +651,7 @@ pub fn secp256k1::scalar::Scalar::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn secp256k1::scalar::Scalar::from_be_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from_le_bytes(value: [u8; 32]) -> core::result::Result<Self, secp256k1::scalar::OutOfRangeError>
 pub fn secp256k1::scalar::Scalar::from(value: secp256k1::SecretKey) -> Self
+pub fn secp256k1::scalar::Scalar::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn secp256k1::scalar::Scalar::index(&self, index: I) -> &Self::Output
 pub fn secp256k1::scalar::Scalar::non_secure_erase(&mut self)
 pub fn secp256k1::scalar::Scalar::partial_cmp(&self, other: &secp256k1::scalar::Scalar) -> core::option::Option<core::cmp::Ordering>
@@ -715,7 +747,9 @@ pub fn secp256k1::XOnlyPublicKey::public_key(&self, parity: secp256k1::Parity) -
 pub fn secp256k1::XOnlyPublicKey::serialize(&self) -> [u8; 32]
 pub fn secp256k1::XOnlyPublicKey::tweak_add_check<V: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<V>, tweaked_key: &Self, tweaked_parity: secp256k1::Parity, tweak: secp256k1::scalar::Scalar) -> bool
 pub fn secp256k1::XOnlyPublicKey::verify<C: secp256k1::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &secp256k1::schnorr::Signature) -> core::result::Result<(), secp256k1::Error>
+pub fn [u8]::eq(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> bool
 pub fn u8::from(parity: secp256k1::Parity) -> u8
+pub fn [u8]::partial_cmp(&self, other: &secp256k1::ecdsa::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
 pub macro secp256k1::impl_array_newtype!
 pub mod secp256k1
 pub mod secp256k1::constants
@@ -770,6 +804,7 @@ pub type secp256k1::ecdsa::serialized_signature::IntoIter::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::IntoIter = secp256k1::ecdsa::serialized_signature::IntoIter
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Item = u8
 pub type secp256k1::ecdsa::serialized_signature::SerializedSignature::Target = [u8]
+pub type secp256k1::ecdsa::Signature::Error = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Err = secp256k1::Error
 pub type secp256k1::ecdsa::Signature::Target = secp256k1_sys::Signature
 pub type secp256k1::ellswift::ElligatorSwift::Err = secp256k1::Error

--- a/contrib/update-lock-files.sh
+++ b/contrib/update-lock-files.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Update the minimal/recent lock file
+
+set -euo pipefail
+
+for file in Cargo-minimal.lock Cargo-recent.lock; do
+    cp --force "$file" Cargo.lock
+    cargo check
+    cp --force Cargo.lock "$file"
+done

--- a/justfile
+++ b/justfile
@@ -32,3 +32,7 @@ sane: lint
 # Check for API changes.
 check-api:
   ./contrib/check-for-api-changes.sh
+
+# Update the lock files.
+update-lock-files:
+  ./contrib/update-lock-files.sh

--- a/justfile
+++ b/justfile
@@ -28,3 +28,7 @@ sane: lint
 
   # Make an attempt to catch feature gate problems in doctests
   cargo test --manifest-path Cargo.toml --doc --no-default-features > /dev/null || exit 1
+
+# Check for API changes.
+check-api:
+  ./contrib/check-for-api-changes.sh

--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+default:
+  @just --list
+
+# Cargo build everything.
+build:
+  cargo build --all-targets --all-features
+
+# Cargo check everything.
+check:
+  cargo check --all-targets --all-features
+
+# Lint everything.
+lint:
+  cargo clippy --all-targets --all-features -- --deny warnings
+
+# Check the formatting
+format:
+  cargo +nightly fmt --check
+
+# Quick and dirty CI useful for pre-push checks.
+sane: lint
+  cargo test --quiet --all-targets --no-default-features > /dev/null || exit 1
+  cargo test --quiet --all-targets > /dev/null || exit 1
+  cargo test --quiet --all-targets --all-features > /dev/null || exit 1
+
+  # doctests don't get run from workspace root with `cargo test`.
+  cargo test --quiet --doc || exit 1
+
+  # Make an attempt to catch feature gate problems in doctests
+  cargo test --manifest-path Cargo.toml --doc --no-default-features > /dev/null || exit 1

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,7 @@ use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
 #[cfg(feature = "alloc")]
-pub use self::alloc_only::*;
+pub use self::alloc_only::{All, SignOnly, VerifyOnly};
 use crate::ffi::types::{c_uint, c_void, AlignedType};
 use crate::ffi::{self, CPtr};
 use crate::{Error, Secp256k1};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub use crate::context::{
 };
 use crate::ffi::types::AlignedType;
 use crate::ffi::CPtr;
-pub use crate::key::{PublicKey, SecretKey, *};
+pub use crate::key::{InvalidParityValue, Keypair, Parity, PublicKey, SecretKey, XOnlyPublicKey};
 pub use crate::scalar::Scalar;
 
 /// Trait describing something that promises to be a 32-byte random number; in particular,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,8 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::{fmt, mem, str};
 
-#[cfg(feature = "global-context")]
-pub use context::global::SECP256K1;
+#[cfg(all(feature = "global-context", feature = "std"))]
+pub use context::global::{self, SECP256K1};
 #[cfg(feature = "hashes")]
 use hashes::Hash;
 #[cfg(feature = "rand")]
@@ -184,7 +184,12 @@ pub use secp256k1_sys as ffi;
 #[cfg(feature = "serde")]
 pub use serde;
 
-pub use crate::context::*;
+#[cfg(feature = "alloc")]
+pub use crate::context::{All, SignOnly, VerifyOnly};
+pub use crate::context::{
+    AllPreallocated, Context, PreallocatedContext, SignOnlyPreallocated, Signing, Verification,
+    VerifyOnlyPreallocated,
+};
 use crate::ffi::types::AlignedType;
 use crate::ffi::CPtr;
 pub use crate::key::{PublicKey, SecretKey, *};


### PR DESCRIPTION
Wildcards make it hard to grep for where stuff comes from, explicit imports and re-exports are ... more explicit.
  
- Patch 1: Re-export the `context` types explicitly.  
- Patch 2: Re-export the `key` types explicitly.

Fix: #681