### PR TITLE
Upgrade hashes dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Bump MSRV to Rust `v1.56.1`
+* Upgrade `hashes` using range dependency `version = ">= 0.12, <= 0.14"`.
 
 # 0.28.2 - 2024-01-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0.103", default-features = false, optional = true }
 
 # You likely only want to enable these if you explicitly do not want to use "std", otherwise enable
 # the respective -std feature e.g., hashes-std
-hashes = { package = "bitcoin_hashes", version = ">= 0.12, <= 0.13", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", version = ">= 0.12, <= 0.14", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Keep the range versioning but increase the threshold to include the latest `v0.14.0` release.
