### PR TITLE
secp256k1-sys: Add memmove to the wasm-sysroot header

### DIFF
--- a/secp256k1-sys/wasm/wasm-sysroot/string.h
+++ b/secp256k1-sys/wasm/wasm-sysroot/string.h
@@ -2,3 +2,4 @@
 void *memset(void *s, int c, size_t n);
 void *memcpy(void *dest, const void *src, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
+void *memmove(void *dest_str, const void *src_str, size_t numBytes);


### PR DESCRIPTION
WASM build is currently failing because we don't include `memmove` in our custom WASM header.

Close: #817