### PR TITLE
Backport of #735 to secp256k1-sys 0.10

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "cc",
  "libc",

--- a/secp256k1-sys/CHANGELOG.md
+++ b/secp256k1-sys/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.1 - 2024-09-10
+
+* Minor build changes to eliminate references to stdio.h [#736](https://github.com/rust-bitcoin/rust-secp256k1/pull/736)
+
 # 0.10.0 - 2024-03-28
 
 * Bump MSRV to Rust `v1.56.1` [#693](https://github.com/rust-bitcoin/rust-secp256k1/pull/693)

--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-sys"
-version = "0.10.0"
+version = "0.10.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>" ]

--- a/secp256k1-sys/depend/secp256k1/src/util.h
+++ b/secp256k1-sys/depend/secp256k1/src/util.h
@@ -11,33 +11,12 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <limits.h>
 
 #define STR_(x) #x
 #define STR(x) STR_(x)
 #define DEBUG_CONFIG_MSG(x) "DEBUG_CONFIG: " x
 #define DEBUG_CONFIG_DEF(x) DEBUG_CONFIG_MSG(#x "=" STR(x))
-
-/* Debug helper for printing arrays of unsigned char. */
-#define PRINT_BUF(buf, len) do { \
-    printf("%s[%lu] = ", #buf, (unsigned long)len); \
-    print_buf_plain(buf, len); \
-} while(0)
-
-static void print_buf_plain(const unsigned char *buf, size_t len) {
-    size_t i;
-    printf("{");
-    for (i = 0; i < len; i++) {
-        if (i % 8 == 0) {
-            printf("\n    ");
-        } else {
-            printf(" ");
-        }
-        printf("0x%02X,", buf[i]);
-    }
-    printf("\n}\n");
-}
 
 # if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L) )
 #  if SECP256K1_GNUC_PREREQ(2,7)

--- a/secp256k1-sys/depend/util.h.patch
+++ b/secp256k1-sys/depend/util.h.patch
@@ -1,4 +1,27 @@
-148,152c148,150
+14d13
+< #include <stdio.h>
+22,41d20
+< /* Debug helper for printing arrays of unsigned char. */
+< #define PRINT_BUF(buf, len) do { \
+<     printf("%s[%lu] = ", #buf, (unsigned long)len); \
+<     print_buf_plain(buf, len); \
+< } while(0)
+< 
+< static void print_buf_plain(const unsigned char *buf, size_t len) {
+<     size_t i;
+<     printf("{");
+<     for (i = 0; i < len; i++) {
+<         if (i % 8 == 0) {
+<             printf("\n    ");
+<         } else {
+<             printf(" ");
+<         }
+<         printf("0x%02X,", buf[i]);
+<     }
+<     printf("\n}\n");
+< }
+< 
+148,152c127,129
 <     void *ret = malloc(size);
 <     if (ret == NULL) {
 <         secp256k1_callback_call(cb, "Out of memory");


### PR DESCRIPTION
This backports #735. I am PR'ing to the secp256k1-0.29.x branch because this will work and because it feels like unnecessary complication to try to create a secp256k1-sys-0.10.x branch, which might be "more correct" but would make our git tree harder to understand and maintain.

As in #735, this just deletes some dead code from secp256k1-sys/depend/secp256k1.