### PR TITLE
secp256k1-sys 0.8.x: fix compilation with `cfg(fuzzer)`

### DIFF
--- a/secp256k1-sys/Cargo.toml
+++ b/secp256k1-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.8.2"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>" ]

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -907,7 +907,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_8_1_context_destroy(mut ctx: NonNull<C
 ///
 /// `message` string should be a null terminated C string and, up to the first null byte, must be valid UTF8.
 ///
-/// For exact safety constraints see [`std::slice::from_raw_parts`] and [`std::str::from_utf8_unchecked`].
+/// For exact safety constraints see [`core::slice::from_raw_parts`] and [`core::str::from_utf8_unchecked`].
 #[no_mangle]
 #[cfg(not(rust_secp_no_symbol_renaming))]
 pub unsafe extern "C" fn rustsecp256k1_v0_8_1_default_illegal_callback_fn(message: *const c_char, _data: *mut c_void) {
@@ -935,7 +935,7 @@ pub unsafe extern "C" fn rustsecp256k1_v0_8_1_default_illegal_callback_fn(messag
 ///
 /// `message` string should be a null terminated C string and, up to the first null byte, must be valid UTF8.
 ///
-/// For exact safety constraints see [`std::slice::from_raw_parts`] and [`std::str::from_utf8_unchecked`].
+/// For exact safety constraints see [`core::slice::from_raw_parts`] and [`core::str::from_utf8_unchecked`].
 #[no_mangle]
 #[cfg(not(rust_secp_no_symbol_renaming))]
 pub unsafe extern "C" fn rustsecp256k1_v0_8_1_default_error_callback_fn(message: *const c_char, _data: *mut c_void) {
@@ -1011,7 +1011,7 @@ mod fuzz_dummy {
     const CTX_SIZE: usize = 1024 * (1024 + 128);
     // Contexts
     pub unsafe fn secp256k1_context_preallocated_size(flags: c_uint) -> size_t {
-        assert!(rustsecp256k1_v0_8_1_context_preallocated_size(flags) + std::mem::size_of::<c_uint>() <= CTX_SIZE);
+        assert!(rustsecp256k1_v0_8_1_context_preallocated_size(flags) + core::mem::size_of::<c_uint>() <= CTX_SIZE);
         CTX_SIZE
     }
 
@@ -1031,7 +1031,7 @@ mod fuzz_dummy {
             if have_ctx == HAVE_CONTEXT_NONE {
                 have_ctx = HAVE_PREALLOCATED_CONTEXT.swap(HAVE_CONTEXT_WORKING, Ordering::AcqRel);
                 if have_ctx == HAVE_CONTEXT_NONE {
-                    assert!(rustsecp256k1_v0_8_1_context_preallocated_size(SECP256K1_START_SIGN | SECP256K1_START_VERIFY) + std::mem::size_of::<c_uint>() <= CTX_SIZE);
+                    assert!(rustsecp256k1_v0_8_1_context_preallocated_size(SECP256K1_START_SIGN | SECP256K1_START_VERIFY) + core::mem::size_of::<c_uint>() <= CTX_SIZE);
                     assert_eq!(rustsecp256k1_v0_8_1_context_preallocated_create(
                             NonNull::new_unchecked(PREALLOCATED_CONTEXT[..].as_mut_ptr() as *mut c_void),
                             SECP256K1_START_SIGN | SECP256K1_START_VERIFY),
@@ -1051,14 +1051,14 @@ mod fuzz_dummy {
             }
         }
         ptr::copy_nonoverlapping(PREALLOCATED_CONTEXT[..].as_ptr(), prealloc.as_ptr() as *mut u8, CTX_SIZE);
-        let ptr = (prealloc.as_ptr()).add(CTX_SIZE).sub(std::mem::size_of::<c_uint>());
+        let ptr = (prealloc.as_ptr()).add(CTX_SIZE).sub(core::mem::size_of::<c_uint>());
         (ptr as *mut c_uint).write(flags);
         NonNull::new_unchecked(prealloc.as_ptr() as *mut Context)
     }
     pub unsafe fn secp256k1_context_preallocated_clone_size(_cx: *const Context) -> size_t { CTX_SIZE }
     pub unsafe fn secp256k1_context_preallocated_clone(cx: *const Context, prealloc: NonNull<c_void>) -> NonNull<Context> {
-        let orig_ptr = (cx as *mut u8).add(CTX_SIZE).sub(std::mem::size_of::<c_uint>());
-        let new_ptr = (prealloc.as_ptr() as *mut u8).add(CTX_SIZE).sub(std::mem::size_of::<c_uint>());
+        let orig_ptr = (cx as *mut u8).add(CTX_SIZE).sub(core::mem::size_of::<c_uint>());
+        let new_ptr = (prealloc.as_ptr() as *mut u8).add(CTX_SIZE).sub(core::mem::size_of::<c_uint>());
         let flags = (orig_ptr as *mut c_uint).read();
         (new_ptr as *mut c_uint).write(flags);
         rustsecp256k1_v0_8_1_context_preallocated_clone(cx, prealloc)
@@ -1077,7 +1077,7 @@ mod fuzz_dummy {
         let cx_flags = if cx == secp256k1_context_no_precomp {
             1
         } else {
-            let ptr = (cx as *const u8).add(CTX_SIZE).sub(std::mem::size_of::<c_uint>());
+            let ptr = (cx as *const u8).add(CTX_SIZE).sub(core::mem::size_of::<c_uint>());
             (ptr as *const c_uint).read()
         };
         assert_eq!(cx_flags & 1, 1); // SECP256K1_FLAGS_TYPE_CONTEXT
@@ -1485,6 +1485,7 @@ pub use self::fuzz_dummy::*;
 mod tests {
     #[cfg(not(rust_secp_no_symbol_renaming))]
     #[test]
+    #[cfg(feature = "std")]
     fn test_strlen() {
         use std::ffi::CString;
         use super::strlen;

--- a/secp256k1-sys/src/types.rs
+++ b/secp256k1-sys/src/types.rs
@@ -34,12 +34,14 @@ pub(crate) const ALIGN_TO: usize = core::mem::align_of::<AlignedType>();
 #[cfg(test)]
 mod tests {
     extern crate libc;
-    use std::any::TypeId;
-    use std::mem;
+    use core::any::TypeId;
+    use core::mem;
+    #[cfg(feature = "std")]
     use std::os::raw;
     use crate::{types, AlignedType};
 
     #[test]
+    #[cfg(feature = "std")]
     fn verify_types() {
         assert_eq!(TypeId::of::<types::c_int>(), TypeId::of::<raw::c_int>());
         assert_eq!(TypeId::of::<types::c_uchar>(), TypeId::of::<raw::c_uchar>());


### PR DESCRIPTION
CI is going to fail miserably and even compiling locally may be difficult. Reviewers should, at a minimum, verify that no code has changed except for test code (in `src/types.rs`) and code gated on `cfg(fuzzing)`.

Fixes #821

