### PR TITLE
Use `Into<Message>` in signing api

### DIFF
--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -15,7 +15,7 @@ fn verify<C: Verification>(
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
-    Ok(secp.verify_ecdsa(&msg, &sig, &pubkey).is_ok())
+    Ok(secp.verify_ecdsa(msg, &sig, &pubkey).is_ok())
 }
 
 fn sign<C: Signing>(
@@ -26,7 +26,7 @@ fn sign<C: Signing>(
     let msg = sha256::Hash::hash(msg);
     let msg = Message::from_digest_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
-    Ok(secp.sign_ecdsa(&msg, &seckey))
+    Ok(secp.sign_ecdsa(msg, &seckey))
 }
 
 fn main() {

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -15,7 +15,7 @@ fn recover<C: Verification>(
     let id = ecdsa::RecoveryId::try_from(i32::from(recovery_id))?;
     let sig = ecdsa::RecoverableSignature::from_compact(&sig, id)?;
 
-    secp.recover_ecdsa(&msg, &sig)
+    secp.recover_ecdsa(msg, &sig)
 }
 
 fn sign_recovery<C: Signing>(
@@ -26,7 +26,7 @@ fn sign_recovery<C: Signing>(
     let msg = sha256::Hash::hash(msg);
     let msg = Message::from_digest_slice(msg.as_ref())?;
     let seckey = SecretKey::from_slice(&seckey)?;
-    Ok(secp.sign_ecdsa_recoverable(&msg, &seckey))
+    Ok(secp.sign_ecdsa_recoverable(msg, &seckey))
 }
 
 fn main() {

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -94,12 +94,12 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
     let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
-    let sig = secp.sign_ecdsa(&message, &secret_key);
-    assert!(secp.verify_ecdsa(&message, &sig, &public_key).is_ok());
+    let sig = secp.sign_ecdsa(message, &secret_key);
+    assert!(secp.verify_ecdsa(message, &sig, &public_key).is_ok());
 
-    let rec_sig = secp.sign_ecdsa_recoverable(&message, &secret_key);
-    assert!(secp.verify_ecdsa(&message, &rec_sig.to_standard(), &public_key).is_ok());
-    assert_eq!(public_key, secp.recover_ecdsa(&message, &rec_sig).unwrap());
+    let rec_sig = secp.sign_ecdsa_recoverable(message, &secret_key);
+    assert!(secp.verify_ecdsa(message, &rec_sig.to_standard(), &public_key).is_ok());
+    assert_eq!(public_key, secp.recover_ecdsa(message, &rec_sig).unwrap());
     let (rec_id, data) = rec_sig.serialize_compact();
     let new_rec_sig = ecdsa::RecoverableSignature::from_compact(&data, rec_id).unwrap();
     assert_eq!(rec_sig, new_rec_sig);
@@ -121,8 +121,8 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
         let public_key = PublicKey::from_secret_key(&secp_alloc, &secret_key);
         let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
-        let sig = secp_alloc.sign_ecdsa(&message, &secret_key);
-        assert!(secp_alloc.verify_ecdsa(&message, &sig, &public_key).is_ok());
+        let sig = secp_alloc.sign_ecdsa(message, &secret_key);
+        assert!(secp_alloc.verify_ecdsa(message, &sig, &public_key).is_ok());
         unsafe { libc::printf("Verified alloc Successfully!\n\0".as_ptr() as _) };
     }
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -133,7 +133,7 @@ impl RecoverableSignature {
     /// verify-capable context.
     #[inline]
     #[cfg(feature = "global-context")]
-    pub fn recover(&self, msg: &Message) -> Result<key::PublicKey, Error> {
+    pub fn recover(&self, msg: impl Into<Message>) -> Result<key::PublicKey, Error> {
         crate::SECP256K1.recover_ecdsa(msg, self)
     }
 }
@@ -154,10 +154,11 @@ impl From<ffi::RecoverableSignature> for RecoverableSignature {
 impl<C: Signing> Secp256k1<C> {
     fn sign_ecdsa_recoverable_with_noncedata_pointer(
         &self,
-        msg: &Message,
+        msg: impl Into<Message>,
         sk: &key::SecretKey,
         noncedata_ptr: *const super_ffi::types::c_void,
     ) -> RecoverableSignature {
+        let msg = msg.into();
         let mut ret = ffi::RecoverableSignature::new();
         unsafe {
             // We can assume the return value because it's not possible to construct
@@ -182,7 +183,7 @@ impl<C: Signing> Secp256k1<C> {
     /// Requires a signing-capable context.
     pub fn sign_ecdsa_recoverable(
         &self,
-        msg: &Message,
+        msg: impl Into<Message>,
         sk: &key::SecretKey,
     ) -> RecoverableSignature {
         self.sign_ecdsa_recoverable_with_noncedata_pointer(msg, sk, ptr::null())
@@ -195,7 +196,7 @@ impl<C: Signing> Secp256k1<C> {
     /// Requires a signing-capable context.
     pub fn sign_ecdsa_recoverable_with_noncedata(
         &self,
-        msg: &Message,
+        msg: impl Into<Message>,
         sk: &key::SecretKey,
         noncedata: &[u8; 32],
     ) -> RecoverableSignature {
@@ -209,9 +210,10 @@ impl<C: Verification> Secp256k1<C> {
     /// `msg`. Requires a verify-capable context.
     pub fn recover_ecdsa(
         &self,
-        msg: &Message,
+        msg: impl Into<Message>,
         sig: &RecoverableSignature,
     ) -> Result<key::PublicKey, Error> {
+        let msg = msg.into();
         unsafe {
             let mut pk = super_ffi::PublicKey::new();
             if ffi::secp256k1_ecdsa_recover(
@@ -252,15 +254,15 @@ mod tests {
         let (sk, pk) = full.generate_keypair(&mut rand::thread_rng());
 
         // Try signing
-        assert_eq!(sign.sign_ecdsa_recoverable(&msg, &sk), full.sign_ecdsa_recoverable(&msg, &sk));
-        let sigr = full.sign_ecdsa_recoverable(&msg, &sk);
+        assert_eq!(sign.sign_ecdsa_recoverable(msg, &sk), full.sign_ecdsa_recoverable(msg, &sk));
+        let sigr = full.sign_ecdsa_recoverable(msg, &sk);
 
         // Try pk recovery
-        assert!(vrfy.recover_ecdsa(&msg, &sigr).is_ok());
-        assert!(full.recover_ecdsa(&msg, &sigr).is_ok());
+        assert!(vrfy.recover_ecdsa(msg, &sigr).is_ok());
+        assert!(full.recover_ecdsa(msg, &sigr).is_ok());
 
-        assert_eq!(vrfy.recover_ecdsa(&msg, &sigr), full.recover_ecdsa(&msg, &sigr));
-        assert_eq!(full.recover_ecdsa(&msg, &sigr), Ok(pk));
+        assert_eq!(vrfy.recover_ecdsa(msg, &sigr), full.recover_ecdsa(msg, &sigr));
+        assert_eq!(full.recover_ecdsa(msg, &sigr), Ok(pk));
     }
 
     #[test]
@@ -280,7 +282,7 @@ mod tests {
         let sk = SecretKey::from_slice(&ONE).unwrap();
         let msg = Message::from_digest_slice(&ONE).unwrap();
 
-        let sig = s.sign_ecdsa_recoverable(&msg, &sk);
+        let sig = s.sign_ecdsa_recoverable(msg, &sk);
 
         assert_eq!(Ok(sig), RecoverableSignature::from_compact(&[
             0x66, 0x73, 0xff, 0xad, 0x21, 0x47, 0x74, 0x1f,
@@ -306,7 +308,7 @@ mod tests {
         let msg = Message::from_digest_slice(&ONE).unwrap();
         let noncedata = [42u8; 32];
 
-        let sig = s.sign_ecdsa_recoverable_with_noncedata(&msg, &sk, &noncedata);
+        let sig = s.sign_ecdsa_recoverable_with_noncedata(msg, &sk, &noncedata);
 
         assert_eq!(Ok(sig), RecoverableSignature::from_compact(&[
             0xb5, 0x0b, 0xb6, 0x79, 0x5f, 0x31, 0x74, 0x8a,
@@ -331,14 +333,14 @@ mod tests {
 
         let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
 
-        let sigr = s.sign_ecdsa_recoverable(&msg, &sk);
+        let sigr = s.sign_ecdsa_recoverable(msg, &sk);
         let sig = sigr.to_standard();
 
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
         let msg = Message::from_digest_slice(&msg).unwrap();
-        assert_eq!(s.verify_ecdsa(&msg, &sig, &pk), Err(Error::IncorrectSignature));
+        assert_eq!(s.verify_ecdsa(msg, &sig, &pk), Err(Error::IncorrectSignature));
 
-        let recovered_key = s.recover_ecdsa(&msg, &sigr).unwrap();
+        let recovered_key = s.recover_ecdsa(msg, &sigr).unwrap();
         assert!(recovered_key != pk);
     }
 
@@ -353,9 +355,9 @@ mod tests {
 
         let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
 
-        let sig = s.sign_ecdsa_recoverable(&msg, &sk);
+        let sig = s.sign_ecdsa_recoverable(msg, &sk);
 
-        assert_eq!(s.recover_ecdsa(&msg, &sig), Ok(pk));
+        assert_eq!(s.recover_ecdsa(msg, &sig), Ok(pk));
     }
 
     #[test]
@@ -371,9 +373,9 @@ mod tests {
 
         let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
 
-        let sig = s.sign_ecdsa_recoverable_with_noncedata(&msg, &sk, &noncedata);
+        let sig = s.sign_ecdsa_recoverable_with_noncedata(msg, &sk, &noncedata);
 
-        assert_eq!(s.recover_ecdsa(&msg, &sig), Ok(pk));
+        assert_eq!(s.recover_ecdsa(msg, &sig), Ok(pk));
     }
 
     #[test]
@@ -386,10 +388,10 @@ mod tests {
 
         // Zero is not a valid sig
         let sig = RecoverableSignature::from_compact(&[0; 64], RecoveryId::Zero).unwrap();
-        assert_eq!(s.recover_ecdsa(&msg, &sig), Err(Error::InvalidSignature));
+        assert_eq!(s.recover_ecdsa(msg, &sig), Err(Error::InvalidSignature));
         // ...but 111..111 is
         let sig = RecoverableSignature::from_compact(&[1; 64], RecoveryId::Zero).unwrap();
-        assert!(s.recover_ecdsa(&msg, &sig).is_ok());
+        assert!(s.recover_ecdsa(msg, &sig).is_ok());
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -338,7 +338,9 @@ impl SecretKey {
     /// Constructs an ECDSA signature for `msg` using the global [`SECP256K1`] context.
     #[inline]
     #[cfg(feature = "global-context")]
-    pub fn sign_ecdsa(&self, msg: Message) -> ecdsa::Signature { SECP256K1.sign_ecdsa(&msg, self) }
+    pub fn sign_ecdsa(&self, msg: impl Into<Message>) -> ecdsa::Signature {
+        SECP256K1.sign_ecdsa(msg, self)
+    }
 
     /// Returns the [`Keypair`] for this [`SecretKey`].
     ///
@@ -737,7 +739,7 @@ impl PublicKey {
     pub fn verify<C: Verification>(
         &self,
         secp: &Secp256k1<C>,
-        msg: &Message,
+        msg: impl Into<Message>,
         sig: &ecdsa::Signature,
     ) -> Result<(), Error> {
         secp.verify_ecdsa(msg, sig, self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@
 //! let digest = sha256::Hash::hash("Hello World!".as_bytes());
 //! let message = Message::from_digest(digest.to_byte_array());
 //!
-//! let sig = secp.sign_ecdsa(&message, &secret_key);
-//! assert!(secp.verify_ecdsa(&message, &sig, &public_key).is_ok());
+//! let sig = secp.sign_ecdsa(message, &secret_key);
+//! assert!(secp.verify_ecdsa(message, &sig, &public_key).is_ok());
 //! # }
 //! ```
 //!
@@ -55,7 +55,7 @@
 //! let message = Message::from_digest(digest.to_byte_array());
 //!
 //! let sig = secret_key.sign_ecdsa(message);
-//! assert!(sig.verify(&message, &public_key).is_ok());
+//! assert!(sig.verify(message, &public_key).is_ok());
 //! # }
 //! ```
 //!
@@ -75,8 +75,8 @@
 //! // be cryptographically broken. It has been trivially used in the past to execute attacks.
 //! let message = Message::from_digest(compute_hash(b"CSW is not Satoshi"));
 //!
-//! let sig = secp.sign_ecdsa(&message, &secret_key);
-//! assert!(secp.verify_ecdsa(&message, &sig, &public_key).is_ok());
+//! let sig = secp.sign_ecdsa(message, &secret_key);
+//! assert!(secp.verify_ecdsa(message, &sig, &public_key).is_ok());
 //! # }
 //! ```
 //!
@@ -115,7 +115,7 @@
 //! ]).expect("compact signatures are 64 bytes; DER signatures are 68-72 bytes");
 //!
 //! # #[cfg(not(secp256k1_fuzz))]
-//! assert!(secp.verify_ecdsa(&message, &sig, &public_key).is_ok());
+//! assert!(secp.verify_ecdsa(message, &sig, &public_key).is_ok());
 //! # }
 //! ```
 //!
@@ -543,12 +543,12 @@ mod tests {
         let (sk, pk) = full.generate_keypair(&mut rand::thread_rng());
         let msg = Message::from_digest([2u8; 32]);
         // Try signing
-        assert_eq!(sign.sign_ecdsa(&msg, &sk), full.sign_ecdsa(&msg, &sk));
-        let sig = full.sign_ecdsa(&msg, &sk);
+        assert_eq!(sign.sign_ecdsa(msg, &sk), full.sign_ecdsa(msg, &sk));
+        let sig = full.sign_ecdsa(msg, &sk);
 
         // Try verifying
-        assert!(vrfy.verify_ecdsa(&msg, &sig, &pk).is_ok());
-        assert!(full.verify_ecdsa(&msg, &sig, &pk).is_ok());
+        assert!(vrfy.verify_ecdsa(msg, &sig, &pk).is_ok());
+        assert!(full.verify_ecdsa(msg, &sig, &pk).is_ok());
 
         // The following drop will have no effect; in fact, they will trigger a compiler
         // error because manually dropping a `ManuallyDrop` is almost certainly incorrect.
@@ -610,12 +610,12 @@ mod tests {
         let (sk, pk) = full.generate_keypair(&mut rand::thread_rng());
         let msg = Message::from_digest([2u8; 32]);
         // Try signing
-        assert_eq!(sign.sign_ecdsa(&msg, &sk), full.sign_ecdsa(&msg, &sk));
-        let sig = full.sign_ecdsa(&msg, &sk);
+        assert_eq!(sign.sign_ecdsa(msg, &sk), full.sign_ecdsa(msg, &sk));
+        let sig = full.sign_ecdsa(msg, &sk);
 
         // Try verifying
-        assert!(vrfy.verify_ecdsa(&msg, &sig, &pk).is_ok());
-        assert!(full.verify_ecdsa(&msg, &sig, &pk).is_ok());
+        assert!(vrfy.verify_ecdsa(msg, &sig, &pk).is_ok());
+        assert!(full.verify_ecdsa(msg, &sig, &pk).is_ok());
     }
 
     #[test]
@@ -632,12 +632,12 @@ mod tests {
         let (sk, pk) = full.generate_keypair(&mut rand::thread_rng());
 
         // Try signing
-        assert_eq!(sign.sign_ecdsa(&msg, &sk), full.sign_ecdsa(&msg, &sk));
-        let sig = full.sign_ecdsa(&msg, &sk);
+        assert_eq!(sign.sign_ecdsa(msg, &sk), full.sign_ecdsa(msg, &sk));
+        let sig = full.sign_ecdsa(msg, &sk);
 
         // Try verifying
-        assert!(vrfy.verify_ecdsa(&msg, &sig, &pk).is_ok());
-        assert!(full.verify_ecdsa(&msg, &sig, &pk).is_ok());
+        assert!(vrfy.verify_ecdsa(msg, &sig, &pk).is_ok());
+        assert!(full.verify_ecdsa(msg, &sig, &pk).is_ok());
 
         // Check that we can produce keys from slices with no precomputation
         let (pk_slice, sk_slice) = (&pk.serialize(), &sk[..]);
@@ -658,7 +658,7 @@ mod tests {
             let msg = Message::from_digest(msg);
 
             let (sk, _) = s.generate_keypair(&mut rand::thread_rng());
-            let sig1 = s.sign_ecdsa(&msg, &sk);
+            let sig1 = s.sign_ecdsa(msg, &sk);
             let der = sig1.serialize_der();
             let sig2 = ecdsa::Signature::from_der(&der[..]).unwrap();
             assert_eq!(sig1, sig2);
@@ -749,14 +749,14 @@ mod tests {
             let msg = Message::from_digest(msg);
 
             let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
-            let sig = s.sign_ecdsa(&msg, &sk);
-            assert_eq!(s.verify_ecdsa(&msg, &sig, &pk), Ok(()));
-            let noncedata_sig = s.sign_ecdsa_with_noncedata(&msg, &sk, &noncedata);
-            assert_eq!(s.verify_ecdsa(&msg, &noncedata_sig, &pk), Ok(()));
-            let low_r_sig = s.sign_ecdsa_low_r(&msg, &sk);
-            assert_eq!(s.verify_ecdsa(&msg, &low_r_sig, &pk), Ok(()));
-            let grind_r_sig = s.sign_ecdsa_grind_r(&msg, &sk, 1);
-            assert_eq!(s.verify_ecdsa(&msg, &grind_r_sig, &pk), Ok(()));
+            let sig = s.sign_ecdsa(msg, &sk);
+            assert_eq!(s.verify_ecdsa(msg, &sig, &pk), Ok(()));
+            let noncedata_sig = s.sign_ecdsa_with_noncedata(msg, &sk, &noncedata);
+            assert_eq!(s.verify_ecdsa(msg, &noncedata_sig, &pk), Ok(()));
+            let low_r_sig = s.sign_ecdsa_low_r(msg, &sk);
+            assert_eq!(s.verify_ecdsa(msg, &low_r_sig, &pk), Ok(()));
+            let grind_r_sig = s.sign_ecdsa_grind_r(msg, &sk, 1);
+            assert_eq!(s.verify_ecdsa(msg, &grind_r_sig, &pk), Ok(()));
             let compact = sig.serialize_compact();
             if compact[0] < 0x80 {
                 assert_eq!(sig, low_r_sig);
@@ -794,13 +794,13 @@ mod tests {
 
         for key in wild_keys.iter().map(|k| SecretKey::from_slice(&k[..]).unwrap()) {
             for msg in wild_msgs.into_iter().map(Message::from_digest) {
-                let sig = s.sign_ecdsa(&msg, &key);
-                let low_r_sig = s.sign_ecdsa_low_r(&msg, &key);
-                let grind_r_sig = s.sign_ecdsa_grind_r(&msg, &key, 1);
+                let sig = s.sign_ecdsa(msg, &key);
+                let low_r_sig = s.sign_ecdsa_low_r(msg, &key);
+                let grind_r_sig = s.sign_ecdsa_grind_r(msg, &key, 1);
                 let pk = PublicKey::from_secret_key(&s, &key);
-                assert_eq!(s.verify_ecdsa(&msg, &sig, &pk), Ok(()));
-                assert_eq!(s.verify_ecdsa(&msg, &low_r_sig, &pk), Ok(()));
-                assert_eq!(s.verify_ecdsa(&msg, &grind_r_sig, &pk), Ok(()));
+                assert_eq!(s.verify_ecdsa(msg, &sig, &pk), Ok(()));
+                assert_eq!(s.verify_ecdsa(msg, &low_r_sig, &pk), Ok(()));
+                assert_eq!(s.verify_ecdsa(msg, &grind_r_sig, &pk), Ok(()));
             }
         }
     }
@@ -816,11 +816,11 @@ mod tests {
 
         let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
 
-        let sig = s.sign_ecdsa(&msg, &sk);
+        let sig = s.sign_ecdsa(msg, &sk);
 
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
         let msg = Message::from_digest(msg);
-        assert_eq!(s.verify_ecdsa(&msg, &sig, &pk), Err(Error::IncorrectSignature));
+        assert_eq!(s.verify_ecdsa(msg, &sig, &pk), Err(Error::IncorrectSignature));
     }
 
     #[test]
@@ -891,7 +891,7 @@ mod tests {
         let expected_sig = hex!("24861b3edd4e7da43319c635091405feced6efa4ec99c3c3c35f6c3ba0ed8816116772e84994084db85a6c20589f6a85af569d42275c2a5dd900da5776b99d5d");
         let expected_sig = ecdsa::Signature::from_compact(&expected_sig).unwrap();
 
-        let sig = secp.sign_ecdsa_with_noncedata(&msg, &sk, &noncedata);
+        let sig = secp.sign_ecdsa_with_noncedata(msg, &sk, &noncedata);
 
         assert_eq!(expected_sig, sig);
     }
@@ -913,10 +913,10 @@ mod tests {
         let msg = Message::from_digest(msg);
 
         // without normalization we expect this will fail
-        assert_eq!(secp.verify_ecdsa(&msg, &sig, &pk), Err(Error::IncorrectSignature));
+        assert_eq!(secp.verify_ecdsa(msg, &sig, &pk), Err(Error::IncorrectSignature));
         // after normalization it should pass
         sig.normalize_s();
-        assert_eq!(secp.verify_ecdsa(&msg, &sig, &pk), Ok(()));
+        assert_eq!(secp.verify_ecdsa(msg, &sig, &pk), Ok(()));
     }
 
     #[test]
@@ -932,7 +932,7 @@ mod tests {
         let expected_sig = hex!("047dd4d049db02b430d24c41c7925b2725bcd5a85393513bdec04b4dc363632b1054d0180094122b380f4cfa391e6296244da773173e78fc745c1b9c79f7b713");
         let expected_sig = ecdsa::Signature::from_compact(&expected_sig).unwrap();
 
-        let sig = secp.sign_ecdsa_low_r(&msg, &sk);
+        let sig = secp.sign_ecdsa_low_r(msg, &sk);
 
         assert_eq!(expected_sig, sig);
     }
@@ -949,7 +949,7 @@ mod tests {
                 .unwrap();
         let expected_sig = ecdsa::Signature::from_str("304302202ffc447100d518c8ba643d11f3e6a83a8640488e7d2537b1954b942408be6ea3021f26e1248dd1e52160c3a38af9769d91a1a806cab5f9d508c103464d3c02d6e1").unwrap();
 
-        let sig = secp.sign_ecdsa_grind_r(&msg, &sk, 2);
+        let sig = secp.sign_ecdsa_grind_r(msg, &sk, 2);
 
         assert_eq!(expected_sig, sig);
     }
@@ -965,7 +965,7 @@ mod tests {
 
         let msg = Message::from_digest([1; 32]);
         let sk = SecretKey::from_slice(&[2; 32]).unwrap();
-        let sig = s.sign_ecdsa(&msg, &sk);
+        let sig = s.sign_ecdsa(msg, &sk);
         static SIG_BYTES: [u8; 71] = [
             48, 69, 2, 33, 0, 157, 11, 173, 87, 103, 25, 211, 42, 231, 107, 237, 179, 76, 119, 72,
             102, 103, 60, 189, 227, 244, 225, 41, 81, 85, 92, 148, 8, 230, 206, 119, 75, 2, 32, 40,
@@ -999,8 +999,8 @@ mod tests {
         let pk = PublicKey::from_secret_key(SECP256K1, &sk);
 
         // Check usage as self
-        let sig = SECP256K1.sign_ecdsa(&msg, &sk);
-        assert!(SECP256K1.verify_ecdsa(&msg, &sig, &pk).is_ok());
+        let sig = SECP256K1.sign_ecdsa(msg, &sk);
+        assert!(SECP256K1.verify_ecdsa(msg, &sig, &pk).is_ok());
     }
 }
 
@@ -1031,7 +1031,7 @@ mod benches {
         let (sk, _) = s.generate_keypair(&mut rand::thread_rng());
 
         bh.iter(|| {
-            let sig = s.sign_ecdsa(&msg, &sk);
+            let sig = s.sign_ecdsa(msg, &sk);
             black_box(sig);
         });
     }
@@ -1042,10 +1042,10 @@ mod benches {
         let msg = crate::random_32_bytes(&mut rand::thread_rng());
         let msg = Message::from_digest(msg);
         let (sk, pk) = s.generate_keypair(&mut rand::thread_rng());
-        let sig = s.sign_ecdsa(&msg, &sk);
+        let sig = s.sign_ecdsa(msg, &sk);
 
         bh.iter(|| {
-            let res = s.verify_ecdsa(&msg, &sig, &pk).unwrap();
+            let res = s.verify_ecdsa(msg, &sig, &pk).unwrap();
             black_box(res);
         });
     }


### PR DESCRIPTION
Closes #700 (also see https://github.com/rust-bitcoin/rust-bitcoin/issues/2821).

Unrelated question while I have the authors attention: the schnorr apis (e.g. https://github.com/liamaharon/rust-secp256k1/blob/9afbf5111113ce84ff6f3b52f37c60554af2c283/secp256k1-sys/src/lib.rs#L81-L82) accepts a param named `msg32`, then directly after `msg_len`. I find it confusing since I would assume from the name `msg32` it must be 32 bytes. Should those instances be renamed `msg` if it is indeed variable len?