### PR TITLE
0.30.x: update deprecation versions and bump minor version

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -272,7 +272,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -193,7 +193,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.30.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -64,7 +64,7 @@ impl SharedSecret {
     pub fn from_bytes(bytes: [u8; SHARED_SECRET_SIZE]) -> SharedSecret { SharedSecret(bytes) }
 
     /// Creates a shared secret from `bytes` slice.
-    #[deprecated(since = "TBD", note = "Use `from_bytes` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_bytes` instead.")]
     #[inline]
     pub fn from_slice(bytes: &[u8]) -> Result<SharedSecret, Error> {
         match bytes.len() {

--- a/src/key.rs
+++ b/src/key.rs
@@ -219,7 +219,7 @@ impl SecretKey {
     /// use secp256k1::SecretKey;
     /// let sk = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
     /// ```
-    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_byte_array` instead.")]
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<SecretKey, Error> {
         match <[u8; constants::SECRET_KEY_SIZE]>::try_from(data) {
@@ -1215,7 +1215,7 @@ impl XOnlyPublicKey {
     ///
     /// Returns [`Error::InvalidPublicKey`] if the length of the data slice is not 32 bytes or the
     /// slice does not represent a valid Secp256k1 point x coordinate.
-    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_byte_array` instead.")]
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<XOnlyPublicKey, Error> {
         match <[u8; constants::SCHNORR_PUBLIC_KEY_SIZE]>::try_from(data) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl Message {
     ///
     /// [secure signature]: https://twitter.com/pwuille/status/1063582706288586752
     #[inline]
-    #[deprecated(since = "TBD", note = "use from_digest instead")]
+    #[deprecated(since = "0.30.0", note = "use from_digest instead")]
     pub fn from_digest_slice(digest: &[u8]) -> Result<Message, Error> {
         Ok(Message::from_digest(digest.try_into().map_err(|_| Error::InvalidMessage)?))
     }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -78,7 +78,7 @@ impl Signature {
     pub fn from_byte_array(sig: [u8; constants::SCHNORR_SIGNATURE_SIZE]) -> Self { Self(sig) }
 
     /// Creates a `Signature` directly from a slice.
-    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+    #[deprecated(since = "0.30.0", note = "Use `from_byte_array` instead.")]
     #[inline]
     pub fn from_slice(data: &[u8]) -> Result<Signature, Error> {
         match data.len() {


### PR DESCRIPTION
We accidentally released a bunch of deprecations with `since` set to `TBD`. Update these.