### PR TITLE
Rename `secret_bytes` to `to_secret_bytes`

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -55,7 +55,12 @@ impl SharedSecret {
 
     /// Returns the shared secret as a byte value.
     #[inline]
-    pub fn secret_bytes(&self) -> [u8; SHARED_SECRET_SIZE] { self.0 }
+    pub fn to_secret_bytes(&self) -> [u8; SHARED_SECRET_SIZE] { self.0 }
+
+    /// Returns the shared secret as a byte value.
+    #[deprecated(since = "TBD", note = "Use `to_secret_bytes` instead.")]
+    #[inline]
+    pub fn secret_bytes(&self) -> [u8; SHARED_SECRET_SIZE] { self.to_secret_bytes() }
 
     /// Creates a shared secret from `bytes` array.
     #[inline]

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -612,9 +612,14 @@ impl Keypair {
 
     /// Returns the secret bytes for this key pair.
     #[inline]
-    pub fn secret_bytes(&self) -> [u8; constants::SECRET_KEY_SIZE] {
+    pub fn to_secret_bytes(&self) -> [u8; constants::SECRET_KEY_SIZE] {
         *SecretKey::from_keypair(self).as_ref()
     }
+
+    /// Returns the secret bytes for this key pair.
+    #[deprecated(since = "TBD", note = "use to_secret_bytes instead")]
+    #[inline]
+    pub fn secret_bytes(&self) -> [u8; constants::SECRET_KEY_SIZE] { self.to_secret_bytes() }
 
     /// Tweaks a keypair by first converting the public key to an xonly key and tweaking it.
     ///


### PR DESCRIPTION
As we did elsewhere add a new function and deprecate the old one.

Done for the two places we missed:

- `ecdh::SharedSecret`
- `Keypair`

Close: #845