### PR TITLE
fix: don't randomize the global context twice

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -46,17 +46,7 @@ pub mod global {
             static ONCE: Once = Once::new();
             static mut CONTEXT: Option<Secp256k1<All>> = None;
             ONCE.call_once(|| unsafe {
-                let mut ctx = Secp256k1::new();
-                #[cfg(all(
-                    not(target_arch = "wasm32"),
-                    feature = "rand",
-                    feature = "std",
-                    not(feature = "global-context-less-secure")
-                ))]
-                {
-                    ctx.randomize(&mut rand::thread_rng());
-                }
-                CONTEXT = Some(ctx);
+                CONTEXT = Some(Secp256k1::new());
             });
             unsafe { CONTEXT.as_ref().unwrap() }
         }


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-secp256k1/issues/759.