### PR TITLE
release 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# Next
+# 0.31.0 - 2025-04-21
 
+* Update `rand` to 0.9 [#788](https://github.com/rust-bitcoin/rust-secp256k1/pull/788)
 * Create keys from owned array values instead of from references [#781](https://github.com/rust-bitcoin/rust-secp256k1/pull/781)
+* Add `from_u8_masked` `RecoveryId` constructor [#778](https://github.com/rust-bitcoin/rust-secp256k1/pull/778)
+* Update upstream to `0cdc758a56360bf58a851fe91085a327ec97685a` (secp256k1-sys 0.6) [#764](https://github.com/rust-bitcoin/rust-secp256k1/pull/764)
+* Add `Keypair::sign_schnorr_no_aux_rand` [#762](https://github.com/rust-bitcoin/rust-secp256k1/pull/762)
+* Replace `Message` with `Into<Message>` in ECDSA signing API [#755](https://github.com/rust-bitcoin/rust-secp256k1/pull/755)
+* Deprecate `ElligatorSwiftParty` in favor of `Party` [#752](https://github.com/rust-bitcoin/rust-secp256k1/pull/752)
 
 # 0.30.0 - 2024-10-08
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -222,7 +222,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -213,7 +213,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.31.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
It's been almost a year since we had a release, and we've made some notable API changes. In particular we updated `rand` to 0.9.

Fixes #790