### PR TITLE
Improve root level imports and exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,8 @@ mod macros;
 mod secret;
 mod context;
 mod key;
+#[cfg(feature = "serde")]
+mod serde_util;
 
 pub mod constants;
 pub mod ecdh;
@@ -182,8 +184,6 @@ pub mod ellswift;
 pub mod musig;
 pub mod scalar;
 pub mod schnorr;
-#[cfg(feature = "serde")]
-mod serde_util;
 
 use core::marker::PhantomData;
 use core::ptr::NonNull;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,9 +189,11 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::{fmt, mem, str};
 
+#[rustfmt::skip]                // Keep public re-exports separate.
+pub use secp256k1_sys as ffi;
+
 #[cfg(all(feature = "global-context", feature = "std"))]
 pub use context::global::{self, SECP256K1};
-pub use secp256k1_sys as ffi;
 
 pub use crate::context::{
     rerandomize_global_context, with_global_context, with_raw_global_context, AllPreallocated,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,11 @@ extern crate core;
 #[cfg(bench)]
 extern crate test;
 
+#[cfg(feature = "rand")]
+pub extern crate rand;
+#[cfg(feature = "serde")]
+pub extern crate serde;
+
 #[macro_use]
 mod macros;
 #[macro_use]
@@ -186,11 +191,7 @@ use core::{fmt, mem, str};
 
 #[cfg(all(feature = "global-context", feature = "std"))]
 pub use context::global::{self, SECP256K1};
-#[cfg(feature = "rand")]
-pub use rand;
 pub use secp256k1_sys as ffi;
-#[cfg(feature = "serde")]
-pub use serde;
 
 pub use crate::context::{
     rerandomize_global_context, with_global_context, with_raw_global_context, AllPreallocated,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,8 +193,7 @@ use core::{fmt, mem, str};
 pub use secp256k1_sys as ffi;
 
 #[cfg(all(feature = "global-context", feature = "std"))]
-pub use context::global::{self, SECP256K1};
-
+pub use crate::context::global::{self, SECP256K1};
 pub use crate::context::{
     rerandomize_global_context, with_global_context, with_raw_global_context, AllPreallocated,
     Context, PreallocatedContext, SignOnlyPreallocated, Signing, Verification,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,9 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::{fmt, mem, str};
 
+use crate::ffi::types::AlignedType;
+use crate::ffi::CPtr;
+
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1_sys as ffi;
 
@@ -201,8 +204,6 @@ pub use crate::context::{
 };
 #[cfg(feature = "alloc")]
 pub use crate::context::{All, SignOnly, VerifyOnly};
-use crate::ffi::types::AlignedType;
-use crate::ffi::CPtr;
 pub use crate::key::{InvalidParityValue, Keypair, Parity, PublicKey, SecretKey, XOnlyPublicKey};
 pub use crate::scalar::Scalar;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,15 +197,18 @@ pub use secp256k1_sys as ffi;
 
 #[cfg(all(feature = "global-context", feature = "std"))]
 pub use crate::context::global::{self, SECP256K1};
-pub use crate::context::{
-    rerandomize_global_context, with_global_context, with_raw_global_context, AllPreallocated,
-    Context, PreallocatedContext, SignOnlyPreallocated, Signing, Verification,
-    VerifyOnlyPreallocated,
-};
 #[cfg(feature = "alloc")]
 pub use crate::context::{All, SignOnly, VerifyOnly};
-pub use crate::key::{InvalidParityValue, Keypair, Parity, PublicKey, SecretKey, XOnlyPublicKey};
-pub use crate::scalar::Scalar;
+#[doc(inline)]
+pub use crate::{
+    context::{
+        rerandomize_global_context, with_global_context, with_raw_global_context, AllPreallocated,
+        Context, PreallocatedContext, SignOnlyPreallocated, Signing, Verification,
+        VerifyOnlyPreallocated,
+    },
+    key::{InvalidParityValue, Keypair, Parity, PublicKey, SecretKey, XOnlyPublicKey},
+    scalar::Scalar,
+};
 
 /// Trait describing something that promises to be a 32-byte uniformly random number.
 ///


### PR DESCRIPTION
Do a bunch of trivial clean ups to the imports and exports in `lib.rs`. Done as tiny patches to make review trivial. The only meaningful change, apart from leaving the code awesomely clean, is the `Scalar` type moving sections in rendered HTML docs.