### PR TITLE
Deprecate `ThirtyTwoByteHash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+* Deprecate `ThirtyTwoByteHash`
+
+  This trait turned out to be problematic during upgrade because we support a ranged dependency for
+  `bitcoin_hashes`. Consider implementing `From<T> for Message` for your type iff your type is a 32
+  byte hash (ie, output from a hash algorithm that produces a 32 byte digest like sha256). When
+  using the impl, consider using `Message::from` instead of `hash.into()` because we will be
+  introducing generics in a future version and the compiler will not be able to work out the target
+  type.
+
 * Bump MSRV to Rust `v1.56.1`
 * Upgrade `hashes` using range dependency `version = ">= 0.12, <= 0.14"`.
 

--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -519,8 +519,6 @@ impl secp256k1_sys::CPtr for secp256k1::PublicKey
 impl secp256k1_sys::CPtr for secp256k1::schnorr::Signature
 impl secp256k1_sys::CPtr for secp256k1::SecretKey
 impl secp256k1_sys::CPtr for secp256k1::XOnlyPublicKey
-impl secp256k1::ThirtyTwoByteHash for bitcoin_hashes::sha256d::Hash
-impl secp256k1::ThirtyTwoByteHash for bitcoin_hashes::sha256::Hash
 impl secp256k1::Verification for secp256k1::All
 impl secp256k1::Verification for secp256k1::VerifyOnly
 impl secp256k1::XOnlyPublicKey
@@ -532,7 +530,6 @@ impl serde::ser::Serialize for secp256k1::PublicKey
 impl serde::ser::Serialize for secp256k1::schnorr::Signature
 impl serde::ser::Serialize for secp256k1::SecretKey
 impl serde::ser::Serialize for secp256k1::XOnlyPublicKey
-impl<T: bitcoin_hashes::sha256t::Tag> secp256k1::ThirtyTwoByteHash for bitcoin_hashes::sha256t::Hash<T>
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::Message
 impl<T: secp256k1::ThirtyTwoByteHash> core::convert::From<T> for secp256k1::SecretKey
 #[non_exhaustive] pub struct secp256k1::scalar::OutOfRangeError
@@ -580,9 +577,6 @@ pub enum secp256k1::SignOnly
 pub enum secp256k1::VerifyOnly
 pub extern crate secp256k1::hashes
 pub fn &'a secp256k1::ecdsa::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
-pub fn bitcoin_hashes::sha256d::Hash::into_32(self) -> [u8; 32]
-pub fn bitcoin_hashes::sha256::Hash::into_32(self) -> [u8; 32]
-pub fn bitcoin_hashes::sha256t::Hash<T>::into_32(self) -> [u8; 32]
 pub fn i32::from(parity: secp256k1::Parity) -> i32
 pub fn secp256k1::All::clone(&self) -> secp256k1::All
 pub fn secp256k1::All::cmp(&self, other: &secp256k1::All) -> core::cmp::Ordering
@@ -772,7 +766,6 @@ pub fn secp256k1::Message::eq(&self, other: &secp256k1::Message) -> bool
 pub fn secp256k1::Message::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn secp256k1::Message::from_digest(digest: [u8; 32]) -> secp256k1::Message
 pub fn secp256k1::Message::from_digest_slice(digest: &[u8]) -> core::result::Result<secp256k1::Message, secp256k1::Error>
-pub fn secp256k1::Message::from_hashed_data<H: secp256k1::ThirtyTwoByteHash + bitcoin_hashes::Hash>(data: &[u8]) -> Self
 pub fn secp256k1::Message::from_slice(digest: &[u8]) -> core::result::Result<secp256k1::Message, secp256k1::Error>
 pub fn secp256k1::Message::from(t: T) -> secp256k1::Message
 pub fn secp256k1::Message::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -904,7 +897,6 @@ pub fn secp256k1::SecretKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) 
 pub fn secp256k1::SecretKey::display_secret(&self) -> DisplaySecret
 pub fn secp256k1::SecretKey::eq(&self, other: &Self) -> bool
 pub fn secp256k1::SecretKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn secp256k1::SecretKey::from_hashed_data<H: secp256k1::ThirtyTwoByteHash + bitcoin_hashes::Hash>(data: &[u8]) -> Self
 pub fn secp256k1::SecretKey::from_keypair(keypair: &secp256k1::Keypair) -> Self
 pub fn secp256k1::SecretKey::from(pair: &'a secp256k1::Keypair) -> Self
 pub fn secp256k1::SecretKey::from(pair: secp256k1::Keypair) -> Self

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -8,7 +8,6 @@
 //! serialized signatures and since it's a bit more complicated it has its own module.
 
 use core::borrow::Borrow;
-use core::convert::TryFrom;
 use core::{fmt, ops};
 
 pub use into_iter::IntoIter;

--- a/src/key.rs
+++ b/src/key.rs
@@ -13,13 +13,14 @@ use crate::ellswift::ElligatorSwift;
 use crate::ffi::types::c_uint;
 use crate::ffi::{self, CPtr};
 use crate::Error::{self, InvalidPublicKey, InvalidPublicKeySum, InvalidSecretKey};
+#[cfg(feature = "hashes")]
+#[allow(deprecated)]
+use crate::ThirtyTwoByteHash;
 #[cfg(feature = "global-context")]
 use crate::SECP256K1;
 use crate::{
     constants, ecdsa, from_hex, schnorr, Message, Scalar, Secp256k1, Signing, Verification,
 };
-#[cfg(feature = "hashes")]
-use crate::{hashes, ThirtyTwoByteHash};
 
 /// Secret key - a 256-bit key used to create ECDSA and Taproot signatures.
 ///
@@ -256,30 +257,6 @@ impl SecretKey {
         SecretKey(sk)
     }
 
-    /// Constructs a [`SecretKey`] by hashing `data` with hash algorithm `H`.
-    ///
-    /// Requires the feature `hashes` to be enabled.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[cfg(feature="hashes")] {
-    /// use secp256k1::hashes::{sha256, Hash};
-    /// use secp256k1::SecretKey;
-    ///
-    /// let sk1 = SecretKey::from_hashed_data::<sha256::Hash>("Hello world!".as_bytes());
-    /// // is equivalent to
-    /// let sk2 = SecretKey::from(sha256::Hash::hash("Hello world!".as_bytes()));
-    ///
-    /// assert_eq!(sk1, sk2);
-    /// # }
-    /// ```
-    #[cfg(feature = "hashes")]
-    #[inline]
-    pub fn from_hashed_data<H: ThirtyTwoByteHash + hashes::Hash>(data: &[u8]) -> Self {
-        <H as hashes::Hash>::hash(data).into()
-    }
-
     /// Returns the secret key as a byte value.
     #[inline]
     pub fn secret_bytes(&self) -> [u8; constants::SECRET_KEY_SIZE] { self.0 }
