### PR TITLE
Update `hashes` to `0.16.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -24,16 +24,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.2"
+name = "bitcoin-internals"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+checksum = "2b854212e29b96c8f0fe04cab11d57586c8f3257de0d146c76cb3b42b3eb9118"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26792cd2bf245069a1c5acb06aa7ad7abe1de69b507c90b490bca81e0665d0ee"
+dependencies = [
+ "bitcoin-internals",
+]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+checksum = "7e5d09f16329cd545d7e6008b2c6b2af3a90bc678cf41ac3d2f6755943301b16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -107,9 +116,9 @@ checksum = "ee6c0438de3ca4d8cac2eec62b228e2f8865cfe9ebefea720406774223fa2d2e"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -24,16 +24,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.2"
+name = "bitcoin-internals"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+checksum = "2b854212e29b96c8f0fe04cab11d57586c8f3257de0d146c76cb3b42b3eb9118"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26792cd2bf245069a1c5acb06aa7ad7abe1de69b507c90b490bca81e0665d0ee"
+dependencies = [
+ "bitcoin-internals",
+]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+checksum = "7e5d09f16329cd545d7e6008b2c6b2af3a90bc678cf41ac3d2f6755943301b16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -101,9 +110,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ arbitrary = ["dep:arbitrary"]
 secp256k1-sys = { version = "0.11.0", default-features = false, path = "./secp256k1-sys" }
 
 arbitrary = { version = "1.4", optional = true }
-hashes = { package = "bitcoin_hashes", version = "0.14", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", version = "0.16", default-features = false, optional = true }
 rand = { version = "0.9", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, optional = true }
 

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -1,7 +1,7 @@
 extern crate hashes;
 extern crate secp256k1;
 
-use hashes::{sha256, Hash};
+use hashes::sha256;
 use secp256k1::{ecdsa, Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verification};
 
 fn verify<C: Verification>(

--- a/examples/sign_verify_recovery.rs
+++ b/examples/sign_verify_recovery.rs
@@ -1,7 +1,7 @@
 extern crate hashes;
 extern crate secp256k1;
 
-use hashes::{sha256, Hash};
+use hashes::sha256;
 use secp256k1::{ecdsa, Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verification};
 
 fn recover<C: Verification>(

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -14,7 +14,7 @@ macro_rules! impl_display_secret {
         #[cfg(feature = "hashes")]
         impl ::core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                use hashes::{sha256, Hash, HashEngine};
+                use hashes::{sha256, HashEngine};
 
                 let tag = "rust-secp256k1DEBUG";
 
@@ -25,7 +25,7 @@ macro_rules! impl_display_secret {
                 engine.input(&self.secret_bytes());
                 let hash = sha256::Hash::from_engine(engine);
 
-                f.debug_tuple(stringify!($thing)).field(&format_args!("#{:.16}", hash)).finish()
+                f.debug_tuple(stringify!($thing)).field(&format_args!("{:?}", hash)).finish()
             }
         }
 


### PR DESCRIPTION
The `0.15.0` was a massive release for `hashes` in terms of API clean up and also adding new HKDF support. ElligatorSwift in combination with HKDF are the primitives required for encrypted message passing on bitcoin, so exporting these in tandum would save an additional `hashes` dependency.

I skip to `0.16.0` because `hashes` allows for `hex-conservative` as an optional dependency, and no listed changes elsewhere.

Reducing the scope of #783 and will take a stab at `rand` later.