### PR TITLE
Explicitly set `RecoveryId` value

### DIFF
--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -48,7 +48,7 @@ fn main() {
     let (recovery_id, serialize_sig) = signature.serialize_compact();
 
     assert_eq!(
-        recover(&secp, msg, serialize_sig, Into::<i32>::into(recovery_id) as u8),
+        recover(&secp, msg, serialize_sig, recovery_id.to_u8()),
         Ok(pubkey)
     );
 }

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -16,13 +16,13 @@ use crate::{key, Error, Message, Secp256k1, Signing, Verification};
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum RecoveryId {
     /// Signature recovery ID 0
-    Zero,
+    Zero = 0,
     /// Signature recovery ID 1
-    One,
+    One = 1,
     /// Signature recovery ID 2
-    Two,
+    Two = 2,
     /// Signature recovery ID 3
-    Three,
+    Three = 3,
 }
 
 impl RecoveryId {
@@ -38,14 +38,7 @@ impl RecoveryId {
     }
 
     /// Returns the `RecoveryId` as an integer.
-    pub const fn to_u8(self) -> u8 {
-        match self {
-            RecoveryId::Zero => 0,
-            RecoveryId::One => 1,
-            RecoveryId::Two => 2,
-            RecoveryId::Three => 3,
-        }
-    }
+    pub const fn to_u8(self) -> u8 { self as u8 }
 }
 
 impl TryFrom<i32> for RecoveryId {
@@ -64,14 +57,7 @@ impl TryFrom<i32> for RecoveryId {
 
 impl From<RecoveryId> for u8 {
     #[inline]
-    fn from(val: RecoveryId) -> Self {
-        match val {
-            RecoveryId::Zero => 0,
-            RecoveryId::One => 1,
-            RecoveryId::Two => 2,
-            RecoveryId::Three => 3,
-        }
-    }
+    fn from(val: RecoveryId) -> Self { val.to_u8() }
 }
 
 /// An ECDSA signature with a recovery ID for pubkey recovery.

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -62,7 +62,7 @@ impl TryFrom<i32> for RecoveryId {
     }
 }
 
-impl From<RecoveryId> for i32 {
+impl From<RecoveryId> for u8 {
     #[inline]
     fn from(val: RecoveryId) -> Self {
         match val {
@@ -96,7 +96,7 @@ impl RecoverableSignature {
                 super_ffi::secp256k1_context_no_precomp,
                 &mut ret,
                 data.as_c_ptr(),
-                recid.into(),
+                i32::from(recid.to_u8()),
             ) == 1
             {
                 Ok(RecoverableSignature(ret))
@@ -123,7 +123,7 @@ impl RecoverableSignature {
     /// Serializes the recoverable signature in compact format.
     pub fn serialize_compact(&self) -> (RecoveryId, [u8; 64]) {
         let mut ret = [0u8; 64];
-        let mut recid = RecoveryId::Zero.into();
+        let mut recid = i32::from(RecoveryId::Zero.to_u8());
         unsafe {
             let err = ffi::secp256k1_ecdsa_recoverable_signature_serialize_compact(
                 super_ffi::secp256k1_context_no_precomp,
@@ -461,9 +461,9 @@ mod tests {
         assert!(RecoveryId::try_from(3i32).is_ok());
         assert!(RecoveryId::try_from(4i32).is_err());
         let id0 = RecoveryId::Zero;
-        assert_eq!(Into::<i32>::into(id0), 0i32);
+        assert_eq!(Into::<u8>::into(id0), 0u8);
         let id1 = RecoveryId::One;
-        assert_eq!(Into::<i32>::into(id1), 1i32);
+        assert_eq!(Into::<u8>::into(id1), 1u8);
     }
 }
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -36,6 +36,16 @@ impl RecoveryId {
             _ => RecoveryId::Three,
         }
     }
+
+    /// Returns the `RecoveryId` as an integer.
+    pub const fn to_u8(self) -> u8 {
+        match self {
+            RecoveryId::Zero => 0,
+            RecoveryId::One => 1,
+            RecoveryId::Two => 2,
+            RecoveryId::Three => 3,
+        }
+    }
 }
 
 impl TryFrom<i32> for RecoveryId {


### PR DESCRIPTION
Draft because on top of #800, this PR is just the last patch.

At the moment its implicit in the name, make it explicit.

Close: #777