### PR TITLE
Enable `hashes` "alloc" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["std"]
 std = ["alloc", "secp256k1-sys/std", "rand?/std", "rand?/std_rng", "rand?/thread_rng", "hashes?/std"]
 # allow use of Secp256k1::new and related API that requires an allocator
-alloc = ["secp256k1-sys/alloc"]
+alloc = ["secp256k1-sys/alloc", "hashes?/alloc"]
 recovery = ["secp256k1-sys/recovery"]
 lowmemory = ["secp256k1-sys/lowmemory"]
 global-context = ["std"]


### PR DESCRIPTION
The feature enabling is borked at the moment. "alloc" should enabled "alloc" ifn optional `hashes` dependency.

The bug is not showing up, my best guess is because in `hashes v0.14` we probably had feature gating nested in macros called across crate boundary's and were either getting or not getting code that we thought we should or shouldn't - what ever the case may be.

<insert rand about macros here>

In order to upgrade to `hashes 0.16.0` we need to fix this.