### PR TITLE
Delete deprecated code

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -145,19 +145,6 @@ impl Signature {
         }
     }
 
-    /// Obtains a raw pointer suitable for use with FFI functions
-    #[inline]
-    #[deprecated(since = "0.25.0", note = "Use Self::as_c_ptr if you need to access the FFI layer")]
-    pub fn as_ptr(&self) -> *const ffi::Signature { self.as_c_ptr() }
-
-    /// Obtains a raw mutable pointer suitable for use with FFI functions
-    #[inline]
-    #[deprecated(
-        since = "0.25.0",
-        note = "Use Self::as_mut_c_ptr if you need to access the FFI layer"
-    )]
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::Signature { self.as_mut_c_ptr() }
-
     #[inline]
     /// Serializes the signature in DER format
     pub fn serialize_der(&self) -> SerializedSignature {

--- a/src/ecdsa/recovery.rs
+++ b/src/ecdsa/recovery.rs
@@ -92,19 +92,6 @@ impl RecoverableSignature {
         }
     }
 
-    /// Obtains a raw pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(since = "0.25.0", note = "Use Self::as_c_ptr if you need to access the FFI layer")]
-    pub fn as_ptr(&self) -> *const ffi::RecoverableSignature { self.as_c_ptr() }
-
-    /// Obtains a raw mutable pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(
-        since = "0.25.0",
-        note = "Use Self::as_mut_c_ptr if you need to access the FFI layer"
-    )]
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::RecoverableSignature { self.as_mut_c_ptr() }
-
     #[inline]
     /// Serializes the recoverable signature in compact format.
     pub fn serialize_compact(&self) -> (RecoveryId, [u8; 64]) {

--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -282,24 +282,6 @@ impl ElligatorSwiftSharedSecret {
     pub const fn as_secret_bytes(&self) -> &[u8; 32] { &self.0 }
 }
 
-/// Represents which party we are in the ECDH.
-///
-/// Here `A` is the initiator and `B` is the responder.
-///
-/// this context, "we" means the party that possesses the secret key passed to
-/// [`ElligatorSwift::shared_secret`].
-///
-/// This distinction is important because the different parties compute different
-/// hashes of the shared secret.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[deprecated(since = "0.30.0", note = "Use `Party` instead.")]
-pub enum ElligatorSwiftParty {
-    /// We are the initiator of the ECDH
-    A,
-    /// We are the responder of the ECDH
-    B,
-}
-
 /// Represents the two parties in ECDH
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Party {
@@ -307,16 +289,6 @@ pub enum Party {
     Initiator,
     /// The party that responds to the initiator's communications
     Responder,
-}
-
-#[allow(deprecated)]
-impl From<ElligatorSwiftParty> for Party {
-    fn from(value: ElligatorSwiftParty) -> Self {
-        match value {
-            ElligatorSwiftParty::A => Party::Initiator,
-            ElligatorSwiftParty::B => Party::Responder,
-        }
-    }
 }
 
 impl Party {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -89,19 +89,6 @@ impl str::FromStr for PublicKey {
 }
 
 impl PublicKey {
-    /// Obtains a raw const pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(since = "0.25.0", note = "Use Self::as_c_ptr if you need to access the FFI layer")]
-    pub fn as_ptr(&self) -> *const ffi::PublicKey { self.as_c_ptr() }
-
-    /// Obtains a raw mutable pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(
-        since = "0.25.0",
-        note = "Use Self::as_mut_c_ptr if you need to access the FFI layer"
-    )]
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::PublicKey { self.as_mut_c_ptr() }
-
     /// Creates a new public key from a [`SecretKey`].
     ///
     /// # Examples
@@ -505,19 +492,6 @@ pub struct Keypair(ffi::Keypair);
 impl_fast_comparisons!(Keypair);
 
 impl Keypair {
-    /// Obtains a raw const pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(since = "0.25.0", note = "Use Self::as_c_ptr if you need to access the FFI layer")]
-    pub fn as_ptr(&self) -> *const ffi::Keypair { self.as_c_ptr() }
-
-    /// Obtains a raw mutable pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(
-        since = "0.25.0",
-        note = "Use Self::as_mut_c_ptr if you need to access the FFI layer"
-    )]
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::Keypair { self.as_mut_c_ptr() }
-
     /// Creates a [`Keypair`] directly from a Secp256k1 secret key.
     #[inline]
     pub fn from_secret_key<C: Signing>(secp: &Secp256k1<C>, sk: &SecretKey) -> Keypair {
@@ -867,19 +841,6 @@ impl str::FromStr for XOnlyPublicKey {
 }
 
 impl XOnlyPublicKey {
-    /// Obtains a raw const pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(since = "0.25.0", note = "Use Self::as_c_ptr if you need to access the FFI layer")]
-    pub fn as_ptr(&self) -> *const ffi::XOnlyPublicKey { self.as_c_ptr() }
-
-    /// Obtains a raw mutable pointer suitable for use with FFI functions.
-    #[inline]
-    #[deprecated(
-        since = "0.25.0",
-        note = "Use Self::as_mut_c_ptr if you need to access the FFI layer"
-    )]
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::XOnlyPublicKey { self.as_mut_c_ptr() }
-
     /// Returns the [`XOnlyPublicKey`] (and its [`Parity`]) for `keypair`.
     #[inline]
     pub fn from_keypair(keypair: &Keypair) -> (XOnlyPublicKey, Parity) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,22 +204,6 @@ use crate::ffi::CPtr;
 pub use crate::key::{InvalidParityValue, Keypair, Parity, PublicKey, SecretKey, XOnlyPublicKey};
 pub use crate::scalar::Scalar;
 
-/// Trait describing something that promises to be a 32-byte uniformly random number.
-///
-/// In particular, anything implementing this trait must have negligible probability
-/// of being zero, overflowing the group order, or equalling any specific value.
-///
-/// Since version 0.29 this has been deprecated; users should instead implement
-/// `Into<Message>` for types that satisfy these properties.
-#[deprecated(
-    since = "0.29.0",
-    note = "Please see v0.29.0 rust-secp256k1/CHANGELOG.md for suggestion"
-)]
-pub trait ThirtyTwoByteHash {
-    /// Converts the object into a 32-byte array
-    fn into_32(self) -> [u8; 32];
-}
-
 /// A (hashed) message input to an ECDSA signature.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Message([u8; constants::MESSAGE_SIZE]);
