### PR TITLE
Allow dead_code on AlignedType

### DIFF
--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -19,6 +19,7 @@ pub use core::ffi::c_void;
 // 16 matches is as big as the biggest alignment in any arch that rust currently supports https://github.com/rust-lang/rust/blob/2c31b45ae878b821975c4ebd94cc1e49f6073fd0/library/std/src/sys_common/alloc.rs
 #[repr(align(16))]
 #[derive(Default, Copy, Clone)]
+#[allow(dead_code)]             // We never access the inner data directly, only by way of a pointer.
 pub struct AlignedType([u8; 16]);
 
 impl AlignedType {


### PR DESCRIPTION
We use the `AlignedType` and take a pointer to its inner data, never access the data directly - this confuses clippy causing a "field is never used" warning.

Shoosh the lint and add a code comment explaining why.