### PR TITLE
release secp256k1 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.30.0 - 2024-10-08
+
+* Allow signing variable-length messages [#706](https://github.com/rust-bitcoin/rust-secp256k1/pull/706)
+* Bump MSRV to 1.63 [#709](https://github.com/rust-bitcoin/rust-secp256k1/pull/709)
+* Deprecate `Message::from_digest_slice` in favor of `Message::from_digest` [#712](https://github.com/rust-bitcoin/rust-secp256k1/pull/712)
+* Truncate debug output of `SecretKey`; tighten `bitcoin_hashes` dependency version [#722](https://github.com/rust-bitcoin/rust-secp256k1/pull/722)
+* Simplify and improve consistency of secret key types' debug output [#726](https://github.com/rust-bitcoin/rust-secp256k1/pull/726)
+* Simplify and improve consistency of public key types' debug output [#745](https://github.com/rust-bitcoin/rust-secp256k1/pull/745)
+* Feature-gate `KeyPair::from_str` on `global-context` or `alloc` [#728](https://github.com/rust-bitcoin/rust-secp256k1/pull/728)
+* Add infallible constructors for `schnorr::Signature` from byteslices [#730](https://github.com/rust-bitcoin/rust-secp256k1/pull/730)
+* Deprecate slice-parsing methods in favor of array-parsing ones [#737](https://github.com/rust-bitcoin/rust-secp256k1/pull/737)
+* Make `RecoveryId` an enum rather than integer [#743](https://github.com/rust-bitcoin/rust-secp256k1/pull/743)
+
 # 0.29.0 - 2024-04-02
 
 * Deprecate `ThirtyTwoByteHash` [#686](https://github.com/rust-bitcoin/rust-secp256k1/pull/686)

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -272,7 +272,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -193,7 +193,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.29.0"
+version = "0.30.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
We could release a new secp256k1-sys at the same time, but we have made no changes there except to delete a bit of unused code in #735, and bump MSRV, so it does not seem worth the extra disruption.