@@ -227,19 +211,6 @@ impl_array_newtype!(Message, u8, constants::MESSAGE_SIZE);
 impl_pretty_debug!(Message);
 
 impl Message {
-    /// Creates a [`Message`] from a 32 byte slice `digest`.
-    ///
-    /// Converts a `MESSAGE_SIZE`-byte slice to a message object. **WARNING:** the slice has to be a
-    /// cryptographically secure hash of the actual message that's going to be signed. Otherwise
-    /// the result of signing isn't a
-    /// [secure signature](https://twitter.com/pwuille/status/1063582706288586752).
-    #[inline]
-    #[deprecated(since = "0.28.0", note = "use from_digest instead")]
-    pub fn from_slice(digest: &[u8]) -> Result<Message, Error> {
-        #[allow(deprecated)]
-        Message::from_digest_slice(digest)
-    }
-
     /// Creates a [`Message`] from a `digest`.
     ///
     /// The `digest` array has to be a cryptographically secure hash of the actual message that's
@@ -269,12 +240,6 @@ impl Message {
     pub fn from_digest_slice(digest: &[u8]) -> Result<Message, Error> {
         Ok(Message::from_digest(digest.try_into().map_err(|_| Error::InvalidMessage)?))
     }
-}
-
-#[allow(deprecated)]
-impl<T: ThirtyTwoByteHash> From<T> for Message {
-    /// Converts a 32-byte hash directly to a message without error paths.
-    fn from(t: T) -> Message { Message(t.into_32()) }
 }
 
 impl fmt::LowerHex for Message {


### PR DESCRIPTION
I don't know the exact policy here in this repo but following along from `rust-bitcoin` delete all deprecated code from at least 2 releases ago - assuming the next release is going to be `v0.32.0`.