### PR TITLE
Fix rerandomization seed usage 

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -377,8 +377,6 @@ pub fn sign_low_r(msg: impl Into<Message>, sk: &SecretKey) -> Signature {
 #[inline]
 pub fn verify(sig: &Signature, msg: impl Into<Message>, pk: &PublicKey) -> Result<(), Error> {
     let msg = msg.into();
-    // We have no seed here but we want rerandomiziation to happen for `rand` users.
-    let seed = [0_u8; 32];
     unsafe {
         let res = crate::with_global_context(
             |secp: &Secp256k1<crate::AllPreallocated>| {
@@ -389,7 +387,7 @@ pub fn verify(sig: &Signature, msg: impl Into<Message>, pk: &PublicKey) -> Resul
                     pk.as_c_ptr(),
                 )
             },
-            Some(&seed),
+            None,
         );
         if res == 0 {
             Err(Error::IncorrectSignature)

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -302,8 +302,6 @@ impl PublicKey {
     /// Returns an error if the resulting key would be invalid.
     #[inline]
     pub fn mul_tweak(mut self, other: &Scalar) -> Result<PublicKey, Error> {
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let res = crate::with_global_context(
                 |secp: &Secp256k1<crate::AllPreallocated>| {
@@ -313,7 +311,7 @@ impl PublicKey {
                         other.as_c_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if res == 1 {
                 Ok(self)
@@ -668,8 +666,6 @@ impl Keypair {
     // TODO: Add checked implementation
     #[inline]
     pub fn add_xonly_tweak(mut self, tweak: &Scalar) -> Result<Keypair, Error> {
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let err = crate::with_global_context(
                 |secp: &Secp256k1<crate::AllPreallocated>| {
@@ -679,7 +675,7 @@ impl Keypair {
                         tweak.as_c_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if err != 1 {
                 return Err(Error::InvalidTweak);
@@ -993,8 +989,6 @@ impl XOnlyPublicKey {
     /// ```
     pub fn add_tweak(mut self, tweak: &Scalar) -> Result<(XOnlyPublicKey, Parity), Error> {
         let mut pk_parity = 0;
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let mut pubkey = ffi::PublicKey::new();
             let mut err = crate::with_global_context(
@@ -1006,7 +1000,7 @@ impl XOnlyPublicKey {
                         tweak.as_c_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if err != 1 {
                 return Err(Error::InvalidTweak);
@@ -1021,7 +1015,7 @@ impl XOnlyPublicKey {
                         &pubkey,
                     )
                 },
-                Some(&seed),
+                None,
             );
             if err == 0 {
                 return Err(Error::InvalidPublicKey);
@@ -1067,8 +1061,6 @@ impl XOnlyPublicKey {
         tweak: Scalar,
     ) -> bool {
         let tweaked_ser = tweaked_key.serialize();
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let err = crate::with_global_context(
                 |secp: &Secp256k1<crate::AllPreallocated>| {
@@ -1080,7 +1072,7 @@ impl XOnlyPublicKey {
                         tweak.as_c_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
 
             err == 1
@@ -1327,8 +1319,6 @@ impl<'de> serde::Deserialize<'de> for XOnlyPublicKey {
 /// # }
 /// ```
 pub fn sort_pubkeys(pubkeys: &mut [&PublicKey]) {
-    // We have no seed here but we want rerandomiziation to happen for `rand` users.
-    let seed = [0_u8; 32];
     unsafe {
         // SAFETY: `PublicKey` has repr(transparent) so we can convert to `ffi::PublicKey`
         let pubkeys_ptr = pubkeys.as_mut_c_ptr() as *mut *const ffi::PublicKey;
@@ -1337,7 +1327,7 @@ pub fn sort_pubkeys(pubkeys: &mut [&PublicKey]) {
             |secp: &Secp256k1<crate::AllPreallocated>| {
                 ffi::secp256k1_ec_pubkey_sort(secp.ctx.as_ptr(), pubkeys_ptr, pubkeys.len())
             },
-            Some(&seed),
+            None,
         );
 
         if ret == 0 {

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -1179,8 +1179,6 @@ impl Session {
         keypair: &Keypair,
         key_agg_cache: &KeyAggCache,
     ) -> PartialSignature {
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let mut partial_sig = MaybeUninit::<ffi::MusigPartialSignature>::uninit();
 
@@ -1195,7 +1193,7 @@ impl Session {
                         self.as_ptr(),
                     )
                 },
-                Some(&seed),
+                Some(&keypair.secret_bytes()),
             );
 
             assert_eq!(res, 1);

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -411,9 +411,6 @@ impl KeyAggCache {
         let mut key_agg_cache = MaybeUninit::<ffi::MusigKeyAggCache>::uninit();
         let mut agg_pk = MaybeUninit::<ffi::XOnlyPublicKey>::uninit();
 
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
-
         unsafe {
             let pubkeys_ref = core::slice::from_raw_parts(
                 pubkeys.as_c_ptr() as *const *const ffi::PublicKey,
@@ -430,7 +427,7 @@ impl KeyAggCache {
                         pubkeys_ref.len(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if ret == 0 {
                 // Returns 0 only if the keys are malformed that never happens in safe rust type system.
@@ -507,8 +504,6 @@ impl KeyAggCache {
     /// # }
     /// ```
     pub fn pubkey_ec_tweak_add(&mut self, tweak: &Scalar) -> Result<PublicKey, InvalidTweakErr> {
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let mut out = PublicKey::from(ffi::PublicKey::new());
 
@@ -521,7 +516,7 @@ impl KeyAggCache {
                         tweak.as_c_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if ret == 0 {
                 Err(InvalidTweakErr)
@@ -569,8 +564,6 @@ impl KeyAggCache {
     /// # }
     /// ```
     pub fn pubkey_xonly_tweak_add(&mut self, tweak: &Scalar) -> Result<PublicKey, InvalidTweakErr> {
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let mut out = PublicKey::from(ffi::PublicKey::new());
 
@@ -583,7 +576,7 @@ impl KeyAggCache {
                         tweak.as_c_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if ret == 0 {
                 Err(InvalidTweakErr)
@@ -956,9 +949,6 @@ impl AggregatedNonce {
 
         let mut aggnonce = MaybeUninit::<ffi::MusigAggNonce>::uninit();
 
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
-
         unsafe {
             let pubnonces = core::slice::from_raw_parts(
                 nonces.as_c_ptr() as *const *const ffi::MusigPubNonce,
@@ -974,7 +964,7 @@ impl AggregatedNonce {
                         pubnonces.len(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if ret == 0 {
                 // This can only crash if the individual nonces are invalid which is not possible is rust.
@@ -1124,9 +1114,6 @@ impl Session {
     pub fn new(key_agg_cache: &KeyAggCache, agg_nonce: AggregatedNonce, msg: &[u8; 32]) -> Self {
         let mut session = MaybeUninit::<ffi::MusigSession>::uninit();
 
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
-
         unsafe {
             let ret = crate::with_global_context(
                 |secp: &Secp256k1<crate::AllPreallocated>| {
@@ -1138,7 +1125,7 @@ impl Session {
                         key_agg_cache.as_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             if ret == 0 {
                 // Only fails on cryptographically unreachable codes or if the args are invalid.
@@ -1281,8 +1268,6 @@ impl Session {
         pub_nonce: &PublicNonce,
         pub_key: PublicKey,
     ) -> bool {
-        // We have no seed here but we want rerandomiziation to happen for `rand` users.
-        let seed = [0_u8; 32];
         unsafe {
             let ret = crate::with_global_context(
                 |secp: &Secp256k1<crate::AllPreallocated>| {
@@ -1295,7 +1280,7 @@ impl Session {
                         self.as_ptr(),
                     )
                 },
-                Some(&seed),
+                None,
             );
             ret == 1
         }

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -161,8 +161,6 @@ pub fn sign_with_rng<R: Rng + CryptoRng>(msg: &[u8], keypair: &Keypair, rng: &mu
 
 /// Verifies a schnorr signature.
 pub fn verify(sig: &Signature, msg: &[u8], pubkey: &XOnlyPublicKey) -> Result<(), Error> {
-    // We have no seed here but we want rerandomiziation to happen for `rand` users.
-    let seed = [0_u8; 32];
     unsafe {
         let ret = crate::with_global_context(
             |secp: &Secp256k1<crate::AllPreallocated>| {
@@ -174,7 +172,7 @@ pub fn verify(sig: &Signature, msg: &[u8], pubkey: &XOnlyPublicKey) -> Result<()
                     pubkey.as_c_ptr(),
                 )
             },
-            Some(&seed),
+            None,
         );
 
         if ret == 1 {


### PR DESCRIPTION
Follow up of #844

Fix rerandomization stuff.

- Use keypair secret data to rerandomize in musig when doing partial siging. 
- Remove all the zero seed arrays and use `None` to disable rerandomization when no secret data used. 