### PR TITLE
Remove context from the API

### DIFF
--- a/examples/generate_keys.rs
+++ b/examples/generate_keys.rs
@@ -8,9 +8,9 @@ fn main() {
     // First option:
     let (seckey, pubkey) = secp.generate_keypair(&mut rng);
 
-    assert_eq!(pubkey, PublicKey::from_secret_key(&secp, &seckey));
+    assert_eq!(pubkey, PublicKey::from_secret_key(&seckey));
 
     // Second option:
     let seckey = SecretKey::new(&mut rng);
-    let _pubkey = PublicKey::from_secret_key(&secp, &seckey);
+    let _pubkey = PublicKey::from_secret_key(&seckey);
 }

--- a/examples/generate_keys.rs
+++ b/examples/generate_keys.rs
@@ -1,12 +1,11 @@
 extern crate secp256k1;
 
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{PublicKey, SecretKey};
 
 fn main() {
-    let secp = Secp256k1::new();
     let mut rng = rand::rng();
     // First option:
-    let (seckey, pubkey) = secp.generate_keypair(&mut rng);
+    let (seckey, pubkey) = secp256k1::generate_keypair(&mut rng);
 
     assert_eq!(pubkey, PublicKey::from_secret_key(&seckey));
 

--- a/examples/musig.rs
+++ b/examples/musig.rs
@@ -10,7 +10,7 @@ fn main() {
     let secp = Secp256k1::new();
     let mut rng = rand::rng();
 
-    let (seckey1, pubkey1) = secp.generate_keypair(&mut rng);
+    let (seckey1, pubkey1) = secp256k1::generate_keypair(&mut rng);
 
     let seckey2 = SecretKey::new(&mut rng);
     let pubkey2 = PublicKey::from_secret_key(&seckey2);
@@ -76,10 +76,10 @@ fn main() {
 
     let session = Session::new(&secp, &musig_key_agg_cache, agg_nonce, msg);
 
-    let keypair1 = Keypair::from_secret_key(&secp, &seckey1);
+    let keypair1 = Keypair::from_secret_key(&seckey1);
     let partial_sign1 = session.partial_sign(&secp, sec_nonce1, &keypair1, &musig_key_agg_cache);
 
-    let keypair2 = Keypair::from_secret_key(&secp, &seckey2);
+    let keypair2 = Keypair::from_secret_key(&seckey2);
     let partial_sign2 = session.partial_sign(&secp, sec_nonce2, &keypair2, &musig_key_agg_cache);
 
     let is_partial_signature_valid =

--- a/examples/musig.rs
+++ b/examples/musig.rs
@@ -96,5 +96,5 @@ fn main() {
 
     let aggregated_signature = session.partial_sig_agg(partial_sigs_ref);
 
-    assert!(aggregated_signature.verify(&secp, &agg_pk, msg).is_ok());
+    assert!(aggregated_signature.verify(&agg_pk, msg).is_ok());
 }

--- a/examples/musig.rs
+++ b/examples/musig.rs
@@ -21,16 +21,16 @@ fn main() {
 
     secp.sort_pubkeys(pubkeys_ref);
 
-    let mut musig_key_agg_cache = KeyAggCache::new(&secp, pubkeys_ref);
+    let mut musig_key_agg_cache = KeyAggCache::new(pubkeys_ref);
 
     let plain_tweak: [u8; 32] = *b"this could be a BIP32 tweak....\0";
     let xonly_tweak: [u8; 32] = *b"this could be a Taproot tweak..\0";
 
     let plain_tweak = Scalar::from_be_bytes(plain_tweak).unwrap();
-    musig_key_agg_cache.pubkey_ec_tweak_add(&secp, &plain_tweak).unwrap();
+    musig_key_agg_cache.pubkey_ec_tweak_add(&plain_tweak).unwrap();
 
     let xonly_tweak = Scalar::from_be_bytes(xonly_tweak).unwrap();
-    let tweaked_agg_pk = musig_key_agg_cache.pubkey_xonly_tweak_add(&secp, &xonly_tweak).unwrap();
+    let tweaked_agg_pk = musig_key_agg_cache.pubkey_xonly_tweak_add(&xonly_tweak).unwrap();
 
     let agg_pk = musig_key_agg_cache.agg_pk();
 
@@ -41,7 +41,6 @@ fn main() {
     let musig_session_sec_rand1 = SessionSecretRand::from_rng(&mut rng);
 
     let nonce_pair1 = new_nonce_pair(
-        &secp,
         musig_session_sec_rand1,
         Some(&musig_key_agg_cache),
         Some(seckey1),
@@ -53,7 +52,6 @@ fn main() {
     let musig_session_sec_rand2 = SessionSecretRand::from_rng(&mut rng);
 
     let nonce_pair2 = new_nonce_pair(
-        &secp,
         musig_session_sec_rand2,
         Some(&musig_key_agg_cache),
         Some(seckey2),
@@ -72,22 +70,22 @@ fn main() {
     let nonces_ref: Vec<&PublicNonce> = nonces.iter().collect();
     let nonces_ref = nonces_ref.as_slice();
 
-    let agg_nonce = AggregatedNonce::new(&secp, nonces_ref);
+    let agg_nonce = AggregatedNonce::new(nonces_ref);
 
-    let session = Session::new(&secp, &musig_key_agg_cache, agg_nonce, msg);
+    let session = Session::new(&musig_key_agg_cache, agg_nonce, msg);
 
     let keypair1 = Keypair::from_secret_key(&seckey1);
-    let partial_sign1 = session.partial_sign(&secp, sec_nonce1, &keypair1, &musig_key_agg_cache);
+    let partial_sign1 = session.partial_sign(sec_nonce1, &keypair1, &musig_key_agg_cache);
 
     let keypair2 = Keypair::from_secret_key(&seckey2);
-    let partial_sign2 = session.partial_sign(&secp, sec_nonce2, &keypair2, &musig_key_agg_cache);
+    let partial_sign2 = session.partial_sign(sec_nonce2, &keypair2, &musig_key_agg_cache);
 
     let is_partial_signature_valid =
-        session.partial_verify(&secp, &musig_key_agg_cache, &partial_sign1, &pub_nonce1, pubkey1);
+        session.partial_verify(&musig_key_agg_cache, &partial_sign1, &pub_nonce1, pubkey1);
     assert!(is_partial_signature_valid);
 
     let is_partial_signature_valid =
-        session.partial_verify(&secp, &musig_key_agg_cache, &partial_sign2, &pub_nonce2, pubkey2);
+        session.partial_verify(&musig_key_agg_cache, &partial_sign2, &pub_nonce2, pubkey2);
     assert!(is_partial_signature_valid);
 
     let partial_sigs = [partial_sign1, partial_sign2];

--- a/examples/musig.rs
+++ b/examples/musig.rs
@@ -13,7 +13,7 @@ fn main() {
     let (seckey1, pubkey1) = secp.generate_keypair(&mut rng);
 
     let seckey2 = SecretKey::new(&mut rng);
-    let pubkey2 = PublicKey::from_secret_key(&secp, &seckey2);
+    let pubkey2 = PublicKey::from_secret_key(&seckey2);
 
     let pubkeys = [pubkey1, pubkey2];
     let mut pubkeys_ref: Vec<&PublicKey> = pubkeys.iter().collect();

--- a/examples/musig.rs
+++ b/examples/musig.rs
@@ -4,10 +4,9 @@ use secp256k1::musig::{
     new_nonce_pair, AggregatedNonce, KeyAggCache, PartialSignature, PublicNonce, Session,
     SessionSecretRand,
 };
-use secp256k1::{Keypair, PublicKey, Scalar, Secp256k1, SecretKey};
+use secp256k1::{Keypair, PublicKey, Scalar, SecretKey};
 
 fn main() {
-    let secp = Secp256k1::new();
     let mut rng = rand::rng();
 
     let (seckey1, pubkey1) = secp256k1::generate_keypair(&mut rng);
@@ -19,7 +18,7 @@ fn main() {
     let mut pubkeys_ref: Vec<&PublicKey> = pubkeys.iter().collect();
     let pubkeys_ref = pubkeys_ref.as_mut_slice();
 
-    secp.sort_pubkeys(pubkeys_ref);
+    secp256k1::sort_pubkeys(pubkeys_ref);
 
     let mut musig_key_agg_cache = KeyAggCache::new(pubkeys_ref);
 

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -15,19 +15,14 @@
 
 extern crate secp256k1;
 
-use secp256k1::{ecdsa, Error, Message, PublicKey, Secp256k1, SecretKey, Signing, Verification};
+use secp256k1::{ecdsa, Error, Message, PublicKey, Secp256k1, SecretKey, Signing};
 
-fn verify<C: Verification>(
-    secp: &Secp256k1<C>,
-    msg_digest: [u8; 32],
-    sig: [u8; 64],
-    pubkey: [u8; 33],
-) -> Result<bool, Error> {
+fn verify(sig: [u8; 64], msg_digest: [u8; 32], pubkey: [u8; 33]) -> Result<bool, Error> {
     let msg = Message::from_digest(msg_digest);
     let sig = ecdsa::Signature::from_compact(&sig)?;
     let pubkey = PublicKey::from_slice(&pubkey)?;
 
-    Ok(secp.verify_ecdsa(&sig, msg, &pubkey).is_ok())
+    Ok(ecdsa::verify(&sig, msg, &pubkey).is_ok())
 }
 
 fn sign<C: Signing>(
@@ -57,5 +52,5 @@ fn main() {
 
     let serialize_sig = signature.serialize_compact();
 
-    assert!(verify(&secp, msg_digest, serialize_sig, pubkey).unwrap());
+    assert!(verify(serialize_sig, msg_digest, pubkey).unwrap());
 }

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -15,7 +15,7 @@
 
 extern crate secp256k1;
 
-use secp256k1::{ecdsa, Error, Message, PublicKey, Secp256k1, SecretKey, Signing};
+use secp256k1::{ecdsa, Error, Message, PublicKey, SecretKey};
 
 fn verify(sig: [u8; 64], msg_digest: [u8; 32], pubkey: [u8; 33]) -> Result<bool, Error> {
     let msg = Message::from_digest(msg_digest);
@@ -25,19 +25,13 @@ fn verify(sig: [u8; 64], msg_digest: [u8; 32], pubkey: [u8; 33]) -> Result<bool,
     Ok(ecdsa::verify(&sig, msg, &pubkey).is_ok())
 }
 
-fn sign<C: Signing>(
-    secp: &Secp256k1<C>,
-    msg_digest: [u8; 32],
-    seckey: [u8; 32],
-) -> Result<ecdsa::Signature, Error> {
+fn sign(msg_digest: [u8; 32], seckey: [u8; 32]) -> Result<ecdsa::Signature, Error> {
     let msg = Message::from_digest(msg_digest);
     let seckey = SecretKey::from_secret_bytes(seckey)?;
-    Ok(secp.sign_ecdsa(msg, &seckey))
+    Ok(ecdsa::sign(msg, &seckey))
 }
 
 fn main() {
-    let secp = Secp256k1::new();
-
     let seckey = [
         59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94, 203, 174, 253,
         102, 39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28,
@@ -48,7 +42,7 @@ fn main() {
     ];
     let msg_digest = *b"this must be secure hash output.";
 
-    let signature = sign(&secp, msg_digest, seckey).unwrap();
+    let signature = sign(msg_digest, seckey).unwrap();
 
     let serialize_sig = signature.serialize_compact();
 

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -83,10 +83,10 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
     let sig = secp.sign_ecdsa(message, &secret_key);
-    assert!(secp.verify_ecdsa(&sig, message, &public_key).is_ok());
+    assert!(ecdsa::verify(&sig, message, &public_key).is_ok());
 
     let rec_sig = ecdsa::RecoverableSignature::sign_ecdsa_recoverable(message, &secret_key);
-    assert!(secp.verify_ecdsa(&rec_sig.to_standard(), message, &public_key).is_ok());
+    assert!(ecdsa::verify(&rec_sig.to_standard(), message, &public_key).is_ok());
     assert_eq!(public_key, rec_sig.recover_ecdsa(message).unwrap());
     let (rec_id, data) = rec_sig.serialize_compact();
     let new_rec_sig = ecdsa::RecoverableSignature::from_compact(&data, rec_id).unwrap();
@@ -110,7 +110,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
         let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
         let sig = secp_alloc.sign_ecdsa(message, &secret_key);
-        assert!(secp_alloc.verify_ecdsa(&sig, message, &public_key).is_ok());
+        assert!(ecdsa::verify(&sig, message, &public_key).is_ok());
         unsafe { libc::printf("Verified alloc Successfully!\n\0".as_ptr() as _) };
     }
 

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -79,7 +79,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     let mut secp = Secp256k1::preallocated_new(&mut buf).unwrap();
     secp.randomize(&mut FakeRng);
     let secret_key = SecretKey::new(&mut FakeRng);
-    let public_key = PublicKey::from_secret_key(&secp, &secret_key);
+    let public_key = PublicKey::from_secret_key(&secret_key);
     let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
     let sig = secp.sign_ecdsa(message, &secret_key);
@@ -106,7 +106,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     #[cfg(feature = "alloc")]
     {
         let secp_alloc = Secp256k1::new();
-        let public_key = PublicKey::from_secret_key(&secp_alloc, &secret_key);
+        let public_key = PublicKey::from_secret_key(&secret_key);
         let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
         let sig = secp_alloc.sign_ecdsa(message, &secret_key);

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -82,7 +82,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     let public_key = PublicKey::from_secret_key(&secret_key);
     let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
-    let sig = secp.sign_ecdsa(message, &secret_key);
+    let sig = ecdsa::sign(message, &secret_key);
     assert!(ecdsa::verify(&sig, message, &public_key).is_ok());
 
     let rec_sig = ecdsa::RecoverableSignature::sign_ecdsa_recoverable(message, &secret_key);
@@ -109,7 +109,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
         let public_key = PublicKey::from_secret_key(&secret_key);
         let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 
-        let sig = secp_alloc.sign_ecdsa(message, &secret_key);
+        let sig = ecdsa::sign(message, &secret_key);
         assert!(ecdsa::verify(&sig, message, &public_key).is_ok());
         unsafe { libc::printf("Verified alloc Successfully!\n\0".as_ptr() as _) };
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -38,13 +38,6 @@ pub mod global {
     ///
     /// If `rand` and `std` feature is enabled, context will have been randomized using
     /// `rng`.
-    ///
-    /// ```
-    /// # #[cfg(all(feature = "global-context", feature = "rand", feature = "std"))] {
-    /// use secp256k1::{PublicKey, SECP256K1};
-    /// let _ = SECP256K1.generate_keypair(&mut rand::rng());
-    /// # }
-    /// ```
     pub static SECP256K1: &GlobalContext = &GlobalContext { __private: () };
 
     impl Deref for GlobalContext {

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -21,11 +21,9 @@ const SHARED_SECRET_SIZE: usize = constants::SECRET_KEY_SIZE;
 ///
 /// ```
 /// # #[cfg(all(feature = "rand", feature = "std"))] {
-/// # use secp256k1::{rand, Secp256k1};
-/// # use secp256k1::ecdh::SharedSecret;
-/// let s = Secp256k1::new();
-/// let (sk1, pk1) = s.generate_keypair(&mut rand::rng());
-/// let (sk2, pk2) = s.generate_keypair(&mut rand::rng());
+/// # use secp256k1::{rand, ecdh::SharedSecret};
+/// let (sk1, pk1) = secp256k1::generate_keypair(&mut rand::rng());
+/// let (sk2, pk2) = secp256k1::generate_keypair(&mut rand::rng());
 /// let sec1 = SharedSecret::new(&pk2, &sk1);
 /// let sec2 = SharedSecret::new(&pk1, &sk2);
 /// assert_eq!(sec1, sec2);
@@ -112,11 +110,10 @@ impl AsRef<[u8]> for SharedSecret {
 /// # Examples
 /// ```ignore
 /// use bitcoin_hashes::{Hash, sha512};
-/// use secp256k1::{ecdh, rand, Secp256k1, PublicKey, SecretKey};
+/// use secp256k1::{ecdh, rand, PublicKey, SecretKey};
 ///
-/// let s = Secp256k1::new();
-/// let (sk1, pk1) = s.generate_keypair(&mut rand::rng());
-/// let (sk2, pk2) = s.generate_keypair(&mut rand::rng());
+/// let (sk1, pk1) = crate::generate_keypair(&mut rand::rng());
+/// let (sk2, pk2) = crate::generate_keypair(&mut rand::rng());
 ///
 /// let point1 = ecdh::shared_secret_point(&pk2, &sk1);
 /// let secret1 = sha512::Hash::hash(&point1);
@@ -189,7 +186,6 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     use super::SharedSecret;
-    use crate::Secp256k1;
 
     #[test]
     fn ecdh() {
@@ -251,11 +247,9 @@ mod benches {
     use test::{black_box, Bencher};
 
     use super::SharedSecret;
-    use crate::Secp256k1;
 
     #[bench]
     pub fn bench_ecdh(bh: &mut Bencher) {
-        let s = Secp256k1::signing_only();
         let (sk, pk) = s.generate_keypair(&mut rand::rng());
 
         bh.iter(|| {

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -371,7 +371,7 @@ impl<C: Verification> Secp256k1<C> {
     /// # use secp256k1::{rand, Secp256k1, Message, Error};
     /// #
     /// # let secp = Secp256k1::new();
-    /// # let (secret_key, public_key) = secp.generate_keypair(&mut rand::rng());
+    /// # let (secret_key, public_key) = secp256k1::generate_keypair(&mut rand::rng());
     /// #
     /// let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
     /// let sig = secp.sign_ecdsa(message, &secret_key);

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -248,7 +248,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
-    use super::{RecoverableSignature, RecoveryId};
+    use super::*;
     use crate::constants::ONE;
     use crate::{Error, Message, Secp256k1, SecretKey};
 

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -250,7 +250,7 @@ mod tests {
 
     use super::*;
     use crate::constants::ONE;
-    use crate::{Error, Message, Secp256k1, SecretKey};
+    use crate::{ecdsa, Error, Message, Secp256k1, SecretKey};
 
     #[test]
     fn capabilities() {
@@ -313,8 +313,6 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn sign_and_verify_fail() {
-        let s = Secp256k1::new();
-
         let msg = Message::from_digest(crate::test_random_32_bytes());
         let (sk, pk) = crate::test_random_keypair();
 
@@ -322,7 +320,7 @@ mod tests {
         let sig = sigr.to_standard();
 
         let msg = Message::from_digest(crate::test_random_32_bytes());
-        assert_eq!(s.verify_ecdsa(&sig, msg, &pk), Err(Error::IncorrectSignature));
+        assert_eq!(ecdsa::verify(&sig, msg, &pk), Err(Error::IncorrectSignature));
 
         let recovered_key = sigr.recover_ecdsa(msg).unwrap();
         assert!(recovered_key != pk);

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -250,7 +250,7 @@ mod tests {
 
     use super::*;
     use crate::constants::ONE;
-    use crate::{ecdsa, Error, Message, Secp256k1, SecretKey};
+    use crate::{ecdsa, Error, Message, SecretKey};
 
     #[test]
     fn capabilities() {

--- a/src/ecdsa/serialized_signature.rs
+++ b/src/ecdsa/serialized_signature.rs
@@ -266,7 +266,7 @@ mod into_iter {
 
 #[cfg(test)]
 mod tests {
-    use super::{SerializedSignature, MAX_LEN};
+    use super::*;
 
     #[test]
     fn iterator_ops_are_homomorphic() {

--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -138,10 +138,9 @@ impl ElligatorSwift {
     /// # Example
     /// ```
     /// # #[cfg(feature = "alloc")] {
-    ///     use secp256k1::{ellswift::ElligatorSwift, PublicKey, Secp256k1, SecretKey};
-    ///     let secp = Secp256k1::new();
+    ///     use secp256k1::{ellswift::ElligatorSwift, PublicKey, SecretKey};
     ///     let sk = SecretKey::from_secret_bytes([1; 32]).unwrap();
-    ///     let pk = PublicKey::from_secret_key(&secp, &sk);
+    ///     let pk = PublicKey::from_secret_key(&sk);
     ///     let es = ElligatorSwift::from_pubkey(pk);
     /// # }
     ///
@@ -375,9 +374,8 @@ mod tests {
     #[cfg(all(not(secp256k1_fuzz), feature = "alloc"))]
     fn test_elligator_swift_rtt() {
         // Test that we can round trip an ElligatorSwift encoding
-        let secp = crate::Secp256k1::new();
         let public_key =
-            PublicKey::from_secret_key(&secp, &SecretKey::from_secret_bytes([1u8; 32]).unwrap());
+            PublicKey::from_secret_key(&SecretKey::from_secret_bytes([1u8; 32]).unwrap());
 
         let ell = ElligatorSwift::from_pubkey(public_key);
         let pk = PublicKey::from_ellswift(ell);
@@ -393,8 +391,7 @@ mod tests {
         let ell =
             ElligatorSwift::from_seckey(&secp, SecretKey::from_secret_bytes(rand32).unwrap(), None);
         let pk = PublicKey::from_ellswift(ell);
-        let expected =
-            PublicKey::from_secret_key(&secp, &SecretKey::from_secret_bytes(priv32).unwrap());
+        let expected = PublicKey::from_secret_key(&SecretKey::from_secret_bytes(priv32).unwrap());
 
         assert_eq!(pk, expected);
     }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -416,13 +416,8 @@ impl PublicKey {
     }
 
     /// Checks that `sig` is a valid ECDSA signature for `msg` using this public key.
-    pub fn verify<C: Verification>(
-        &self,
-        secp: &Secp256k1<C>,
-        msg: impl Into<Message>,
-        sig: &ecdsa::Signature,
-    ) -> Result<(), Error> {
-        secp.verify_ecdsa(sig, msg, self)
+    pub fn verify(&self, msg: impl Into<Message>, sig: &ecdsa::Signature) -> Result<(), Error> {
+        ecdsa::verify(sig, msg, self)
     }
 }
 
@@ -1110,11 +1105,10 @@ impl XOnlyPublicKey {
     /// Checks that `sig` is a valid schnorr signature for `msg` using this public key.
     pub fn verify<C: Verification>(
         &self,
-        secp: &Secp256k1<C>,
         msg: &[u8],
         sig: &schnorr::Signature,
     ) -> Result<(), Error> {
-        secp.verify_schnorr(sig, msg, self)
+        schnorr::verify(sig, msg, self)
     }
 }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -19,8 +19,6 @@ use crate::ellswift::ElligatorSwift;
 use crate::ffi::types::c_uint;
 use crate::ffi::{self, CPtr};
 use crate::Error::{self, InvalidPublicKey, InvalidPublicKeySum};
-#[cfg(feature = "global-context")]
-use crate::SECP256K1;
 use crate::{constants, ecdsa, from_hex, schnorr, Message, Scalar, Secp256k1, Verification};
 
 /// Public key - used to verify ECDSA signatures and to do Taproot tweaks.
@@ -712,19 +710,15 @@ impl Keypair {
         XOnlyPublicKey::from_keypair(self)
     }
 
-    /// Constructs a schnorr signature for `msg` using the global [`SECP256K1`] context.
+    /// Constructs a schnorr signature for `msg`.
     #[inline]
-    #[cfg(all(feature = "global-context", feature = "rand", feature = "std"))]
-    pub fn sign_schnorr(&self, msg: &[u8]) -> schnorr::Signature {
-        SECP256K1.sign_schnorr(msg, self)
-    }
+    #[cfg(all(feature = "rand", feature = "std"))]
+    pub fn sign_schnorr(&self, msg: &[u8]) -> schnorr::Signature { schnorr::sign(msg, self) }
 
-    /// Constructs a schnorr signature without aux rand for `msg` using the global
-    /// [`SECP256K1`] context.
+    /// Constructs a schnorr signature without aux rand for `msg`.
     #[inline]
-    #[cfg(all(feature = "global-context", feature = "std"))]
     pub fn sign_schnorr_no_aux_rand(&self, msg: &[u8]) -> schnorr::Signature {
-        SECP256K1.sign_schnorr_no_aux_rand(msg, self)
+        schnorr::sign_no_aux_rand(msg, self)
     }
 
     /// Attempts to erase the secret within the underlying array.

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -1387,7 +1387,7 @@ mod test {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
-    use super::{Keypair, Parity, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey, *};
+    use super::*;
     use crate::Error::{InvalidPublicKey, InvalidSecretKey};
     use crate::{constants, from_hex, to_hex, Scalar};
 

--- a/src/key/secret.rs
+++ b/src/key/secret.rs
@@ -7,10 +7,7 @@ use core::{ops, str};
 use serde::ser::SerializeTuple;
 
 use crate::ffi::CPtr as _;
-use crate::{
-    constants, ffi, from_hex, Error, Keypair, Parity, PublicKey, Scalar, Secp256k1, Signing,
-    XOnlyPublicKey,
-};
+use crate::{constants, ffi, from_hex, Error, Keypair, Parity, PublicKey, Scalar, XOnlyPublicKey};
 #[cfg(feature = "global-context")]
 use crate::{ecdsa, Message, SECP256K1};
 
@@ -193,10 +190,9 @@ impl SecretKey {
     ///
     /// ```
     /// # #[cfg(all(feature = "rand", feature = "std"))] {
-    /// use secp256k1::{rand, Secp256k1, SecretKey, Keypair};
+    /// use secp256k1::{rand, SecretKey, Keypair};
     ///
-    /// let secp = Secp256k1::new();
-    /// let keypair = Keypair::new(&secp, &mut rand::rng());
+    /// let keypair = Keypair::new(&mut rand::rng());
     /// let secret_key = SecretKey::from_keypair(&keypair);
     /// # }
     /// ```
@@ -286,9 +282,7 @@ impl SecretKey {
     ///
     /// This is equivalent to using [`Keypair::from_secret_key`].
     #[inline]
-    pub fn keypair<C: Signing>(&self, secp: &Secp256k1<C>) -> Keypair {
-        Keypair::from_secret_key(secp, self)
-    }
+    pub fn keypair(&self) -> Keypair { Keypair::from_secret_key(self) }
 
     /// Returns the [`PublicKey`] for this [`SecretKey`].
     ///
@@ -300,8 +294,8 @@ impl SecretKey {
     ///
     /// This is equivalent to `XOnlyPublicKey::from_keypair(self.keypair(secp))`.
     #[inline]
-    pub fn x_only_public_key<C: Signing>(&self, secp: &Secp256k1<C>) -> (XOnlyPublicKey, Parity) {
-        let kp = self.keypair(secp);
+    pub fn x_only_public_key(&self) -> (XOnlyPublicKey, Parity) {
+        let kp = self.keypair();
         XOnlyPublicKey::from_keypair(&kp)
     }
 

--- a/src/key/secret.rs
+++ b/src/key/secret.rs
@@ -294,9 +294,7 @@ impl SecretKey {
     ///
     /// This is equivalent to using [`PublicKey::from_secret_key`].
     #[inline]
-    pub fn public_key<C: Signing>(&self, secp: &Secp256k1<C>) -> PublicKey {
-        PublicKey::from_secret_key(secp, self)
-    }
+    pub fn public_key(&self) -> PublicKey { PublicKey::from_secret_key(self) }
 
     /// Returns the [`XOnlyPublicKey`] (and its [`Parity`]) for this [`SecretKey`].
     ///

--- a/src/key/secret.rs
+++ b/src/key/secret.rs
@@ -42,9 +42,8 @@ mod encapsulate {
     ///
     /// ```
     /// # #[cfg(all(feature = "rand", feature = "std"))] {
-    /// use secp256k1::{rand, Secp256k1, SecretKey};
+    /// use secp256k1::{rand, SecretKey};
     ///
-    /// let secp = Secp256k1::new();
     /// let secret_key = SecretKey::new(&mut rand::rng());
     /// # }
     /// ```

--- a/src/key/secret.rs
+++ b/src/key/secret.rs
@@ -7,9 +7,10 @@ use core::{ops, str};
 use serde::ser::SerializeTuple;
 
 use crate::ffi::CPtr as _;
-use crate::{constants, ffi, from_hex, Error, Keypair, Parity, PublicKey, Scalar, XOnlyPublicKey};
-#[cfg(feature = "global-context")]
-use crate::{ecdsa, Message, SECP256K1};
+use crate::{
+    constants, ecdsa, ffi, from_hex, Error, Keypair, Message, Parity, PublicKey, Scalar,
+    XOnlyPublicKey,
+};
 
 mod encapsulate {
     use crate::constants::SECRET_KEY_SIZE;
@@ -271,12 +272,9 @@ impl SecretKey {
         }
     }
 
-    /// Constructs an ECDSA signature for `msg` using the global [`SECP256K1`] context.
+    /// Constructs an ECDSA signature for `msg`.
     #[inline]
-    #[cfg(feature = "global-context")]
-    pub fn sign_ecdsa(&self, msg: impl Into<Message>) -> ecdsa::Signature {
-        SECP256K1.sign_ecdsa(msg, self)
-    }
+    pub fn sign_ecdsa(&self, msg: impl Into<Message>) -> ecdsa::Signature { ecdsa::sign(msg, self) }
 
     /// Returns the [`Keypair`] for this [`SecretKey`].
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,9 @@ pub use crate::{
         Context, PreallocatedContext, SignOnlyPreallocated, Signing, Verification,
         VerifyOnlyPreallocated,
     },
-    key::{InvalidParityValue, Keypair, Parity, PublicKey, SecretKey, XOnlyPublicKey},
+    key::{
+        sort_pubkeys, InvalidParityValue, Keypair, Parity, PublicKey, SecretKey, XOnlyPublicKey,
+    },
     scalar::Scalar,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1063,7 +1063,7 @@ mod benches {
     use rand::rngs::mock::StepRng;
     use test::{black_box, Bencher};
 
-    use super::{Message, Secp256k1};
+    use super::*;
 
     #[bench]
     pub fn generate(bh: &mut Bencher) {

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -1226,7 +1226,7 @@ impl Session {
     ///     msg,
     /// );
     ///
-    /// let keypair = Keypair::from_secret_key(&secp, &sk1);
+    /// let keypair = Keypair::from_secret_key(&sk1);
     /// let partial_sig1 = session.partial_sign(
     ///     &secp,
     ///     sec_nonce1,
@@ -1311,7 +1311,7 @@ impl Session {
     /// let partial_sig1 = session.partial_sign(
     ///     &secp,
     ///     sec_nonce1,
-    ///     &Keypair::from_secret_key(&secp, &sk1),
+    ///     &Keypair::from_secret_key(&sk1),
     ///     &key_agg_cache,
     /// ).unwrap();
     ///
@@ -1319,7 +1319,7 @@ impl Session {
     /// let partial_sig2 = session.partial_sign(
     ///     &secp,
     ///     sec_nonce2,
-    ///     &Keypair::from_secret_key(&secp, &sk2),
+    ///     &Keypair::from_secret_key(&sk2),
     ///     &key_agg_cache,
     /// ).unwrap();
     ///
@@ -1581,10 +1581,10 @@ mod tests {
         let session = Session::new(&secp, &key_agg_cache, agg_nonce, msg);
 
         // Test partial signing
-        let keypair1 = Keypair::from_secret_key(&secp, &seckey1);
+        let keypair1 = Keypair::from_secret_key(&seckey1);
         let partial_sign1 = session.partial_sign(&secp, sec_nonce1, &keypair1, &key_agg_cache);
 
-        let keypair2 = Keypair::from_secret_key(&secp, &seckey2);
+        let keypair2 = Keypair::from_secret_key(&seckey2);
         let partial_sign2 = session.partial_sign(&secp, sec_nonce2, &keypair2, &key_agg_cache);
 
         // Test partial signature verification
@@ -1660,10 +1660,10 @@ mod tests {
         let agg_nonce = AggregatedNonce::new(&secp, &nonces);
         let session = Session::new(&secp, &key_agg_cache, agg_nonce, msg);
 
-        let keypair1 = Keypair::from_secret_key(&secp, &seckey1);
+        let keypair1 = Keypair::from_secret_key(&seckey1);
         let partial_sign1 = session.partial_sign(&secp, sec_nonce1, &keypair1, &key_agg_cache);
 
-        let keypair2 = Keypair::from_secret_key(&secp, &seckey2);
+        let keypair2 = Keypair::from_secret_key(&seckey2);
         let partial_sign2 = session.partial_sign(&secp, sec_nonce2, &keypair2, &key_agg_cache);
 
         // Test signature verification

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -13,8 +13,7 @@ use std;
 
 use crate::ffi::{self, CPtr};
 use crate::{
-    from_hex, schnorr, Error, Keypair, PublicKey, Scalar, Secp256k1, SecretKey, Signing,
-    Verification, XOnlyPublicKey,
+    from_hex, schnorr, Error, Keypair, PublicKey, Scalar, Secp256k1, SecretKey, XOnlyPublicKey,
 };
 
 /// Serialized size (in bytes) of the aggregated nonce.
@@ -147,7 +146,6 @@ impl fmt::Display for InvalidTweakErr {
 ///
 /// # Arguments:
 ///
-/// * `secp` : [`Secp256k1`] context object initialized for signing
 /// * `session_secrand`: [`SessionSecretRand`] Uniform random identifier for this session. Each call to this
 ///   function must have a UNIQUE `session_secrand`.
 /// * `sec_key`: Optional [`SecretKey`] that we will use to sign to a create partial signature. Provide this
@@ -164,9 +162,8 @@ impl fmt::Display for InvalidTweakErr {
 /// ```rust
 /// # #[cfg(feature = "std")]
 /// # #[cfg(feature = "rand")] {
-/// # use secp256k1::{PublicKey, Secp256k1, SecretKey};
+/// # use secp256k1::{PublicKey, SecretKey};
 /// # use secp256k1::musig::{new_nonce_pair, SessionSecretRand};
-/// # let secp = Secp256k1::new();
 /// // The session id must be sampled at random. Read documentation for more details.
 /// let session_secrand = SessionSecretRand::from_rng(&mut rand::rng());
 /// let sk = SecretKey::new(&mut rand::rng());
@@ -175,11 +172,10 @@ impl fmt::Display for InvalidTweakErr {
 /// // Supply extra auxiliary randomness to prevent misuse(for example, time of day)
 /// let extra_rand : Option<[u8; 32]> = None;
 ///
-/// let (_sec_nonce, _pub_nonce) = new_nonce_pair(&secp, session_secrand, None, Some(sk), pk, None, None);
+/// let (_sec_nonce, _pub_nonce) = new_nonce_pair(session_secrand, None, Some(sk), pk, None, None);
 /// # }
 /// ```
-pub fn new_nonce_pair<C: Signing>(
-    secp: &Secp256k1<C>,
+pub fn new_nonce_pair(
     mut session_secrand: SessionSecretRand,
     key_agg_cache: Option<&KeyAggCache>,
     sec_key: Option<SecretKey>,
@@ -187,11 +183,23 @@ pub fn new_nonce_pair<C: Signing>(
     msg: Option<&[u8; 32]>,
     extra_rand: Option<[u8; 32]>,
 ) -> (SecretNonce, PublicNonce) {
-    let cx = secp.ctx().as_ptr();
     let extra_ptr = extra_rand.as_ref().map(|e| e.as_ptr()).unwrap_or(core::ptr::null());
     let sk_ptr = sec_key.as_ref().map(|e| e.as_c_ptr()).unwrap_or(core::ptr::null());
     let msg_ptr = msg.as_ref().map(|e| e.as_c_ptr()).unwrap_or(core::ptr::null());
     let cache_ptr = key_agg_cache.map(|e| e.as_ptr()).unwrap_or(core::ptr::null());
+
+    let mut seed = session_secrand.to_byte_array();
+    if let Some(bytes) = sec_key {
+        for (this, that) in seed.iter_mut().zip(bytes.to_secret_bytes().iter()) {
+            *this ^= *that;
+        }
+    }
+    if let Some(bytes) = extra_rand {
+        for (this, that) in seed.iter_mut().zip(bytes.iter()) {
+            *this ^= *that;
+        }
+    }
+
     unsafe {
         // The use of a mutable pointer to `session_secrand`, which is a local variable,
         // may seem concerning/wrong. It is ok: this pointer is only mutable because the
@@ -201,18 +209,25 @@ pub fn new_nonce_pair<C: Signing>(
         // caller or anything.
         let mut sec_nonce = MaybeUninit::<ffi::MusigSecNonce>::uninit();
         let mut pub_nonce = MaybeUninit::<ffi::MusigPubNonce>::uninit();
-        if ffi::secp256k1_musig_nonce_gen(
-            cx,
-            sec_nonce.as_mut_ptr(),
-            pub_nonce.as_mut_ptr(),
-            session_secrand.as_mut_ptr(),
-            sk_ptr,
-            pub_key.as_c_ptr(),
-            msg_ptr,
-            cache_ptr,
-            extra_ptr,
-        ) == 0
-        {
+
+        let ret = crate::with_global_context(
+            |secp: &Secp256k1<crate::AllPreallocated>| {
+                ffi::secp256k1_musig_nonce_gen(
+                    secp.ctx.as_ptr(),
+                    sec_nonce.as_mut_ptr(),
+                    pub_nonce.as_mut_ptr(),
+                    session_secrand.as_mut_ptr(),
+                    sk_ptr,
+                    pub_key.as_c_ptr(),
+                    msg_ptr,
+                    cache_ptr,
+                    extra_ptr,
+                )
+            },
+            Some(&seed),
+        );
+
+        if ret == 0 {
             // Rust type system guarantees that
             // - input secret key is valid
             // - msg is 32 bytes
@@ -371,15 +386,14 @@ impl KeyAggCache {
     /// ```rust
     /// # #[cfg(feature = "std")]
     /// # #[cfg(feature = "rand")] {
-    /// # use secp256k1::{Secp256k1, SecretKey, Keypair, PublicKey};
+    /// # use secp256k1::{SecretKey, Keypair, PublicKey};
     /// # use secp256k1::musig::KeyAggCache;
-    /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     /// #
-    /// let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
+    /// let key_agg_cache = KeyAggCache::new(&[&pub_key1, &pub_key2]);
     /// let _agg_pk = key_agg_cache.agg_pk();
     /// # }
     /// ```
@@ -387,15 +401,16 @@ impl KeyAggCache {
     /// # Panics
     ///
     /// Panics if an empty slice of pubkeys is provided.
-    pub fn new<C: Verification>(secp: &Secp256k1<C>, pubkeys: &[&PublicKey]) -> Self {
+    pub fn new(pubkeys: &[&PublicKey]) -> Self {
         if pubkeys.is_empty() {
             panic!("Cannot aggregate an empty slice of pubkeys");
         }
 
-        let cx = secp.ctx().as_ptr();
-
         let mut key_agg_cache = MaybeUninit::<ffi::MusigKeyAggCache>::uninit();
         let mut agg_pk = MaybeUninit::<ffi::XOnlyPublicKey>::uninit();
+
+        // We have no seed here but we want rerandomiziation to happen for `rand` users.
+        let seed = [0_u8; 32];
 
         unsafe {
             let pubkeys_ref = core::slice::from_raw_parts(
@@ -403,14 +418,19 @@ impl KeyAggCache {
                 pubkeys.len(),
             );
 
-            if ffi::secp256k1_musig_pubkey_agg(
-                cx,
-                agg_pk.as_mut_ptr(),
-                key_agg_cache.as_mut_ptr(),
-                pubkeys_ref.as_ptr(),
-                pubkeys_ref.len(),
-            ) == 0
-            {
+            let ret = crate::with_global_context(
+                |secp: &Secp256k1<crate::AllPreallocated>| {
+                    ffi::secp256k1_musig_pubkey_agg(
+                        secp.ctx.as_ptr(),
+                        agg_pk.as_mut_ptr(),
+                        key_agg_cache.as_mut_ptr(),
+                        pubkeys_ref.as_ptr(),
+                        pubkeys_ref.len(),
+                    )
+                },
+                Some(&seed),
+            );
+            if ret == 0 {
                 // Returns 0 only if the keys are malformed that never happens in safe rust type system.
                 unreachable!("Invalid XOnlyPublicKey in input pubkeys")
             } else {
@@ -470,36 +490,38 @@ impl KeyAggCache {
     /// # #[cfg(not(secp256k1_fuzz))]
     /// # #[cfg(feature = "std")]
     /// # #[cfg(feature = "rand")] {
-    /// # use secp256k1::{Scalar, Secp256k1, SecretKey, Keypair, PublicKey};
+    /// # use secp256k1::{Scalar, SecretKey, Keypair, PublicKey};
     /// # use secp256k1::musig::KeyAggCache;
-    /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     /// #
-    /// let mut key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
+    /// let mut key_agg_cache = KeyAggCache::new(&[&pub_key1, &pub_key2]);
     ///
     /// let tweak: [u8; 32] = *b"this could be a BIP32 tweak....\0";
     /// let tweak = Scalar::from_be_bytes(tweak).unwrap();
-    /// let tweaked_key = key_agg_cache.pubkey_ec_tweak_add(&secp, &tweak).unwrap();
+    /// let tweaked_key = key_agg_cache.pubkey_ec_tweak_add(&tweak).unwrap();
     /// # }
     /// ```
-    pub fn pubkey_ec_tweak_add<C: Verification>(
-        &mut self,
-        secp: &Secp256k1<C>,
-        tweak: &Scalar,
-    ) -> Result<PublicKey, InvalidTweakErr> {
-        let cx = secp.ctx().as_ptr();
+    pub fn pubkey_ec_tweak_add(&mut self, tweak: &Scalar) -> Result<PublicKey, InvalidTweakErr> {
+        // We have no seed here but we want rerandomiziation to happen for `rand` users.
+        let seed = [0_u8; 32];
         unsafe {
             let mut out = PublicKey::from(ffi::PublicKey::new());
-            if ffi::secp256k1_musig_pubkey_ec_tweak_add(
-                cx,
-                out.as_mut_c_ptr(),
-                self.as_mut_ptr(),
-                tweak.as_c_ptr(),
-            ) == 0
-            {
+
+            let ret = crate::with_global_context(
+                |secp: &Secp256k1<crate::AllPreallocated>| {
+                    ffi::secp256k1_musig_pubkey_ec_tweak_add(
+                        secp.ctx.as_ptr(),
+                        out.as_mut_c_ptr(),
+                        self.as_mut_ptr(),
+                        tweak.as_c_ptr(),
+                    )
+                },
+                Some(&seed),
+            );
+            if ret == 0 {
                 Err(InvalidTweakErr)
             } else {
                 self.aggregated_xonly_public_key = out.x_only_public_key().0;
@@ -531,35 +553,37 @@ impl KeyAggCache {
     /// # #[cfg(not(secp256k1_fuzz))]
     /// # #[cfg(feature = "std")]
     /// # #[cfg(feature = "rand")] {
-    /// # use secp256k1::{Scalar, Secp256k1, SecretKey, Keypair, PublicKey};
+    /// # use secp256k1::{Scalar, SecretKey, Keypair, PublicKey};
     /// # use secp256k1::musig::KeyAggCache;
-    /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
-    /// let mut key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
+    /// let mut key_agg_cache = KeyAggCache::new(&[&pub_key1, &pub_key2]);
     ///
     /// let tweak = Scalar::from_be_bytes(*b"Insecure tweak, Don't use this!!").unwrap(); // tweak could be from tap
-    /// let _x_only_key_tweaked = key_agg_cache.pubkey_xonly_tweak_add(&secp, &tweak).unwrap();
+    /// let _x_only_key_tweaked = key_agg_cache.pubkey_xonly_tweak_add(&tweak).unwrap();
     /// # }
     /// ```
-    pub fn pubkey_xonly_tweak_add<C: Verification>(
-        &mut self,
-        secp: &Secp256k1<C>,
-        tweak: &Scalar,
-    ) -> Result<PublicKey, InvalidTweakErr> {
-        let cx = secp.ctx().as_ptr();
+    pub fn pubkey_xonly_tweak_add(&mut self, tweak: &Scalar) -> Result<PublicKey, InvalidTweakErr> {
+        // We have no seed here but we want rerandomiziation to happen for `rand` users.
+        let seed = [0_u8; 32];
         unsafe {
             let mut out = PublicKey::from(ffi::PublicKey::new());
-            if ffi::secp256k1_musig_pubkey_xonly_tweak_add(
-                cx,
-                out.as_mut_c_ptr(),
-                self.as_mut_ptr(),
-                tweak.as_c_ptr(),
-            ) == 0
-            {
+
+            let ret = crate::with_global_context(
+                |secp: &Secp256k1<crate::AllPreallocated>| {
+                    ffi::secp256k1_musig_pubkey_xonly_tweak_add(
+                        secp.ctx.as_ptr(),
+                        out.as_mut_c_ptr(),
+                        self.as_mut_ptr(),
+                        tweak.as_c_ptr(),
+                    )
+                },
+                Some(&seed),
+            );
+            if ret == 0 {
                 Err(InvalidTweakErr)
             } else {
                 self.aggregated_xonly_public_key = out.x_only_public_key().0;
@@ -604,27 +628,25 @@ impl KeyAggCache {
     /// ```rust
     /// # #[cfg(feature = "std")]
     /// # #[cfg(feature = "rand")] {
-    /// # use secp256k1::{Secp256k1, SecretKey, Keypair, PublicKey};
+    /// # use secp256k1::{SecretKey, Keypair, PublicKey};
     /// # use secp256k1::musig::{KeyAggCache, SessionSecretRand};
-    /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     /// #
-    /// let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
+    /// let key_agg_cache = KeyAggCache::new(&[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
     /// let session_secrand = SessionSecretRand::from_rng(&mut rand::rng());
     ///
     /// // Provide the current time for mis-use resistance
     /// let msg = b"Public message we want to sign!!";
     /// let extra_rand : Option<[u8; 32]> = None;
-    /// let (_sec_nonce, _pub_nonce) = key_agg_cache.nonce_gen(&secp, session_secrand, pub_key1, msg, extra_rand);
+    /// let (_sec_nonce, _pub_nonce) = key_agg_cache.nonce_gen(session_secrand, pub_key1, msg, extra_rand);
     /// # }
     /// ```
-    pub fn nonce_gen<C: Signing>(
+    pub fn nonce_gen(
         &self,
-        secp: &Secp256k1<C>,
         session_secrand: SessionSecretRand,
         pub_key: PublicKey,
         msg: &[u8; 32],
@@ -633,7 +655,7 @@ impl KeyAggCache {
         // The secret key here is supplied as NULL. This is okay because we supply the
         // public key and the message.
         // This makes a simple API for the user because it does not require them to pass here.
-        new_nonce_pair(secp, session_secrand, Some(self), None, pub_key, Some(msg), extra_rand)
+        new_nonce_pair(session_secrand, Some(self), None, pub_key, Some(msg), extra_rand)
     }
 
     /// Get a const pointer to the inner KeyAggCache
@@ -899,39 +921,41 @@ impl AggregatedNonce {
     /// ```rust
     /// # #[cfg(feature = "std")]
     /// # #[cfg(feature = "rand")] {
-    /// # use secp256k1::{Secp256k1, SecretKey, Keypair, PublicKey};
+    /// # use secp256k1::{SecretKey, Keypair, PublicKey};
     /// # use secp256k1::musig::{AggregatedNonce, KeyAggCache, SessionSecretRand};
-    /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
-    /// # let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
+    /// # let key_agg_cache = KeyAggCache::new(&[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
     ///
     /// let msg = b"Public message we want to sign!!";
     ///
     /// let session_secrand1 = SessionSecretRand::from_rng(&mut rand::rng());
-    /// let (_sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(&secp, session_secrand1, pub_key1, msg, None);
+    /// let (_sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(session_secrand1, pub_key1, msg, None);
     ///
     /// // Signer two does the same: Possibly on a different device
     /// let session_secrand2 = SessionSecretRand::from_rng(&mut rand::rng());
-    /// let (_sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(&secp, session_secrand2, pub_key2, msg, None);
+    /// let (_sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(session_secrand2, pub_key2, msg, None);
     ///
-    /// let aggnonce = AggregatedNonce::new(&secp, &[&pub_nonce1, &pub_nonce2]);
+    /// let aggnonce = AggregatedNonce::new(&[&pub_nonce1, &pub_nonce2]);
     /// # }
     /// ```
     /// # Panics
     ///
     /// Panics if an empty slice of nonces is provided.
     ///
-    pub fn new<C: Signing>(secp: &Secp256k1<C>, nonces: &[&PublicNonce]) -> Self {
+    pub fn new(nonces: &[&PublicNonce]) -> Self {
         if nonces.is_empty() {
             panic!("Cannot aggregate an empty slice of nonces");
         }
 
         let mut aggnonce = MaybeUninit::<ffi::MusigAggNonce>::uninit();
+
+        // We have no seed here but we want rerandomiziation to happen for `rand` users.
+        let seed = [0_u8; 32];
 
         unsafe {
             let pubnonces = core::slice::from_raw_parts(
@@ -939,13 +963,18 @@ impl AggregatedNonce {
                 nonces.len(),
             );
 
-            if ffi::secp256k1_musig_nonce_agg(
-                secp.ctx().as_ptr(),
-                aggnonce.as_mut_ptr(),
-                pubnonces.as_ptr(),
-                pubnonces.len(),
-            ) == 0
-            {
+            let ret = crate::with_global_context(
+                |secp: &Secp256k1<crate::AllPreallocated>| {
+                    ffi::secp256k1_musig_nonce_agg(
+                        secp.ctx().as_ptr(),
+                        aggnonce.as_mut_ptr(),
+                        pubnonces.as_ptr(),
+                        pubnonces.len(),
+                    )
+                },
+                Some(&seed),
+            );
+            if ret == 0 {
                 // This can only crash if the individual nonces are invalid which is not possible is rust.
                 // Note that even if aggregate nonce is point at infinity, the musig spec sets it as `G`
                 unreachable!("Public key nonces are well-formed and valid in rust typesystem")
@@ -1059,15 +1088,14 @@ impl Session {
     /// ```rust
     /// # #[cfg(feature = "std")]
     /// # #[cfg(feature = "rand")] {
-    /// # use secp256k1::{Secp256k1, SecretKey, Keypair, PublicKey};
+    /// # use secp256k1::{SecretKey, Keypair, PublicKey};
     /// # use secp256k1::musig::{AggregatedNonce, KeyAggCache, Session, SessionSecretRand};
-    /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
-    /// # let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
+    /// # let key_agg_cache = KeyAggCache::new(&[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
     ///
     /// let msg = b"Public message we want to sign!!";
@@ -1075,40 +1103,42 @@ impl Session {
     /// // Provide the current time for mis-use resistance
     /// let session_secrand1 = SessionSecretRand::from_rng(&mut rand::rng());
     /// let extra_rand1 : Option<[u8; 32]> = None;
-    /// let (_sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(&secp, session_secrand1, pub_key1, msg, extra_rand1);
+    /// let (_sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(session_secrand1, pub_key1, msg, extra_rand1);
     ///
     /// // Signer two does the same. Possibly on a different device
     /// let session_secrand2 = SessionSecretRand::from_rng(&mut rand::rng());
     /// let extra_rand2 : Option<[u8; 32]> = None;
-    /// let (_sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(&secp, session_secrand2, pub_key2, msg, extra_rand2);
+    /// let (_sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(session_secrand2, pub_key2, msg, extra_rand2);
     ///
-    /// let aggnonce = AggregatedNonce::new(&secp, &[&pub_nonce1, &pub_nonce2]);
+    /// let aggnonce = AggregatedNonce::new(&[&pub_nonce1, &pub_nonce2]);
     ///
     /// let session = Session::new(
-    ///     &secp,
     ///     &key_agg_cache,
     ///     aggnonce,
     ///     msg,
     /// );
     /// # }
     /// ```
-    pub fn new<C: Signing>(
-        secp: &Secp256k1<C>,
-        key_agg_cache: &KeyAggCache,
-        agg_nonce: AggregatedNonce,
-        msg: &[u8; 32],
-    ) -> Self {
+    pub fn new(key_agg_cache: &KeyAggCache, agg_nonce: AggregatedNonce, msg: &[u8; 32]) -> Self {
         let mut session = MaybeUninit::<ffi::MusigSession>::uninit();
 
+        // We have no seed here but we want rerandomiziation to happen for `rand` users.
+        let seed = [0_u8; 32];
+
         unsafe {
-            if ffi::secp256k1_musig_nonce_process(
-                secp.ctx().as_ptr(),
-                session.as_mut_ptr(),
-                agg_nonce.as_ptr(),
-                msg.as_c_ptr(),
-                key_agg_cache.as_ptr(),
-            ) == 0
-            {
+            let ret = crate::with_global_context(
+                |secp: &Secp256k1<crate::AllPreallocated>| {
+                    ffi::secp256k1_musig_nonce_process(
+                        secp.ctx().as_ptr(),
+                        session.as_mut_ptr(),
+                        agg_nonce.as_ptr(),
+                        msg.as_c_ptr(),
+                        key_agg_cache.as_ptr(),
+                    )
+                },
+                Some(&seed),
+            );
+            if ret == 0 {
                 // Only fails on cryptographically unreachable codes or if the args are invalid.
                 // None of which can occur in safe rust.
                 unreachable!("Impossible to construct invalid arguments in safe rust.
@@ -1141,23 +1171,29 @@ impl Session {
     ///
     /// - If the provided [`SecretNonce`] has already been used for signing
     ///
-    pub fn partial_sign<C: Signing>(
+    pub fn partial_sign(
         &self,
-        secp: &Secp256k1<C>,
         mut secnonce: SecretNonce,
         keypair: &Keypair,
         key_agg_cache: &KeyAggCache,
     ) -> PartialSignature {
+        // We have no seed here but we want rerandomiziation to happen for `rand` users.
+        let seed = [0_u8; 32];
         unsafe {
             let mut partial_sig = MaybeUninit::<ffi::MusigPartialSignature>::uninit();
 
-            let res = ffi::secp256k1_musig_partial_sign(
-                secp.ctx().as_ptr(),
-                partial_sig.as_mut_ptr(),
-                secnonce.as_mut_ptr(),
-                keypair.as_c_ptr(),
-                key_agg_cache.as_ptr(),
-                self.as_ptr(),
+            let res = crate::with_global_context(
+                |secp: &Secp256k1<crate::AllPreallocated>| {
+                    ffi::secp256k1_musig_partial_sign(
+                        secp.ctx().as_ptr(),
+                        partial_sig.as_mut_ptr(),
+                        secnonce.as_mut_ptr(),
+                        keypair.as_c_ptr(),
+                        key_agg_cache.as_ptr(),
+                        self.as_ptr(),
+                    )
+                },
+                Some(&seed),
             );
 
             assert_eq!(res, 1);
@@ -1195,31 +1231,29 @@ impl Session {
     /// # #[cfg(not(secp256k1_fuzz))]
     /// # #[cfg(feature = "std")]
     /// # #[cfg(feature = "rand")] {
-    /// # use secp256k1::{Secp256k1, SecretKey, Keypair, PublicKey};
+    /// # use secp256k1::{SecretKey, Keypair, PublicKey};
     /// # use secp256k1::musig::{AggregatedNonce, KeyAggCache, SessionSecretRand, Session};
-    /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
-    /// # let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
+    /// # let key_agg_cache = KeyAggCache::new(&[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
     ///
     /// let msg = b"Public message we want to sign!!";
     ///
     /// // Provide the current time for mis-use resistance
     /// let session_secrand1 = SessionSecretRand::from_rng(&mut rand::rng());
-    /// let (mut sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(&secp, session_secrand1, pub_key1, msg, None);
+    /// let (mut sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(session_secrand1, pub_key1, msg, None);
     ///
     /// // Signer two does the same. Possibly on a different device
     /// let session_secrand2 = SessionSecretRand::from_rng(&mut rand::rng());
-    /// let (_sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(&secp, session_secrand2, pub_key2, msg, None);
+    /// let (_sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(session_secrand2, pub_key2, msg, None);
     ///
-    /// let aggnonce = AggregatedNonce::new(&secp, &[&pub_nonce1, &pub_nonce2]);
+    /// let aggnonce = AggregatedNonce::new(&[&pub_nonce1, &pub_nonce2]);
     ///
     /// let session = Session::new(
-    ///     &secp,
     ///     &key_agg_cache,
     ///     aggnonce,
     ///     msg,
@@ -1227,14 +1261,12 @@ impl Session {
     ///
     /// let keypair = Keypair::from_secret_key(&sk1);
     /// let partial_sig1 = session.partial_sign(
-    ///     &secp,
     ///     sec_nonce1,
     ///     &keypair,
     ///     &key_agg_cache,
     /// );
     ///
     /// assert!(session.partial_verify(
-    ///     &secp,
     ///     &key_agg_cache,
     ///     &partial_sig1,
     ///     &pub_nonce1,
@@ -1242,24 +1274,30 @@ impl Session {
     /// ));
     /// # }
     /// ```
-    pub fn partial_verify<C: Signing>(
+    pub fn partial_verify(
         &self,
-        secp: &Secp256k1<C>,
         key_agg_cache: &KeyAggCache,
         partial_sig: &PartialSignature,
         pub_nonce: &PublicNonce,
         pub_key: PublicKey,
     ) -> bool {
-        let cx = secp.ctx().as_ptr();
+        // We have no seed here but we want rerandomiziation to happen for `rand` users.
+        let seed = [0_u8; 32];
         unsafe {
-            ffi::secp256k1_musig_partial_sig_verify(
-                cx,
-                partial_sig.as_ptr(),
-                pub_nonce.as_ptr(),
-                pub_key.as_c_ptr(),
-                key_agg_cache.as_ptr(),
-                self.as_ptr(),
-            ) == 1
+            let ret = crate::with_global_context(
+                |secp: &Secp256k1<crate::AllPreallocated>| {
+                    ffi::secp256k1_musig_partial_sig_verify(
+                        secp.ctx.as_ptr(),
+                        partial_sig.as_ptr(),
+                        pub_nonce.as_ptr(),
+                        pub_key.as_c_ptr(),
+                        key_agg_cache.as_ptr(),
+                        self.as_ptr(),
+                    )
+                },
+                Some(&seed),
+            );
+            ret == 1
         }
     }
 
@@ -1276,39 +1314,36 @@ impl Session {
     ///
     /// ```rust
     /// # #[cfg(feature = "rand-std")] {
-    /// # use secp256k1::{KeyAggCache, Secp256k1, SecretKey, Keypair, PublicKey, SessionSecretRand, AggregatedNonce, Session};
-    /// # let secp = Secp256k1::new();
+    /// # use secp256k1::{KeyAggCache, SecretKey, Keypair, PublicKey, SessionSecretRand, AggregatedNonce, Session};
     /// # let sk1 = SecretKey::new(&mut rand::rng());
     /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
     /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
-    /// let key_agg_cache = KeyAggCache::new(&secp, &[pub_key1, pub_key2]);
+    /// let key_agg_cache = KeyAggCache::new(&[pub_key1, pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
     ///
     /// let msg = b"Public message we want to sign!!";
     ///
     /// // Provide the current time for mis-use resistance
     /// let session_secrand1 = SessionSecretRand::from_rng(&mut rand::rng());
-    /// let (mut sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(&secp, session_secrand1, pub_key1, msg, None)
+    /// let (mut sec_nonce1, pub_nonce1) = key_agg_cache.nonce_gen(session_secrand1, pub_key1, msg, None)
     ///     .expect("non zero session id");
     ///
     /// // Signer two does the same. Possibly on a different device
     /// let session_secrand2 = SessionSecretRand::from_rng(&mut rand::rng());
-    /// let (mut sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(&secp, session_secrand2, pub_key2, msg, None)
+    /// let (mut sec_nonce2, pub_nonce2) = key_agg_cache.nonce_gen(session_secrand2, pub_key2, msg, None)
     ///     .expect("non zero session id");
     ///
-    /// let aggnonce = AggregatedNonce::new(&secp, &[pub_nonce1, pub_nonce2]);
+    /// let aggnonce = AggregatedNonce::new(&[pub_nonce1, pub_nonce2]);
     ///
     /// let session = Session::new(
-    ///     &secp,
     ///     &key_agg_cache,
     ///     aggnonce,
     ///     msg,
     /// );
     ///
     /// let partial_sig1 = session.partial_sign(
-    ///     &secp,
     ///     sec_nonce1,
     ///     &Keypair::from_secret_key(&sk1),
     ///     &key_agg_cache,
@@ -1316,7 +1351,6 @@ impl Session {
     ///
     /// // Other party creates the other partial signature
     /// let partial_sig2 = session.partial_sign(
-    ///     &secp,
     ///     sec_nonce2,
     ///     &Keypair::from_secret_key(&sk2),
     ///     &key_agg_cache,
@@ -1329,7 +1363,7 @@ impl Session {
     /// let aggregated_signature = session.partial_sig_agg(partial_sigs_ref);
     ///
     /// // Get the final schnorr signature
-    /// assert!(aggregated_signature.verify(&secp, &agg_pk, &msg_bytes).is_ok());
+    /// assert!(aggregated_signature.verify(&agg_pk, &msg_bytes).is_ok());
     /// # }
     /// ```
     ///
@@ -1377,7 +1411,7 @@ mod tests {
     use super::*;
     #[cfg(feature = "std")]
     #[cfg(feature = "rand")]
-    use crate::{PublicKey, Secp256k1};
+    use crate::PublicKey;
 
     #[test]
     #[cfg(feature = "std")]
@@ -1409,13 +1443,11 @@ mod tests {
     #[cfg(not(secp256k1_fuzz))]
     #[cfg(feature = "std")]
     fn key_agg_cache() {
-        let secp = Secp256k1::new();
-
         let (_seckey1, pubkey1) = crate::test_random_keypair();
         let (_seckey2, pubkey2) = crate::test_random_keypair();
 
         let pubkeys = [&pubkey1, &pubkey2];
-        let key_agg_cache = KeyAggCache::new(&secp, &pubkeys);
+        let key_agg_cache = KeyAggCache::new(&pubkeys);
         let agg_pk = key_agg_cache.agg_pk();
 
         // Test agg_pk_full
@@ -1427,15 +1459,13 @@ mod tests {
     #[cfg(not(secp256k1_fuzz))]
     #[cfg(feature = "std")]
     fn key_agg_cache_tweaking() {
-        let secp = Secp256k1::new();
-
         let (_seckey1, pubkey1) = crate::test_random_keypair();
         let (_seckey2, pubkey2) = crate::test_random_keypair();
 
-        let mut key_agg_cache = KeyAggCache::new(&secp, &[&pubkey1, &pubkey2]);
-        let key_agg_cache1 = KeyAggCache::new(&secp, &[&pubkey2, &pubkey1]);
-        let key_agg_cache2 = KeyAggCache::new(&secp, &[&pubkey1, &pubkey1]);
-        let key_agg_cache3 = KeyAggCache::new(&secp, &[&pubkey1, &pubkey1, &pubkey2]);
+        let mut key_agg_cache = KeyAggCache::new(&[&pubkey1, &pubkey2]);
+        let key_agg_cache1 = KeyAggCache::new(&[&pubkey2, &pubkey1]);
+        let key_agg_cache2 = KeyAggCache::new(&[&pubkey1, &pubkey1]);
+        let key_agg_cache3 = KeyAggCache::new(&[&pubkey1, &pubkey1, &pubkey2]);
         assert_ne!(key_agg_cache, key_agg_cache1); // swapped keys DOES mean not equal
         assert_ne!(key_agg_cache, key_agg_cache2); // missing keys
         assert_ne!(key_agg_cache, key_agg_cache3); // repeated key
@@ -1447,49 +1477,44 @@ mod tests {
         // Test EC tweaking
         let plain_tweak: [u8; 32] = *b"this could be a BIP32 tweak....\0";
         let plain_tweak = Scalar::from_be_bytes(plain_tweak).unwrap();
-        let tweaked_key = key_agg_cache.pubkey_ec_tweak_add(&secp, &plain_tweak).unwrap();
+        let tweaked_key = key_agg_cache.pubkey_ec_tweak_add(&plain_tweak).unwrap();
         assert_ne!(key_agg_cache.agg_pk(), original_agg_pk);
         assert_eq!(key_agg_cache.agg_pk(), tweaked_key.x_only_public_key().0);
 
         // Test xonly tweaking
         let xonly_tweak: [u8; 32] = *b"this could be a Taproot tweak..\0";
         let xonly_tweak = Scalar::from_be_bytes(xonly_tweak).unwrap();
-        let tweaked_agg_pk = key_agg_cache.pubkey_xonly_tweak_add(&secp, &xonly_tweak).unwrap();
+        let tweaked_agg_pk = key_agg_cache.pubkey_xonly_tweak_add(&xonly_tweak).unwrap();
         assert_eq!(key_agg_cache.agg_pk(), tweaked_agg_pk.x_only_public_key().0);
     }
 
     #[test]
     #[cfg(feature = "std")]
     #[should_panic(expected = "Cannot aggregate an empty slice of pubkeys")]
-    fn key_agg_cache_empty_panic() {
-        let secp = Secp256k1::new();
-        let _ = KeyAggCache::new(&secp, &[]);
-    }
+    fn key_agg_cache_empty_panic() { let _ = KeyAggCache::new(&[]); }
 
     #[test]
     #[cfg(feature = "std")]
     #[cfg(feature = "rand")]
     fn nonce_generation() {
-        let secp = Secp256k1::new();
         let mut rng = rand::rng();
 
         let (_seckey1, pubkey1) = crate::test_random_keypair();
         let (seckey2, pubkey2) = crate::test_random_keypair();
 
-        let key_agg_cache = KeyAggCache::new(&secp, &[&pubkey1, &pubkey2]);
+        let key_agg_cache = KeyAggCache::new(&[&pubkey1, &pubkey2]);
 
         let msg: &[u8; 32] = b"This message is exactly 32 bytes";
 
         // Test nonce generation with KeyAggCache
         let session_secrand1 = SessionSecretRand::from_rng(&mut rng);
         let (_sec_nonce1, pub_nonce1) =
-            key_agg_cache.nonce_gen(&secp, session_secrand1, pubkey1, msg, None);
+            key_agg_cache.nonce_gen(session_secrand1, pubkey1, msg, None);
 
         // Test direct nonce generation
         let session_secrand2 = SessionSecretRand::from_rng(&mut rng);
         let extra_rand = Some([42u8; 32]);
         let (_sec_nonce2, _pub_nonce2) = new_nonce_pair(
-            &secp,
             session_secrand2,
             Some(&key_agg_cache),
             Some(seckey2),
@@ -1508,27 +1533,26 @@ mod tests {
     #[cfg(feature = "std")]
     #[cfg(feature = "rand")]
     fn aggregated_nonce() {
-        let secp = Secp256k1::new();
         let mut rng = rand::rng();
 
         let (_seckey1, pubkey1) = crate::test_random_keypair();
         let (_seckey2, pubkey2) = crate::test_random_keypair();
 
-        let key_agg_cache = KeyAggCache::new(&secp, &[&pubkey1, &pubkey2]);
+        let key_agg_cache = KeyAggCache::new(&[&pubkey1, &pubkey2]);
 
         let msg: &[u8; 32] = b"This message is exactly 32 bytes";
 
         let session_secrand1 = SessionSecretRand::from_rng(&mut rng);
-        let (_, pub_nonce1) = key_agg_cache.nonce_gen(&secp, session_secrand1, pubkey1, msg, None);
+        let (_, pub_nonce1) = key_agg_cache.nonce_gen(session_secrand1, pubkey1, msg, None);
 
         let session_secrand2 = SessionSecretRand::from_rng(&mut rng);
-        let (_, pub_nonce2) = key_agg_cache.nonce_gen(&secp, session_secrand2, pubkey2, msg, None);
+        let (_, pub_nonce2) = key_agg_cache.nonce_gen(session_secrand2, pubkey2, msg, None);
 
         // Test AggregatedNonce creation
-        let agg_nonce = AggregatedNonce::new(&secp, &[&pub_nonce1, &pub_nonce2]);
-        let agg_nonce1 = AggregatedNonce::new(&secp, &[&pub_nonce2, &pub_nonce1]);
-        let agg_nonce2 = AggregatedNonce::new(&secp, &[&pub_nonce2, &pub_nonce2]);
-        let agg_nonce3 = AggregatedNonce::new(&secp, &[&pub_nonce2, &pub_nonce2]);
+        let agg_nonce = AggregatedNonce::new(&[&pub_nonce1, &pub_nonce2]);
+        let agg_nonce1 = AggregatedNonce::new(&[&pub_nonce2, &pub_nonce1]);
+        let agg_nonce2 = AggregatedNonce::new(&[&pub_nonce2, &pub_nonce2]);
+        let agg_nonce3 = AggregatedNonce::new(&[&pub_nonce2, &pub_nonce2]);
         assert_eq!(agg_nonce, agg_nonce1); // swapped nonces
         assert_ne!(agg_nonce, agg_nonce2); // repeated/different nonces
         assert_ne!(agg_nonce, agg_nonce3); // repeated nonce but still both nonces present
@@ -1544,9 +1568,8 @@ mod tests {
     #[cfg(feature = "std")]
     #[should_panic(expected = "Cannot aggregate an empty slice of nonces")]
     fn aggregated_nonce_empty_panic() {
-        let secp = Secp256k1::new();
         let empty_nonces: Vec<&PublicNonce> = vec![];
-        let _agg_nonce = AggregatedNonce::new(&secp, &empty_nonces);
+        let _agg_nonce = AggregatedNonce::new(&empty_nonces);
     }
 
     #[test]
@@ -1554,75 +1577,44 @@ mod tests {
     #[cfg(feature = "std")]
     #[cfg(feature = "rand")]
     fn session_and_partial_signing() {
-        let secp = Secp256k1::new();
         let mut rng = rand::rng();
 
         let (seckey1, pubkey1) = crate::test_random_keypair();
         let (seckey2, pubkey2) = crate::test_random_keypair();
 
         let pubkeys = [&pubkey1, &pubkey2];
-        let key_agg_cache = KeyAggCache::new(&secp, &pubkeys);
+        let key_agg_cache = KeyAggCache::new(&pubkeys);
 
         let msg: &[u8; 32] = b"This message is exactly 32 bytes";
 
         let session_secrand1 = SessionSecretRand::from_rng(&mut rng);
         let (sec_nonce1, pub_nonce1) =
-            key_agg_cache.nonce_gen(&secp, session_secrand1, pubkey1, msg, None);
+            key_agg_cache.nonce_gen(session_secrand1, pubkey1, msg, None);
 
         let session_secrand2 = SessionSecretRand::from_rng(&mut rng);
         let (sec_nonce2, pub_nonce2) =
-            key_agg_cache.nonce_gen(&secp, session_secrand2, pubkey2, msg, None);
+            key_agg_cache.nonce_gen(session_secrand2, pubkey2, msg, None);
 
         let nonces = [&pub_nonce1, &pub_nonce2];
-        let agg_nonce = AggregatedNonce::new(&secp, &nonces);
+        let agg_nonce = AggregatedNonce::new(&nonces);
 
         // Test Session creation
-        let session = Session::new(&secp, &key_agg_cache, agg_nonce, msg);
+        let session = Session::new(&key_agg_cache, agg_nonce, msg);
 
         // Test partial signing
         let keypair1 = Keypair::from_secret_key(&seckey1);
-        let partial_sign1 = session.partial_sign(&secp, sec_nonce1, &keypair1, &key_agg_cache);
+        let partial_sign1 = session.partial_sign(sec_nonce1, &keypair1, &key_agg_cache);
 
         let keypair2 = Keypair::from_secret_key(&seckey2);
-        let partial_sign2 = session.partial_sign(&secp, sec_nonce2, &keypair2, &key_agg_cache);
+        let partial_sign2 = session.partial_sign(sec_nonce2, &keypair2, &key_agg_cache);
 
         // Test partial signature verification
-        assert!(session.partial_verify(
-            &secp,
-            &key_agg_cache,
-            &partial_sign1,
-            &pub_nonce1,
-            pubkey1
-        ));
-        assert!(session.partial_verify(
-            &secp,
-            &key_agg_cache,
-            &partial_sign2,
-            &pub_nonce2,
-            pubkey2
-        ));
+        assert!(session.partial_verify(&key_agg_cache, &partial_sign1, &pub_nonce1, pubkey1));
+        assert!(session.partial_verify(&key_agg_cache, &partial_sign2, &pub_nonce2, pubkey2));
         // Test that they are invalid if you switch keys
-        assert!(!session.partial_verify(
-            &secp,
-            &key_agg_cache,
-            &partial_sign2,
-            &pub_nonce2,
-            pubkey1
-        ));
-        assert!(!session.partial_verify(
-            &secp,
-            &key_agg_cache,
-            &partial_sign2,
-            &pub_nonce1,
-            pubkey2
-        ));
-        assert!(!session.partial_verify(
-            &secp,
-            &key_agg_cache,
-            &partial_sign2,
-            &pub_nonce1,
-            pubkey1
-        ));
+        assert!(!session.partial_verify(&key_agg_cache, &partial_sign2, &pub_nonce2, pubkey1));
+        assert!(!session.partial_verify(&key_agg_cache, &partial_sign2, &pub_nonce1, pubkey2));
+        assert!(!session.partial_verify(&key_agg_cache, &partial_sign2, &pub_nonce1, pubkey1));
 
         // Test PartialSignature serialization/deserialization
         let serialized_partial_sig = partial_sign1.serialize();
@@ -1636,34 +1628,33 @@ mod tests {
     #[cfg(feature = "std")]
     #[cfg(feature = "rand")]
     fn signature_aggregation_and_verification() {
-        let secp = Secp256k1::new();
         let mut rng = rand::rng();
 
         let (seckey1, pubkey1) = crate::test_random_keypair();
         let (seckey2, pubkey2) = crate::test_random_keypair();
 
         let pubkeys = [&pubkey1, &pubkey2];
-        let key_agg_cache = KeyAggCache::new(&secp, &pubkeys);
+        let key_agg_cache = KeyAggCache::new(&pubkeys);
 
         let msg: &[u8; 32] = b"This message is exactly 32 bytes";
 
         let session_secrand1 = SessionSecretRand::from_rng(&mut rng);
         let (sec_nonce1, pub_nonce1) =
-            key_agg_cache.nonce_gen(&secp, session_secrand1, pubkey1, msg, None);
+            key_agg_cache.nonce_gen(session_secrand1, pubkey1, msg, None);
 
         let session_secrand2 = SessionSecretRand::from_rng(&mut rng);
         let (sec_nonce2, pub_nonce2) =
-            key_agg_cache.nonce_gen(&secp, session_secrand2, pubkey2, msg, None);
+            key_agg_cache.nonce_gen(session_secrand2, pubkey2, msg, None);
 
         let nonces = [&pub_nonce1, &pub_nonce2];
-        let agg_nonce = AggregatedNonce::new(&secp, &nonces);
-        let session = Session::new(&secp, &key_agg_cache, agg_nonce, msg);
+        let agg_nonce = AggregatedNonce::new(&nonces);
+        let session = Session::new(&key_agg_cache, agg_nonce, msg);
 
         let keypair1 = Keypair::from_secret_key(&seckey1);
-        let partial_sign1 = session.partial_sign(&secp, sec_nonce1, &keypair1, &key_agg_cache);
+        let partial_sign1 = session.partial_sign(sec_nonce1, &keypair1, &key_agg_cache);
 
         let keypair2 = Keypair::from_secret_key(&seckey2);
-        let partial_sign2 = session.partial_sign(&secp, sec_nonce2, &keypair2, &key_agg_cache);
+        let partial_sign2 = session.partial_sign(sec_nonce2, &keypair2, &key_agg_cache);
 
         // Test signature verification
         let aggregated_signature = session.partial_sig_agg(&[&partial_sign1, &partial_sign2]);
@@ -1692,7 +1683,6 @@ mod tests {
     #[cfg(feature = "rand")]
     #[should_panic(expected = "Cannot aggregate an empty slice of partial signatures")]
     fn partial_sig_agg_empty_panic() {
-        let secp = Secp256k1::new();
         let mut rng = rand::rng();
 
         let (_seckey1, pubkey1) = crate::test_random_keypair();
@@ -1702,18 +1692,18 @@ mod tests {
         let mut pubkeys_ref: Vec<&PublicKey> = pubkeys.iter().collect();
         let pubkeys_ref = pubkeys_ref.as_mut_slice();
 
-        let key_agg_cache = KeyAggCache::new(&secp, pubkeys_ref);
+        let key_agg_cache = KeyAggCache::new(pubkeys_ref);
         let msg: &[u8; 32] = b"This message is exactly 32 bytes";
 
         let session_secrand1 = SessionSecretRand::from_rng(&mut rng);
-        let (_, pub_nonce1) = key_agg_cache.nonce_gen(&secp, session_secrand1, pubkey1, msg, None);
+        let (_, pub_nonce1) = key_agg_cache.nonce_gen(session_secrand1, pubkey1, msg, None);
         let session_secrand2 = SessionSecretRand::from_rng(&mut rng);
-        let (_, pub_nonce2) = key_agg_cache.nonce_gen(&secp, session_secrand2, pubkey2, msg, None);
+        let (_, pub_nonce2) = key_agg_cache.nonce_gen(session_secrand2, pubkey2, msg, None);
 
         let nonces = [pub_nonce1, pub_nonce2];
         let nonces_ref: Vec<&PublicNonce> = nonces.iter().collect();
-        let agg_nonce = AggregatedNonce::new(&secp, &nonces_ref);
-        let session = Session::new(&secp, &key_agg_cache, agg_nonce, msg);
+        let agg_nonce = AggregatedNonce::new(&nonces_ref);
+        let session = Session::new(&key_agg_cache, agg_nonce, msg);
 
         let _agg_sig = session.partial_sig_agg(&[]);
     }

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -12,6 +12,8 @@ use core::mem::MaybeUninit;
 use std;
 
 use crate::ffi::{self, CPtr};
+#[cfg(doc)]
+use crate::key;
 use crate::{
     from_hex, schnorr, Error, Keypair, PublicKey, Scalar, Secp256k1, SecretKey, XOnlyPublicKey,
 };
@@ -369,7 +371,7 @@ impl KeyAggCache {
     /// ensures the same resulting `agg_pk` for the same multiset of pubkeys.
     /// This is useful to do before aggregating pubkeys, such that the order of pubkeys
     /// does not affect the combined public key.
-    /// To do this, call [`Secp256k1::sort_pubkeys`].
+    /// To do this, call [`key::sort_pubkeys`].
     ///
     /// # Returns
     ///

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -170,7 +170,7 @@ impl fmt::Display for InvalidTweakErr {
 /// // The session id must be sampled at random. Read documentation for more details.
 /// let session_secrand = SessionSecretRand::from_rng(&mut rand::rng());
 /// let sk = SecretKey::new(&mut rand::rng());
-/// let pk = PublicKey::from_secret_key(&secp, &sk);
+/// let pk = PublicKey::from_secret_key(&sk);
 ///
 /// // Supply extra auxiliary randomness to prevent misuse(for example, time of day)
 /// let extra_rand : Option<[u8; 32]> = None;
@@ -375,9 +375,9 @@ impl KeyAggCache {
     /// # use secp256k1::musig::KeyAggCache;
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     /// #
     /// let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
     /// let _agg_pk = key_agg_cache.agg_pk();
@@ -474,9 +474,9 @@ impl KeyAggCache {
     /// # use secp256k1::musig::KeyAggCache;
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     /// #
     /// let mut key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
     ///
@@ -535,9 +535,9 @@ impl KeyAggCache {
     /// # use secp256k1::musig::KeyAggCache;
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
     /// let mut key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
     ///
@@ -608,9 +608,9 @@ impl KeyAggCache {
     /// # use secp256k1::musig::{KeyAggCache, SessionSecretRand};
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     /// #
     /// let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
@@ -903,9 +903,9 @@ impl AggregatedNonce {
     /// # use secp256k1::musig::{AggregatedNonce, KeyAggCache, SessionSecretRand};
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
     /// # let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
@@ -1064,9 +1064,9 @@ impl Session {
     /// # use secp256k1::musig::{AggregatedNonce, KeyAggCache, Session, SessionSecretRand};
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
     /// # let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
@@ -1200,9 +1200,9 @@ impl Session {
     /// # use secp256k1::musig::{AggregatedNonce, KeyAggCache, SessionSecretRand, Session};
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
     /// # let key_agg_cache = KeyAggCache::new(&secp, &[&pub_key1, &pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.
@@ -1280,9 +1280,9 @@ impl Session {
     /// # use secp256k1::{KeyAggCache, Secp256k1, SecretKey, Keypair, PublicKey, SessionSecretRand, AggregatedNonce, Session};
     /// # let secp = Secp256k1::new();
     /// # let sk1 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key1 = PublicKey::from_secret_key(&secp, &sk1);
+    /// # let pub_key1 = PublicKey::from_secret_key(&sk1);
     /// # let sk2 = SecretKey::new(&mut rand::rng());
-    /// # let pub_key2 = PublicKey::from_secret_key(&secp, &sk2);
+    /// # let pub_key2 = PublicKey::from_secret_key(&sk2);
     ///
     /// let key_agg_cache = KeyAggCache::new(&secp, &[pub_key1, pub_key2]);
     /// // The session id must be sampled at random. Read documentation for more details.

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -374,13 +374,12 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_xonly_key_extraction() {
-        let secp = Secp256k1::new();
         let sk_str = "688C77BC2D5AAFF5491CF309D4753B732135470D05B7B2CD21ADD0744FE97BEF";
         let keypair = Keypair::from_str(sk_str).unwrap();
         let sk = SecretKey::from_keypair(&keypair);
         assert_eq!(SecretKey::from_str(sk_str).unwrap(), sk);
         let pk = crate::key::PublicKey::from_keypair(&keypair);
-        assert_eq!(crate::key::PublicKey::from_secret_key(&secp, &sk), pk);
+        assert_eq!(crate::key::PublicKey::from_secret_key(&sk), pk);
         let (xpk, _parity) = keypair.x_only_public_key();
         assert_eq!(XOnlyPublicKey::from(pk), xpk);
     }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -456,8 +456,7 @@ mod tests {
         use rand::SeedableRng as _;
         use rand_xoshiro::Xoshiro128PlusPlus as SmallRng;
 
-        let secp = Secp256k1::new();
-        let kp = Keypair::new(&secp, &mut SmallRng::from_seed([2; 16]));
+        let kp = Keypair::new(&mut SmallRng::from_seed([2; 16]));
         let (pk, _parity) = kp.x_only_public_key();
         assert_eq!(
             &pk.serialize()[..],

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -135,7 +135,7 @@ impl Keypair {
     ///
     /// let secp = Secp256k1::new();
     /// let key = SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000001").unwrap();
-    /// let key = Keypair::from_secret_key(&secp, &key);
+    /// let key = Keypair::from_secret_key(&key);
     /// // Here we explicitly display the secret value:
     /// assert_eq!(
     ///     "0000000000000000000000000000000000000000000000000000000000000001",


### PR DESCRIPTION
Tested in https://github.com/rust-bitcoin/rust-bitcoin/pull/4960

### TODO in this PR: 

Remove the FIXMEs, I don't exactly understand the `rerandomize_seed` and what is ok to put in it?

While trying to work this out I created #847 and #848, apoelstra can you school me on _exactly_ how random the seed needs to be please?

 
### Follow up PRs:
 
- Do we want to remove the `SECP256K1`, `global-context` (and `global-context-less-secure`) features in this PR instead of deprecating stuff?
- Go over the docs and fix places that mention the context