### PR TITLE
chore(ci): Fix typo in Dockerfile comment

### DIFF
--- a/secp256k1-sys/depend/secp256k1/ci/linux-debian.Dockerfile
+++ b/secp256k1-sys/depend/secp256k1/ci/linux-debian.Dockerfile
@@ -19,7 +19,7 @@ RUN dpkg --add-architecture i386 && \
     dpkg --add-architecture arm64 && \
     dpkg --add-architecture ppc64el
 
-# dkpg-dev: to make pkg-config work in cross-builds
+# dpkg-dev: to make pkg-config work in cross-builds
 # llvm: for llvm-symbolizer, which is used by clang's UBSan for symbolized stack traces
 RUN apt-get update && apt-get install --no-install-recommends -y \
         git ca-certificates \


### PR DESCRIPTION
Corrects the spelling of "dpkg-dev" in a comment within the Dockerfile.

The comment explains the reason for installing the `dpkg-dev` package..

