### PR TITLE
Make schnorr sign/verify accept a message slice instead of 32 bytes `Message`

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -958,8 +958,8 @@ impl Keypair {
     /// Constructs an schnorr signature for `msg` using the global [`SECP256K1`] context.
     #[inline]
     #[cfg(all(feature = "global-context", feature = "rand-std"))]
-    pub fn sign_schnorr(&self, msg: Message) -> schnorr::Signature {
-        SECP256K1.sign_schnorr(&msg, self)
+    pub fn sign_schnorr(&self, msg: &[u8]) -> schnorr::Signature {
+        SECP256K1.sign_schnorr(msg, self)
     }
 
     /// Attempts to erase the secret within the underlying array.
@@ -1316,7 +1316,7 @@ impl XOnlyPublicKey {
     pub fn verify<C: Verification>(
         &self,
         secp: &Secp256k1<C>,
-        msg: &Message,
+        msg: &[u8],
         sig: &schnorr::Signature,
     ) -> Result<(), Error> {
         secp.verify_schnorr(sig, msg, self)


### PR DESCRIPTION
As discussed on https://github.com/rust-bitcoin/rust-secp256k1/issues/702 and on IRC, 
BIP340 has evolved from supporting only "pre-hashed" 32 byte messages, to supporting messages of "any length" and as such we should allow the users to pass a message of any length.
Note that passing exactly 32 bytes will make the API behave exactly as before (ie it will produce the same signatures).

I added all the test vectors from: https://github.com/bitcoin/bips/blob/master/bip-0340/test-vectors.csv To make sure the API is correct even for empty messages and shorter/longer ones :)