### PR TITLE
Change `Debug` implementation for `SecretKey`

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -78,6 +78,20 @@ impl SharedSecret {
     }
 }
 
+impl ffi::CPtr for SharedSecret {
+    type Target = u8;
+
+    fn as_c_ptr(&self) -> *const Self::Target {
+        let SharedSecret(dat) = self;
+        dat.as_ptr()
+    }
+
+    fn as_mut_c_ptr(&mut self) -> *mut Self::Target {
+        let &mut SharedSecret(ref mut dat) = self;
+        dat.as_mut_ptr()
+    }
+}
+
 impl str::FromStr for SharedSecret {
     type Err = Error;
     fn from_str(s: &str) -> Result<SharedSecret, Error> {


### PR DESCRIPTION
The only purpose of `hashes` in this crate is to blind secret keys when implementing `Debug`. By using a different blinding function, particularly one in `ffi`, we may remove `hashes` entirely. Notably, since there is no longer a feature requirement, all users would get a `Debug` implementation with a finger print.

I have more questions than I do solutions. Why is this function pointer an `Option`? When getting the nonce, how do we want to display it? Does the message parameter matter?