### PR TITLE
secp256k1-sys: remove `CPtr` impl for `&[T]` and associated weirdness

### DIFF
--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -915,7 +915,7 @@ extern "C" {
     #[cfg_attr(not(rust_secp_no_symbol_renaming), link_name = "rustsecp256k1_v0_11_ec_pubkey_sort")]
     pub fn secp256k1_ec_pubkey_sort(
         ctx: *const Context,
-        pubkeys: *const *const PublicKey,
+        pubkeys: *mut *const PublicKey,
         n_pubkeys: size_t,
     ) -> c_int;
 }

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -1388,25 +1388,6 @@ impl<T> CPtr for [T] {
     }
 }
 
-impl<T> CPtr for &[T] {
-    type Target = T;
-    fn as_c_ptr(&self) -> *const Self::Target {
-        if self.is_empty() {
-            ptr::null()
-        } else {
-            self.as_ptr()
-        }
-    }
-
-    fn as_mut_c_ptr(&mut self) -> *mut Self::Target {
-        if self.is_empty() {
-            ptr::null_mut()
-        } else {
-            self.as_ptr() as *mut Self::Target
-        }
-    }
-}
-
 impl CPtr for [u8; 32] {
     type Target = u8;
     fn as_c_ptr(&self) -> *const Self::Target { self.as_ptr() }

--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -167,8 +167,8 @@ impl ElligatorSwift {
     ///     let alice_es = ElligatorSwift::from_seckey(&secp, alice_sk, None);
     ///     let bob_es = ElligatorSwift::from_seckey(&secp, bob_sk, None);
     ///
-    ///     let alice_shared_secret = ElligatorSwift::shared_secret(alice_es, bob_es, alice_sk, Party::Initiator, None);
-    ///     let bob_shared_secret = ElligatorSwift::shared_secret(alice_es, bob_es, bob_sk, Party::Responder, None);
+    ///     let alice_shared_secret = ElligatorSwift::shared_secret(alice_es, bob_es, alice_sk, Party::Initiator);
+    ///     let bob_shared_secret = ElligatorSwift::shared_secret(alice_es, bob_es, bob_sk, Party::Responder);
     ///
     ///     assert_eq!(alice_shared_secret, bob_shared_secret);
     /// # }
@@ -178,7 +178,6 @@ impl ElligatorSwift {
         ellswift_b: ElligatorSwift,
         secret_key: SecretKey,
         party: impl Into<Party>,
-        data: Option<&[u8]>,
     ) -> ElligatorSwiftSharedSecret {
         let mut shared_secret = [0u8; 32];
         let p: Party = party.into();
@@ -191,7 +190,7 @@ impl ElligatorSwift {
                 secret_key.as_c_ptr(),
                 p.to_ffi_int(),
                 ffi::secp256k1_ellswift_xdh_hash_function_bip324,
-                data.as_c_ptr() as *mut c_void,
+                ptr::null_mut(),
             );
             debug_assert_eq!(ret, 1);
         }
@@ -631,7 +630,7 @@ mod tests {
             let sec_key = SecretKey::from_byte_array(my_secret).unwrap();
             let initiator = if initiator == 0 { Party::Responder } else { Party::Initiator };
 
-            let shared = ElligatorSwift::shared_secret(el_a, el_b, sec_key, initiator, None);
+            let shared = ElligatorSwift::shared_secret(el_a, el_b, sec_key, initiator);
 
             assert_eq!(shared.0, shared_secret);
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1644,11 +1644,9 @@ impl<C: Verification> Secp256k1<C> {
     pub fn sort_pubkeys(&self, pubkeys: &mut [&PublicKey]) {
         let cx = self.ctx().as_ptr();
         unsafe {
-            let mut pubkeys_ref = core::slice::from_raw_parts(
-                pubkeys.as_c_ptr() as *mut *const ffi::PublicKey,
-                pubkeys.len(),
-            );
-            if secp256k1_ec_pubkey_sort(cx, pubkeys_ref.as_mut_c_ptr(), pubkeys_ref.len()) == 0 {
+            // SAFETY: `PublicKey` has repr(transparent) so we can convert to `ffi::PublicKey`
+            let pubkeys_ptr = pubkeys.as_mut_c_ptr() as *mut *const ffi::PublicKey;
+            if secp256k1_ec_pubkey_sort(cx, pubkeys_ptr, pubkeys.len()) == 0 {
                 unreachable!("Invalid public keys for sorting function")
             }
         }


### PR DESCRIPTION
Fixes the signature of secp256k1_ec_pubkey_sort to use `*mut` rather than `*const`.

Separately, our call to `secp256k1_ec_pubkey_sort`, while correctly starting from a `&mut [PublicKey]`, briefly constructed a `&[ffi::PublicKey]` slice before obtaining a `*mut` pointer from this. This was unsound for completely unnecessary reasons, and only compiled because we have an impl of the `CPtr` trait for `&[T]`, which provides a `as_mut_c_ptr()` method which basically cannot be safely used.

Removing that `&[T]` impl revealed another case where it was (unnecessarily) being used: in `EllSwift::shared_secret`, where we use it to obtain a `*mut` pointer from a `&[u8]`, which we pass across the FFI boundary which simply drops it.