### PR TITLE
ci: shellcheck checks

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: Shellcheck
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@2.0.0
+      env:
+        SHELLCHECK_OPTS: -x # allow outside sources
+      with:
+        # This code comes directly from upstream libsecp256k1
+        # and should not be linted here.
+        ignore_paths: ./secp256k1-sys/depend/**/*.sh

--- a/contrib/extra_tests.sh
+++ b/contrib/extra_tests.sh
@@ -42,10 +42,6 @@ say() {
     echo "extra_tests: $1"
 }
 
-say_err() {
-    say "$1" >&2
-}
-
 verbose_say() {
     if [ "$flag_verbose" = true ]; then
 	say "$1"

--- a/contrib/sanitizer.sh
+++ b/contrib/sanitizer.sh
@@ -48,10 +48,6 @@ say() {
     echo "extra_tests: $1"
 }
 
-say_err() {
-    say "$1" >&2
-}
-
 verbose_say() {
     if [ "$flag_verbose" = true ]; then
 	say "$1"

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -26,8 +26,8 @@ if [ "$allownonascii" != "true" ] &&
 	# Note that the use of brackets around a tr range is ok here, (it's
 	# even required, for portability to Solaris 10's /usr/bin/tr), since
 	# the square bracket bytes happen to fall in the designated range.
-	test $(git diff --cached --name-only --diff-filter=A -z $against |
-	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+	test "$(git diff --cached --name-only --diff-filter=A -z "$against" |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c)" != 0
 then
 	cat <<\EOF
 Error: Attempt to add a non-ASCII file name.
@@ -44,7 +44,7 @@ EOF
 fi
 
 # If there are whitespace errors, print the offending file names and fail.
-git diff-index --check --cached $against -- || exit 1
+git diff-index --check --cached "$against" -- || exit 1
 
 # Check that code lints cleanly.
 cargo clippy --features=rand,std,recovery,lowmemory,global-context --all-targets -- -D warnings || exit 1


### PR DESCRIPTION
Following https://github.com/rust-bitcoin/rust-bitcoin/pull/2762,
adding CI shellcheck cheks here as well.

I also did all fixes that I could find with

```bash
shellcheck **/*.sh
```

If I've missed any please let me know.