### PR TITLE
Standardize byte conversion APIs and enable

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -62,6 +62,16 @@ impl SharedSecret {
     #[inline]
     pub fn secret_bytes(&self) -> [u8; SHARED_SECRET_SIZE] { self.to_secret_bytes() }
 
+    /// Returns the shared secret as a reference to a byte array.
+    #[inline]
+    pub fn as_secret_bytes(&self) -> &[u8; SHARED_SECRET_SIZE] { &self.0 }
+
+    /// Creates a shared secret from `bytes` array.
+    #[inline]
+    pub fn from_secret_bytes(bytes: [u8; SHARED_SECRET_SIZE]) -> SharedSecret {
+        Self::from_bytes(bytes)
+    }
+
     /// Creates a shared secret from `bytes` array.
     #[inline]
     pub fn from_bytes(bytes: [u8; SHARED_SECRET_SIZE]) -> SharedSecret { SharedSecret(bytes) }

--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -103,6 +103,14 @@ impl ElligatorSwift {
     /// Returns the 64-byte array representation of this `ElligatorSwift` object.
     pub fn to_array(&self) -> [u8; 64] { self.0.to_array() }
 
+    /// Returns the 64-byte array representation of this `ElligatorSwift` object.
+    pub fn to_byte_array(&self) -> [u8; 64] { self.to_array() }
+
+    /// Creates an `ElligatorSwift` object from a 64-byte array.
+    pub fn from_byte_array(data: [u8; 64]) -> ElligatorSwift {
+        ElligatorSwift::from_array(data)
+    }
+
     /// Creates the Elligator Swift encoding from a secret key, using some aux_rand if defined.
     /// This method is preferred instead of just decoding, because the private key offers extra
     /// entropy.
@@ -278,6 +286,12 @@ impl ElligatorSwiftSharedSecret {
     /// Returns the secret bytes as a reference to an array.
     pub const fn as_secret_bytes(&self) -> &[u8; 32] { &self.0 }
 }
+
+impl AsRef<[u8]> for ElligatorSwiftSharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl_non_secure_erase!(ElligatorSwiftSharedSecret, 0, [0u8; 32]);
 
 /// Represents the two parties in ECDH
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -928,6 +928,12 @@ impl XOnlyPublicKey {
         ret
     }
 
+    /// Serializes the key as a byte-encoded x coordinate value (32 bytes).
+    #[inline]
+    pub fn to_byte_array(&self) -> [u8; constants::SCHNORR_PUBLIC_KEY_SIZE] {
+        self.serialize()
+    }
+
     /// Tweaks an [`XOnlyPublicKey`] by adding the generator multiplied with the given tweak to it.
     ///
     /// # Returns


### PR DESCRIPTION
This PR standardizes byte conversion methods across [XOnlyPublicKey](cci:2://file:///d:/friendly-project/rust-secp256k1/src/key/mod.rs:821:0-821:47), [ElligatorSwift](cci:2://file:///d:/friendly-project/rust-secp256k1/src/ellswift.rs:79:0-79:47), and [SharedSecret](cci:2://file:///d:/friendly-project/rust-secp256k1/src/ecdh.rs:32:0-32:50) to align with the library's [to_byte_array](cci:1://file:///d:/friendly-project/rust-secp256k1/src/ellswift.rs:105:4-106:63) / [from_byte_array](cci:1://file:///d:/friendly-project/rust-secp256k1/src/key/mod.rs:889:4-912:5) convention.

**Changes:**
- Added [to_byte_array](cci:1://file:///d:/friendly-project/rust-secp256k1/src/ellswift.rs:105:4-106:63) for [XOnlyPublicKey](cci:2://file:///d:/friendly-project/rust-secp256k1/src/key/mod.rs:821:0-821:47).
- Added [to_byte_array](cci:1://file:///d:/friendly-project/rust-secp256k1/src/ellswift.rs:105:4-106:63) / [from_byte_array](cci:1://file:///d:/friendly-project/rust-secp256k1/src/key/mod.rs:889:4-912:5) for [ElligatorSwift](cci:2://file:///d:/friendly-project/rust-secp256k1/src/ellswift.rs:79:0-79:47).
- Added [as_secret_bytes](cci:1://file:///d:/friendly-project/rust-secp256k1/src/ellswift.rs:285:4-286:64) / [from_secret_bytes](cci:1://file:///d:/friendly-project/rust-secp256k1/src/ecdh.rs:68:4-72:5) for [SharedSecret](cci:2://file:///d:/friendly-project/rust-secp256k1/src/ecdh.rs:32:0-32:50).
