### PR TITLE
Release tracking PR: `v0.29.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 0.29.0 - 2024-04-02
 
-* Deprecate `ThirtyTwoByteHash`
+* Deprecate `ThirtyTwoByteHash` [#686](https://github.com/rust-bitcoin/rust-secp256k1/pull/686)
 
   This trait turned out to be problematic during upgrade because we support a ranged dependency for
   `bitcoin_hashes`. Consider implementing `From<T> for Message` for your type iff your type is a 32
@@ -9,8 +9,9 @@
   introducing generics in a future version and the compiler will not be able to work out the target
   type.
 
-* Bump MSRV to Rust `v1.56.1`
-* Upgrade `hashes` using range dependency `version = ">= 0.12, <= 0.14"`.
+* Bump MSRV to Rust `v1.56.1` [#693](https://github.com/rust-bitcoin/rust-secp256k1/pull/693)
+* Upgrade `hashes` using range dependency `version = ">= 0.12, <= 0.14"` [#690](https://github.com/rust-bitcoin/rust-secp256k1/pull/690)
+* Depend on latest `secp256k1-sys` (vendors `secp256k1 v0.4.1`) [#688](https://github.com/rust-bitcoin/rust-secp256k1/pull/688)
 
 # 0.28.2 - 2024-01-30
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -257,7 +257,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.29.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -178,7 +178,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.29.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.29.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
In preparation for release add a dummy changelog entry and bump the version. 
