### PR TITLE
fix CHANGELOG.md for 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ The major change in this version is the increase of the Minimum Supported Rust V
 
 ## Other improvements
 
-* `global-context` feature now activates `global-context-less-secure`.
+* `global-context-less-secure` feature now activates `global-context`.
 * `githooks/` directory added for contributors
 * [Clippy is now used in CI](https://github.com/rust-bitcoin/rust-secp256k1/pull/448) and the code is clippy-compliant
 * Various documentation improvements


### PR DESCRIPTION
The mentioned commit in the changelog is this: https://github.com/rust-bitcoin/rust-secp256k1/commit/c1bb316675b14f895d3fd339f281c83d2864971e


Change looks unnecessary, however, I had a minor heart-attack once I saw the changelog because we've been using the global-context feature for some time.