### PR TITLE
chore: fix minor spelling mistakes

### DIFF
--- a/secp256k1-sys/depend/secp256k1/CMakeLists.txt
+++ b/secp256k1-sys/depend/secp256k1/CMakeLists.txt
@@ -55,7 +55,7 @@ option(SECP256K1_INSTALL "Enable installation." ${PROJECT_IS_TOP_LEVEL})
 ## Modules
 
 # We declare all options before processing them, to make sure we can express
-# dependendencies while processing.
+# dependencies while processing.
 option(SECP256K1_ENABLE_MODULE_ECDH "Enable ECDH module." ON)
 option(SECP256K1_ENABLE_MODULE_RECOVERY "Enable ECDSA pubkey recovery module." OFF)
 option(SECP256K1_ENABLE_MODULE_EXTRAKEYS "Enable extrakeys module." ON)

--- a/secp256k1-sys/depend/secp256k1/configure.ac
+++ b/secp256k1-sys/depend/secp256k1/configure.ac
@@ -254,8 +254,8 @@ fi
 print_msan_notice=no
 if test x"$enable_ctime_tests" = x"yes"; then
   SECP_MSAN_CHECK
-  # MSan on Clang >=16 reports unitialized memory in function parameters and return values, even if
-  # the uninitalized variable is never actually "used". This is called "eager" checking, and it's
+  # MSan on Clang >=16 reports uninitialized memory in function parameters and return values, even if
+  # the uninitialized variable is never actually "used". This is called "eager" checking, and it's
   # sounds like good idea for normal use of MSan. However, it yields many false positives in the
   # ctime_tests because many return values depend on secret (i.e., "uninitialized") values, and
   # we're only interested in detecting branches (which count as "uses") on secret data.

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -159,7 +159,7 @@ impl PublicKey {
     /// # Safety
     ///
     /// If you pass this to any FFI functions, except as an out-pointer,
-    /// the result is likely to be an assertation failure and process
+    /// the result is likely to be an assertion failure and process
     /// termination.
     pub unsafe fn new() -> Self { Self::from_array_unchecked([0; 64]) }
 
@@ -168,7 +168,7 @@ impl PublicKey {
     /// # Safety
     ///
     /// Does not check the validity of the underlying representation. If it is
-    /// invalid the result may be assertation failures (and process aborts) from
+    /// invalid the result may be assertion failures (and process aborts) from
     /// the underlying library. You should not use this method except with data
     /// that you obtained from the FFI interface of the same version of this
     /// library.
@@ -244,7 +244,7 @@ impl Signature {
     /// # Safety
     ///
     /// If you pass this to any FFI functions, except as an out-pointer,
-    /// the result is likely to be an assertation failure and process
+    /// the result is likely to be an assertion failure and process
     /// termination.
     pub unsafe fn new() -> Self { Self::from_array_unchecked([0; 64]) }
 
@@ -253,7 +253,7 @@ impl Signature {
     /// # Safety
     ///
     /// Does not check the validity of the underlying representation. If it is
-    /// invalid the result may be assertation failures (and process aborts) from
+    /// invalid the result may be assertion failures (and process aborts) from
     /// the underlying library. You should not use this method except with data
     /// that you obtained from the FFI interface of the same version of this
     /// library.
@@ -325,7 +325,7 @@ impl XOnlyPublicKey {
     /// # Safety
     ///
     /// If you pass this to any FFI functions, except as an out-pointer,
-    /// the result is likely to be an assertation failure and process
+    /// the result is likely to be an assertion failure and process
     /// termination.
     pub unsafe fn new() -> Self { Self::from_array_unchecked([0; 64]) }
 
@@ -334,7 +334,7 @@ impl XOnlyPublicKey {
     /// # Safety
     ///
     /// Does not check the validity of the underlying representation. If it is
-    /// invalid the result may be assertation failures (and process aborts) from
+    /// invalid the result may be assertion failures (and process aborts) from
     /// the underlying library. You should not use this method except with data
     /// that you obtained from the FFI interface of the same version of this
     /// library.
@@ -405,7 +405,7 @@ impl Keypair {
     /// # Safety
     ///
     /// If you pass this to any FFI functions, except as an out-pointer,
-    /// the result is likely to be an assertation failure and process
+    /// the result is likely to be an assertion failure and process
     /// termination.
     pub unsafe fn new() -> Self { Self::from_array_unchecked([0; 96]) }
 
@@ -414,7 +414,7 @@ impl Keypair {
     /// # Safety
     ///
     /// Does not check the validity of the underlying representation. If it is
-    /// invalid the result may be assertation failures (and process aborts) from
+    /// invalid the result may be assertion failures (and process aborts) from
     /// the underlying library. You should not use this method except with data
     /// that you obtained from the FFI interface of the same version of this
     /// library.

--- a/secp256k1-sys/src/macros.rs
+++ b/secp256k1-sys/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! impl_array_newtype {
         impl $thing {
             /// Like `cmp::Ord` but faster and with no guarantees across library versions.
             ///
-            /// The inner byte array of `Self` is passed across the FFI boundry, as such there are
+            /// The inner byte array of `Self` is passed across the FFI boundary, as such there are
             /// no guarantees on its layout and it is subject to change across library versions,
             /// even minor versions. For this reason comparison function implementations (e.g.
             /// `Ord`, `PartialEq`) take measures to ensure the data will remain constant (e.g., by
@@ -20,7 +20,7 @@ macro_rules! impl_array_newtype {
 
             /// Like `cmp::Eq` but faster and with no guarantees across library versions.
             ///
-            /// The inner byte array of `Self` is passed across the FFI boundry, as such there are
+            /// The inner byte array of `Self` is passed across the FFI boundary, as such there are
             /// no guarantees on its layout and it is subject to change across library versions,
             /// even minor versions. For this reason comparison function implementations (e.g.
             /// `Ord`, `PartialEq`) take measures to ensure the data will remain constant (e.g., by

--- a/src/context/spinlock.rs
+++ b/src/context/spinlock.rs
@@ -15,7 +15,7 @@ const MAX_SPINLOCK_ATTEMPTS: usize = 128;
 // for some small number of iterations before giving up. By trying again in
 // a loop, you can emulate a "true" spinlock that will only yield once it
 // has access. However, this would be very dangerous, especially in a nostd
-// environment, because if we are pre-empted by an interrupt handler while
+// environment, because if we are pre-emptied by an interrupt handler while
 // the lock is held, and that interrupt handler attempts to take the lock,
 // then we deadlock.
 //


### PR DESCRIPTION
Fixed a few spelling mistakes — changed “dependendencies” to “dependencies”, “unintialized” to “uninitialized”, “assertation” to “assertion”, “boundry” to “boundary”,and “empted”  to “emptied”.