### PR TITLE
0.31.x: update deprecation versions and bump minor version

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -222,7 +222,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -213,7 +213,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.31.0"
+version = "0.31.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -11,7 +11,7 @@ fn verify<C: Verification>(
     pubkey: [u8; 33],
 ) -> Result<bool, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_digest_slice(msg.as_ref())?;
+    let msg = Message::from_digest(msg.to_byte_array());
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
@@ -24,8 +24,8 @@ fn sign<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::Signature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_digest_slice(msg.as_ref())?;
-    let seckey = SecretKey::from_slice(&seckey)?;
+    let msg = Message::from_digest(msg.to_byte_array());
+    let seckey = SecretKey::from_byte_array(seckey)?;
     Ok(secp.sign_ecdsa(msg, &seckey))
 }
 

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -11,7 +11,7 @@ fn recover<C: Verification>(
     recovery_id: u8,
 ) -> Result<PublicKey, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_digest_slice(msg.as_ref())?;
+    let msg = Message::from_digest(msg.to_byte_array());
     let id = ecdsa::RecoveryId::try_from(i32::from(recovery_id))?;
     let sig = ecdsa::RecoverableSignature::from_compact(&sig, id)?;
 
@@ -24,8 +24,8 @@ fn sign_recovery<C: Signing>(
     seckey: [u8; 32],
 ) -> Result<ecdsa::RecoverableSignature, Error> {
     let msg = sha256::Hash::hash(msg);
-    let msg = Message::from_digest_slice(msg.as_ref())?;
-    let seckey = SecretKey::from_slice(&seckey)?;
+    let msg = Message::from_digest(msg.to_byte_array());
+    let seckey = SecretKey::from_byte_array(seckey)?;
     Ok(secp.sign_ecdsa_recoverable(msg, &seckey))
 }
 

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -64,7 +64,7 @@ impl SharedSecret {
     pub fn from_bytes(bytes: [u8; SHARED_SECRET_SIZE]) -> SharedSecret { SharedSecret(bytes) }
 
     /// Creates a shared secret from `bytes` slice.
-    #[deprecated(since = "TBD", note = "Use `from_bytes` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_bytes` instead.")]
     #[inline]
     pub fn from_slice(bytes: &[u8]) -> Result<SharedSecret, Error> {
         match bytes.len() {

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -178,7 +178,7 @@ impl<'de> ::serde::Deserialize<'de> for SharedSecret {
         } else {
             d.deserialize_bytes(super::serde_util::BytesVisitor::new(
                 "raw 32 bytes SharedSecret",
-                SharedSecret::from_slice,
+                |x| x.try_into().map(SharedSecret::from_bytes),
             ))
         }
     }
@@ -263,7 +263,7 @@ mod tests {
         ];
         static STR: &str = "01010101010101010001020304050607ffff0000ffff00006363636363636363";
 
-        let secret = SharedSecret::from_slice(&BYTES).unwrap();
+        let secret = SharedSecret::from_bytes(BYTES);
 
         assert_tokens(&secret.compact(), &[Token::BorrowedBytes(&BYTES[..])]);
         assert_tokens(&secret.compact(), &[Token::Bytes(&BYTES)]);

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -261,7 +261,7 @@ mod tests {
         let full = Secp256k1::new();
 
         let msg = crate::random_32_bytes(&mut rand::rng());
-        let msg = Message::from_digest_slice(&msg).unwrap();
+        let msg = Message::from_digest(msg);
 
         // Try key generation
         let (sk, pk) = full.generate_keypair(&mut rand::rng());
@@ -292,8 +292,8 @@ mod tests {
         let mut s = Secp256k1::new();
         s.randomize(&mut rand::rng());
 
-        let sk = SecretKey::from_slice(&ONE).unwrap();
-        let msg = Message::from_digest_slice(&ONE).unwrap();
+        let sk = SecretKey::from_byte_array(ONE).unwrap();
+        let msg = Message::from_digest(ONE);
 
         let sig = s.sign_ecdsa_recoverable(msg, &sk);
 
@@ -317,8 +317,8 @@ mod tests {
         let mut s = Secp256k1::new();
         s.randomize(&mut rand::rng());
 
-        let sk = SecretKey::from_slice(&ONE).unwrap();
-        let msg = Message::from_digest_slice(&ONE).unwrap();
+        let sk = SecretKey::from_byte_array(ONE).unwrap();
+        let msg = Message::from_digest(ONE);
         let noncedata = [42u8; 32];
 
         let sig = s.sign_ecdsa_recoverable_with_noncedata(msg, &sk, &noncedata);
@@ -342,7 +342,7 @@ mod tests {
         s.randomize(&mut rand::rng());
 
         let msg = crate::random_32_bytes(&mut rand::rng());
-        let msg = Message::from_digest_slice(&msg).unwrap();
+        let msg = Message::from_digest(msg);
 
         let (sk, pk) = s.generate_keypair(&mut rand::rng());
 
@@ -350,7 +350,7 @@ mod tests {
         let sig = sigr.to_standard();
 
         let msg = crate::random_32_bytes(&mut rand::rng());
-        let msg = Message::from_digest_slice(&msg).unwrap();
+        let msg = Message::from_digest(msg);
         assert_eq!(s.verify_ecdsa(msg, &sig, &pk), Err(Error::IncorrectSignature));
 
         let recovered_key = s.recover_ecdsa(msg, &sigr).unwrap();
@@ -364,7 +364,7 @@ mod tests {
         s.randomize(&mut rand::rng());
 
         let msg = crate::random_32_bytes(&mut rand::rng());
-        let msg = Message::from_digest_slice(&msg).unwrap();
+        let msg = Message::from_digest(msg);
 
         let (sk, pk) = s.generate_keypair(&mut rand::rng());
 
@@ -380,7 +380,7 @@ mod tests {
         s.randomize(&mut rand::rng());
 
         let msg = crate::random_32_bytes(&mut rand::rng());
-        let msg = Message::from_digest_slice(&msg).unwrap();
+        let msg = Message::from_digest(msg);
 
         let noncedata = [42u8; 32];
 
@@ -397,7 +397,7 @@ mod tests {
         let mut s = Secp256k1::new();
         s.randomize(&mut rand::rng());
 
-        let msg = Message::from_digest_slice(&[0x55; 32]).unwrap();
+        let msg = Message::from_digest([0x55; 32]);
 
         // Zero is not a valid sig
         let sig = RecoverableSignature::from_compact(&[0; 64], RecoveryId::Zero).unwrap();
@@ -468,8 +468,8 @@ mod benches {
     pub fn bench_recover(bh: &mut Bencher) {
         let s = Secp256k1::new();
         let msg = crate::random_32_bytes(&mut rand::rng());
-        let msg = Message::from_digest_slice(&msg).unwrap();
-        let (sk, _) = s.generate_keypair(&mut rand::rng());
+        let msg = Message::from_digest(msg);
+        let (sk, _) = s.generate_keypair(&mut rand::thread_rng());
         let sig = s.sign_ecdsa_recoverable(&msg, &sk);
 
         bh.iter(|| {

--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -378,7 +378,7 @@ mod tests {
         // Test that we can round trip an ElligatorSwift encoding
         let secp = crate::Secp256k1::new();
         let public_key =
-            PublicKey::from_secret_key(&secp, &SecretKey::from_slice(&[1u8; 32]).unwrap());
+            PublicKey::from_secret_key(&secp, &SecretKey::from_byte_array([1u8; 32]).unwrap());
 
         let ell = ElligatorSwift::from_pubkey(public_key);
         let pk = PublicKey::from_ellswift(ell);
@@ -391,9 +391,11 @@ mod tests {
         let secp = crate::Secp256k1::new();
         let rand32 = [1u8; 32];
         let priv32 = [1u8; 32];
-        let ell = ElligatorSwift::from_seckey(&secp, SecretKey::from_slice(&rand32).unwrap(), None);
+        let ell =
+            ElligatorSwift::from_seckey(&secp, SecretKey::from_byte_array(rand32).unwrap(), None);
         let pk = PublicKey::from_ellswift(ell);
-        let expected = PublicKey::from_secret_key(&secp, &SecretKey::from_slice(&priv32).unwrap());
+        let expected =
+            PublicKey::from_secret_key(&secp, &SecretKey::from_byte_array(priv32).unwrap());
 
         assert_eq!(pk, expected);
     }
@@ -406,13 +408,13 @@ mod tests {
         let priv32 = [2u8; 32];
         let ell = ElligatorSwift::from_seckey(
             &secp,
-            SecretKey::from_slice(&rand32).unwrap(),
+            SecretKey::from_byte_array(rand32).unwrap(),
             Some(rand32),
         );
         let pk = ElligatorSwift::shared_secret_with_hasher(
             ell,
             ell,
-            SecretKey::from_slice(&priv32).unwrap(),
+            SecretKey::from_byte_array(priv32).unwrap(),
             Party::Initiator,
             |_, _, _| ElligatorSwiftSharedSecret([0xff; 32]),
         );
@@ -626,7 +628,7 @@ mod tests {
                     ElligatorSwift::from_array(ellswift_theirs),
                 )
             };
-            let sec_key = SecretKey::from_slice(&my_secret).unwrap();
+            let sec_key = SecretKey::from_byte_array(my_secret).unwrap();
             let initiator = if initiator == 0 { Party::Responder } else { Party::Initiator };
 
             let shared = ElligatorSwift::shared_secret(el_a, el_b, sec_key, initiator, None);

--- a/src/key.rs
+++ b/src/key.rs
@@ -401,10 +401,10 @@ impl<'de> serde::Deserialize<'de> for SecretKey {
                 "a hex string representing 32 byte SecretKey",
             ))
         } else {
-            let visitor =
-                super::serde_util::Tuple32Visitor::new("raw 32 bytes SecretKey", |bytes| {
-                    SecretKey::from_byte_array(bytes)
-                });
+            let visitor = super::serde_util::Tuple32Visitor::new(
+                "raw 32 bytes SecretKey",
+                SecretKey::from_byte_array,
+            );
             d.deserialize_tuple(constants::SECRET_KEY_SIZE, visitor)
         }
     }
@@ -790,10 +790,10 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
                 "an ASCII hex string representing a public key",
             ))
         } else {
-            let visitor =
-                super::serde_util::Tuple33Visitor::new("33 bytes compressed public key", |bytes| {
-                    PublicKey::from_byte_array_compressed(bytes)
-                });
+            let visitor = super::serde_util::Tuple33Visitor::new(
+                "33 bytes compressed public key",
+                PublicKey::from_byte_array_compressed,
+            );
             d.deserialize_tuple(constants::PUBLIC_KEY_SIZE, visitor)
         }
     }
@@ -1634,6 +1634,7 @@ mod test {
     use crate::{constants, from_hex, to_hex, Scalar};
 
     #[test]
+    #[allow(deprecated)]
     fn skey_from_slice() {
         let sk = SecretKey::from_slice(&[1; 31]);
         assert_eq!(sk, Err(InvalidSecretKey));
@@ -1668,7 +1669,7 @@ mod test {
         let s = Secp256k1::new();
 
         let (sk1, pk1) = s.generate_keypair(&mut rand::rng());
-        assert_eq!(SecretKey::from_slice(&sk1[..]), Ok(sk1));
+        assert_eq!(SecretKey::from_byte_array(sk1.secret_bytes()), Ok(sk1));
         assert_eq!(PublicKey::from_slice(&pk1.serialize()[..]), Ok(pk1));
         assert_eq!(PublicKey::from_slice(&pk1.serialize_uncompressed()[..]), Ok(pk1));
     }
@@ -1688,22 +1689,22 @@ mod test {
     #[rustfmt::skip]
     fn invalid_secret_key() {
         // Zero
-        assert_eq!(SecretKey::from_slice(&[0; 32]), Err(InvalidSecretKey));
+        assert_eq!(SecretKey::from_byte_array([0; 32]), Err(InvalidSecretKey));
         assert_eq!(
             SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000000"),
             Err(InvalidSecretKey)
         );
         // -1
-        assert_eq!(SecretKey::from_slice(&[0xff; 32]), Err(InvalidSecretKey));
+        assert_eq!(SecretKey::from_byte_array([0xff; 32]), Err(InvalidSecretKey));
         // Top of range
-        assert!(SecretKey::from_slice(&[
+        assert!(SecretKey::from_byte_array([
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
             0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B,
             0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x40,
         ]).is_ok());
         // One past top of range
-        assert!(SecretKey::from_slice(&[
+        assert!(SecretKey::from_byte_array([
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
             0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B,
@@ -1772,6 +1773,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_seckey_from_bad_slice() {
         // Bad sizes
         assert_eq!(
@@ -1825,7 +1827,7 @@ mod test {
 
         #[cfg(not(secp256k1_fuzz))]
         let s = Secp256k1::signing_only();
-        let sk = SecretKey::from_slice(&SK_BYTES).expect("sk");
+        let sk = SecretKey::from_byte_array(SK_BYTES).expect("sk");
 
         // In fuzzing mode secret->public key derivation is different, so
         // hard-code the expected result.
@@ -2180,7 +2182,7 @@ mod test {
 
         #[cfg(not(secp256k1_fuzz))]
         let s = Secp256k1::new();
-        let sk = SecretKey::from_slice(&SK_BYTES).unwrap();
+        let sk = SecretKey::from_byte_array(SK_BYTES).unwrap();
 
         // In fuzzing mode secret->public key derivation is different, so
         // hard-code the expected result.
@@ -2320,10 +2322,11 @@ mod test {
         pk_bytes[0] = 0x02; // Use positive Y co-ordinate.
         pk_bytes[1..].clone_from_slice(&PK_BYTES);
 
-        let sk = SecretKey::from_slice(&SK_BYTES).expect("failed to parse sk bytes");
+        let sk = SecretKey::from_byte_array(SK_BYTES).expect("failed to parse sk bytes");
         let pk = PublicKey::from_slice(&pk_bytes).expect("failed to create pk from iterator");
         let kp = Keypair::from_secret_key(&secp, &sk);
-        let xonly = XOnlyPublicKey::from_slice(&PK_BYTES).expect("failed to get xonly from slice");
+        let xonly =
+            XOnlyPublicKey::from_byte_array(PK_BYTES).expect("failed to get xonly from slice");
 
         (sk, pk, kp, xonly)
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -219,7 +219,7 @@ impl SecretKey {
     /// use secp256k1::SecretKey;
     /// let sk = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
     /// ```
-    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_byte_array` instead.")]
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<SecretKey, Error> {
         match <[u8; constants::SECRET_KEY_SIZE]>::try_from(data) {
@@ -860,7 +860,7 @@ impl Keypair {
     ///
     /// [`Error::InvalidSecretKey`] if the slice is not exactly 32 bytes long,
     /// or if the encoded number is an invalid scalar.
-    #[deprecated(since = "TBD", note = "Use `from_seckey_byte_array` instead.")]
+    #[deprecated(since = "0.31.0", note = "Use `from_seckey_byte_array` instead.")]
     #[inline]
     pub fn from_seckey_slice<C: Signing>(
         secp: &Secp256k1<C>,
@@ -1239,7 +1239,7 @@ impl XOnlyPublicKey {
     ///
     /// Returns [`Error::InvalidPublicKey`] if the length of the data slice is not 32 bytes or the
     /// slice does not represent a valid Secp256k1 point x coordinate.
-    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_byte_array` instead.")]
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<XOnlyPublicKey, Error> {
         match <[u8; constants::SCHNORR_PUBLIC_KEY_SIZE]>::try_from(data) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -640,9 +640,9 @@ mod tests {
         assert!(full.verify_ecdsa(msg, &sig, &pk).is_ok());
 
         // Check that we can produce keys from slices with no precomputation
-        let (pk_slice, sk_slice) = (&pk.serialize(), &sk[..]);
+        let pk_slice = &pk.serialize();
         let new_pk = PublicKey::from_slice(pk_slice).unwrap();
-        let new_sk = SecretKey::from_slice(sk_slice).unwrap();
+        let new_sk = SecretKey::from_byte_array(sk.secret_bytes()).unwrap();
         assert_eq!(sk, new_sk);
         assert_eq!(pk, new_pk);
     }
@@ -792,7 +792,7 @@ mod tests {
         wild_keys[1][0] -= 1;
         wild_msgs[1][0] -= 1;
 
-        for key in wild_keys.iter().map(|k| SecretKey::from_slice(&k[..]).unwrap()) {
+        for key in wild_keys.iter().copied().map(SecretKey::from_byte_array).map(Result::unwrap) {
             for msg in wild_msgs.into_iter().map(Message::from_digest) {
                 let sig = s.sign_ecdsa(msg, &key);
                 let low_r_sig = s.sign_ecdsa_low_r(msg, &key);
@@ -964,7 +964,7 @@ mod tests {
         let s = Secp256k1::new();
 
         let msg = Message::from_digest([1; 32]);
-        let sk = SecretKey::from_slice(&[2; 32]).unwrap();
+        let sk = SecretKey::from_byte_array([2; 32]).unwrap();
         let sig = s.sign_ecdsa(msg, &sk);
         static SIG_BYTES: [u8; 71] = [
             48, 69, 2, 33, 0, 157, 11, 173, 87, 103, 25, 211, 42, 231, 107, 237, 179, 76, 119, 72,
@@ -991,7 +991,7 @@ mod tests {
     fn test_global_context() {
         use crate::SECP256K1;
         let sk_data = hex!("e6dd32f8761625f105c39a39f19370b3521d845a12456d60ce44debd0a362641");
-        let sk = SecretKey::from_slice(&sk_data).unwrap();
+        let sk = SecretKey::from_byte_array(sk_data).unwrap();
         let msg_data = hex!("a4965ca63b7d8562736ceec36dfa5a11bf426eb65be8ea3f7a49ae363032da0d");
         let msg = Message::from_digest(msg_data);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl Message {
     ///
     /// [secure signature]: https://twitter.com/pwuille/status/1063582706288586752
     #[inline]
-    #[deprecated(since = "TBD", note = "use from_digest instead")]
+    #[deprecated(since = "0.30.0", note = "use from_digest instead")]
     pub fn from_digest_slice(digest: &[u8]) -> Result<Message, Error> {
         Ok(Message::from_digest(digest.try_into().map_err(|_| Error::InvalidMessage)?))
     }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -78,7 +78,7 @@ impl Signature {
     pub fn from_byte_array(sig: [u8; constants::SCHNORR_SIGNATURE_SIZE]) -> Self { Self(sig) }
 
     /// Creates a `Signature` directly from a slice.
-    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_byte_array` instead.")]
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<Signature, Error> {
         match data.len() {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -36,7 +36,7 @@ static XONLY_PK_BYTES: [u8; 32] = [
 ];
 
 fn secret_key() -> SecretKey {
-    SecretKey::from_slice(&SK_BYTES).expect("failed to create sk from slice")
+    SecretKey::from_byte_array(SK_BYTES).expect("failed to create sk from slice")
 }
 
 // Our current serde serialization implementation is only guaranteed to be fixed
@@ -69,8 +69,8 @@ fn bincode_keypair() {
 
 #[test]
 fn bincode_x_only_public_key() {
-    let pk =
-        XOnlyPublicKey::from_slice(&XONLY_PK_BYTES).expect("failed to create xonly pk from slice");
+    let pk = XOnlyPublicKey::from_byte_array(XONLY_PK_BYTES)
+        .expect("failed to create xonly pk from slice");
     let ser = bincode::serialize(&pk).unwrap();
 
     assert_eq!(ser, XONLY_PK_BYTES);


### PR DESCRIPTION
We accidentally released a bunch of deprecations with `since` set to `TBD`. Update these.