### PR TITLE
Fix grammatical typos

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -221,7 +221,7 @@ mod alloc_only {
                 ctx.randomize(&mut rand::rng());
             }
 
-            #[allow(clippy::let_and_return)] // as for unusted_mut
+            #[allow(clippy::let_and_return)] // as for unused_mut
             ctx
         }
     }

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -1034,7 +1034,7 @@ impl AggregatedSignature {
     }
 }
 
-/// A musig Siging session.
+/// A musig Signing session.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Session(ffi::MusigSession);
 


### PR DESCRIPTION
Fixed several typos in code comments
unusted_mut -> unused_mut
Siging -> Signing