### PR TITLE
Reorder verify_ecdsa args to match those of verify_schnorr

### DIFF
--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -15,7 +15,7 @@ fn verify<C: Verification>(
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
-    Ok(secp.verify_ecdsa(msg, &sig, &pubkey).is_ok())
+    Ok(secp.verify_ecdsa(&sig, msg, &pubkey).is_ok())
 }
 
 fn sign<C: Signing>(

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -91,10 +91,10 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
     let sig = secp.sign_ecdsa(message, &secret_key);
-    assert!(secp.verify_ecdsa(message, &sig, &public_key).is_ok());
+    assert!(secp.verify_ecdsa(&sig, message, &public_key).is_ok());
 
     let rec_sig = secp.sign_ecdsa_recoverable(message, &secret_key);
-    assert!(secp.verify_ecdsa(message, &rec_sig.to_standard(), &public_key).is_ok());
+    assert!(secp.verify_ecdsa(&rec_sig.to_standard(), message, &public_key).is_ok());
     assert_eq!(public_key, secp.recover_ecdsa(message, &rec_sig).unwrap());
     let (rec_id, data) = rec_sig.serialize_compact();
     let new_rec_sig = ecdsa::RecoverableSignature::from_compact(&data, rec_id).unwrap();
@@ -118,7 +118,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
         let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
         let sig = secp_alloc.sign_ecdsa(message, &secret_key);
-        assert!(secp_alloc.verify_ecdsa(message, &sig, &public_key).is_ok());
+        assert!(secp_alloc.verify_ecdsa(&sig, message, &public_key).is_ok());
         unsafe { libc::printf("Verified alloc Successfully!\n\0".as_ptr() as _) };
     }
 

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -195,7 +195,7 @@ impl Signature {
     #[inline]
     #[cfg(feature = "global-context")]
     pub fn verify(&self, msg: impl Into<Message>, pk: &PublicKey) -> Result<(), Error> {
-        SECP256K1.verify_ecdsa(msg, self, pk)
+        SECP256K1.verify_ecdsa(self, msg, pk)
     }
 }
 
@@ -375,17 +375,17 @@ impl<C: Verification> Secp256k1<C> {
     /// #
     /// let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
     /// let sig = secp.sign_ecdsa(message, &secret_key);
-    /// assert_eq!(secp.verify_ecdsa(message, &sig, &public_key), Ok(()));
+    /// assert_eq!(secp.verify_ecdsa(&sig, message, &public_key), Ok(()));
     ///
     /// let message = Message::from_digest_slice(&[0xcd; 32]).expect("32 bytes");
-    /// assert_eq!(secp.verify_ecdsa(message, &sig, &public_key), Err(Error::IncorrectSignature));
+    /// assert_eq!(secp.verify_ecdsa(&sig, message, &public_key), Err(Error::IncorrectSignature));
     /// # }
     /// ```
     #[inline]
     pub fn verify_ecdsa(
         &self,
-        msg: impl Into<Message>,
         sig: &Signature,
+        msg: impl Into<Message>,
         pk: &PublicKey,
     ) -> Result<(), Error> {
         let msg = msg.into();

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -351,7 +351,7 @@ mod tests {
 
         let msg = crate::random_32_bytes(&mut rand::rng());
         let msg = Message::from_digest_slice(&msg).unwrap();
-        assert_eq!(s.verify_ecdsa(msg, &sig, &pk), Err(Error::IncorrectSignature));
+        assert_eq!(s.verify_ecdsa(&sig, msg, &pk), Err(Error::IncorrectSignature));
 
         let recovered_key = s.recover_ecdsa(msg, &sigr).unwrap();
         assert!(recovered_key != pk);

--- a/src/key.rs
+++ b/src/key.rs
@@ -743,7 +743,7 @@ impl PublicKey {
         msg: impl Into<Message>,
         sig: &ecdsa::Signature,
     ) -> Result<(), Error> {
-        secp.verify_ecdsa(msg, sig, self)
+        secp.verify_ecdsa(sig, msg, self)
     }
 }
 


### PR DESCRIPTION
The issue  (#617) seemed to have good support with 4 thumbs up, so this PR will reorder `verify_ecdsa` args to match those of `verify_schnorr`, which just swaps the place of `msg` and `sig`. This will break the API, but will potentially cause less confusion in the future

Closes #617 
