### PR TITLE
Fix docs.rs badge target

### DIFF
--- a/secp256k1-sys/README.md
+++ b/secp256k1-sys/README.md
@@ -4,7 +4,7 @@
   <p>
     <a href="https://crates.io/crates/secp256k1-sys"><img alt="Crate Info" src="https://img.shields.io/crates/v/secp256k1-sys.svg"/></a>
     <a href="https://github.com/rust-bitcoin/rust-secp256k1/blob/master/LICENSE"><img alt="CC0 1.0 Universal Licensed" src="https://img.shields.io/badge/license-CC0--1.0-blue.svg"/></a>
-    <a href="https://docs.rs/secp256k1"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-secp256k1-green"/></a>
+    <a href="https://docs.rs/secp256k1-sys"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-secp256k1--sys-green"/></a>
     <a href="https://blog.rust-lang.org/2020/02/27/Rust-1.56.1.html"><img alt="Rustc Version 1.56.1+" src="https://img.shields.io/badge/rustc-1.56.1%2B-lightgrey.svg"/></a>
   </p>
 </div>


### PR DESCRIPTION
The docs.rs badge in secp256k1-sys/README.md pointed to the parent crate (secp256k1) instead of this crate. This PR updates the link and badge label to target secp256k1-sys.