### PR TITLE
Stop indexing hash types

### DIFF
--- a/src/secret.rs
+++ b/src/secret.rs
@@ -20,8 +20,8 @@ macro_rules! impl_display_secret {
 
                 let mut engine = sha256::Hash::engine();
                 let tag_hash = sha256::Hash::hash(tag.as_bytes());
-                engine.input(&tag_hash[..]);
-                engine.input(&tag_hash[..]);
+                engine.input(&tag_hash.as_ref());
+                engine.input(&tag_hash.as_ref());
                 engine.input(&self.secret_bytes());
                 let hash = sha256::Hash::from_engine(engine);
 


### PR DESCRIPTION
In preparation for removing `SliceIndex` from hash type impls (in `bitcoin_hashes`) lets stop indexing hash types here.

Internal change only.