### PR TITLE
Add `from_u8_masked` `RecoveryId` constructor

### DIFF
--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -25,6 +25,19 @@ pub enum RecoveryId {
     Three,
 }
 
+impl RecoveryId {
+    /// Creates a `RecoveryId` from a `u8` value by masking off the top 6 bits.
+    #[inline]
+    pub const fn from_u8_masked(id: u8) -> RecoveryId {
+        match id & 0x03 {
+            0 => RecoveryId::Zero,
+            1 => RecoveryId::One,
+            2 => RecoveryId::Two,
+            _ => RecoveryId::Three,
+        }
+    }
+}
+
 impl TryFrom<i32> for RecoveryId {
     type Error = Error;
     #[inline]


### PR DESCRIPTION
Add an infallible constructor that takes a u8 and masks off the top 6 bits.

Mentioned in https://github.com/rust-bitcoin/rust-bitcoin/issues/3965