### PR TITLE
Create `Party` enum and deprecate `ElligatorSwiftParty` in favor of it

### DIFF
--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -307,6 +307,33 @@ impl ElligatorSwiftParty {
     }
 }
 
+/// Represents the two parties in ECDH
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Party {
+    /// The party that starts the key exchange or communication process
+    Initiator,
+    /// The party that responds to the initiator's communications
+    Responder,
+}
+
+impl From<ElligatorSwiftParty> for Party {
+    fn from(value: ElligatorSwiftParty) -> Self {
+        match value {
+            ElligatorSwiftParty::A => Party::Initiator,
+            ElligatorSwiftParty::B => Party::Responder,
+        }
+    }
+}
+
+impl Party {
+    fn to_ffi_int(self) -> c_int {
+        match self {
+            Party::Initiator => 0,
+            Party::Responder => 1,
+        }
+    }
+}
+
 impl FromStr for ElligatorSwift {
     fn from_str(hex: &str) -> Result<Self, Self::Err> {
         let mut ser = [0u8; 64];


### PR DESCRIPTION
The initial naming of ElligatorSwiftParty wasn't very descriptive, so it will be deprecated in favor of a more descriptive `Party` enum. I updated `shared_secret` and `shared_secret_with_hasher` to accept the new `Party` enum as well - I'm not sure if there's a better way to do it, but changing it to an `impl Into<Party>` should preserve backwards compatibility

Fixes #741 