### PR TITLE
secp256k1-sys: fix `lowmemory` feature

### DIFF
--- a/secp256k1-sys/build.rs
+++ b/secp256k1-sys/build.rs
@@ -35,10 +35,12 @@ fn main() {
 
     if cfg!(feature = "lowmemory") {
         base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume negligible memory
-        base_config.define("ECMULT_GEN_PREC_BITS", Some("2"));
+        base_config.define("COMB_BLOCKS", Some("2"));
+        base_config.define("COMB_TEETH", Some("5"));
     } else {
-        base_config.define("ECMULT_GEN_PREC_BITS", Some("4"));
         base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
+        base_config.define("COMB_BLOCKS", Some("43"));
+        base_config.define("COMB_TEETH", Some("6"));
     }
     base_config.define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
     #[cfg(feature = "recovery")]


### PR DESCRIPTION
When upstream switched to multicomb they changed the #define flags needed to reduce the size of the ecmult_gen precomp table. We should have updated our bulid.rs.

Before this change, on my system the secp256k1-sys rlib with the lowmemory feature has size 630602. After this change, it has size 610090, a 3.3% reduction. Probably not worth backporting, although it's not a breaking change and we totally could backport it.

Fixes #795