### PR TITLE
Release tracking PR: `secp256k1 0.33.0-beta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+# 0.33.0-beta - 2025-10-02
+
+* Depend on latest `secp256k1-sys` (vendors `secp256k1 v0.7.0`) [#879](https://github.com/rust-bitcoin/rust-secp256k1/pull/879)
+
 # 0.32.0 - 2025-10-02
+
+We released `0.32.0-beta.0`, `0.32.0-beta.1`, `0.32.0-beta.2` before
+working out that this number scheme does not play nicely with `cargo`.
 
 ### Remove `Secp256k1` from public API functions
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -206,7 +206,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "secp256k1"
-version = "0.32.0-beta.2"
+version = "0.33.0-beta"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -197,7 +197,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.32.0-beta.2"
+version = "0.33.0-beta"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1"
-version = "0.32.0-beta.2"
+version = "0.33.0-beta"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version number, and update teh lock files.

Note the `0.32.0-beta.X` thing turned out not to work. Go to the next major (minor pre-1.0) number but keep `-beta`.