### PR TITLE
Add `non_secure_erase` to missing secret types

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ bench marks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench --features=recove
 
 ### A note on `non_secure_erase`
 
-This crate's secret types (`SecretKey`, `Keypair`, `SharedSecret`, `Scalar`, and `DisplaySecret`)
+This crate's secret types (`SecretKey`, `Keypair`, `SharedSecret`, `Scalar`, `DisplaySecret`,
+`SessionSecretRand`, `SecretNonce`, and `ElligatorSwiftSharedSecret`)
 have a method called `non_secure_erase` that *attempts* to overwrite the contained secret. This
 method is provided to assist other libraries in building secure secret erasure. However, this
 library makes no guarantees about the security of using `non_secure_erase`. In particular,

--- a/secp256k1-sys/src/lib.rs
+++ b/secp256k1-sys/src/lib.rs
@@ -1456,6 +1456,17 @@ impl MusigSecNonce {
     }
 
     pub fn dangerous_into_bytes(self) -> [c_uchar; MUSIG_SECNONCE_SIZE] { self.0 }
+
+    /// Attempts to erase the contents of the underlying array.
+    ///
+    /// Note, however, that the compiler is allowed to freely copy or move the
+    /// contents of this array to other places in memory. Preventing this behavior
+    /// is very subtle. For more discussion on this, please see the documentation
+    /// of the [`zeroize`](https://docs.rs/zeroize) crate.
+    #[inline]
+    pub fn non_secure_erase(&mut self) {
+        non_secure_erase_impl(&mut self.0, [0u8; MUSIG_SECNONCE_SIZE]);
+    }
 }
 
 #[repr(C)]

--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -264,6 +264,7 @@ impl ElligatorSwift {
 /// private key.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ElligatorSwiftSharedSecret([u8; 32]);
+impl_non_secure_erase!(ElligatorSwiftSharedSecret, 0, [0u8; 32]);
 
 impl ElligatorSwiftSharedSecret {
     /// Creates shared secret from bytes.

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -54,6 +54,7 @@ impl fmt::Display for ParseError {
 #[allow(missing_copy_implementations)]
 #[derive(Debug, Eq, PartialEq)]
 pub struct SessionSecretRand([u8; 32]);
+impl_non_secure_erase!(SessionSecretRand, 0, [0u8; 32]);
 
 impl SessionSecretRand {
     /// Creates a new [`SessionSecretRand`] with random bytes from the given rng
@@ -717,6 +718,15 @@ impl SecretNonce {
     pub fn dangerous_from_bytes(array: [u8; secp256k1_sys::MUSIG_SECNONCE_SIZE]) -> Self {
         SecretNonce(ffi::MusigSecNonce::dangerous_from_bytes(array))
     }
+
+    /// Attempts to erase the secret within the underlying array.
+    ///
+    /// Note, however, that the compiler is allowed to freely copy or move the contents
+    /// of this array to other places in memory. Preventing this behavior is very subtle.
+    /// For more discussion on this, please see the documentation of the
+    /// [`zeroize`](https://docs.rs/zeroize) crate.
+    #[inline]
+    pub fn non_secure_erase(&mut self) { self.0.non_secure_erase(); }
 }
 
 /// An individual MuSig public nonce. Not to be confused with [`AggregatedNonce`].


### PR DESCRIPTION
`SessionSecretRand`, `SecretNonce`, and ElligatorSwiftSharedSecret all hold secret data but were missing `non_secure_erase`

Note that this doesn't wipe data on Drop like `zeroize` does since most of these types implement `Copy`, but it allows downstream users to erase memory manually.