### PR TITLE
Implement `Default` for `SpinLock<SelfContainedContext>`

### DIFF
--- a/src/context/spinlock.rs
+++ b/src/context/spinlock.rs
@@ -43,6 +43,10 @@ impl SpinLock<SelfContainedContext> {
     }
 }
 
+impl Default for SpinLock<SelfContainedContext> {
+    fn default() -> Self { Self::new() }
+}
+
 #[cfg(test)]
 impl SpinLock<u64> {
     pub const fn new(v: u64) -> Self {


### PR DESCRIPTION
This is a bit silly since we cannot implement `Default` for `SpinLock<u64>` but clippy is complaining so throw it in.