@@ -372,6 +349,7 @@ impl SecretKey {
 }
 
 #[cfg(feature = "hashes")]
+#[allow(deprecated)]
 impl<T: ThirtyTwoByteHash> From<T> for SecretKey {
     /// Converts a 32-byte hash directly to a secret key without error paths.
     fn from(t: T) -> SecretKey {

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,7 +3,6 @@
 //! Public and secret keys.
 //!
 
-use core::convert::TryFrom;
 use core::ops::{self, BitXor};
 use core::{fmt, ptr, str};
 

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -12,9 +12,7 @@ use crate::ffi::{self, CPtr};
 use crate::key::{Keypair, XOnlyPublicKey};
 #[cfg(feature = "global-context")]
 use crate::SECP256K1;
-use crate::{
-    constants, from_hex, impl_array_newtype, Error, Message, Secp256k1, Signing, Verification,
-};
+use crate::{constants, from_hex, Error, Message, Secp256k1, Signing, Verification};
 
 /// Represents a schnorr signature.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
The implementations of `ThirtyTwoByteHash` for types from the `hashes` crate are problematic during upgrades because both `bitcoin` and `secp256k1` depend on `hashes` and when the versions of `hashes` get out of sync usage of the trait breaks.
    
Deprecate the `ThirtyTwoByteHash` trait and remove the impls for types from `bitcoin_hashes`.
    
Add an explanation in the changelog because its too long to go in the deprecation message.


Close: #673