### PR TITLE
test: Enable API tests and standardize byte array methods

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -57,6 +57,9 @@ impl SharedSecret {
     #[inline]
     pub fn to_secret_bytes(&self) -> [u8; SHARED_SECRET_SIZE] { self.0 }
 
+    /// Returns the shared secret as secret bytes
+    pub fn as_secret_bytes(&self) -> &[u8; SHARED_SECRET_SIZE] { &self.0 }
+
     /// Returns the shared secret as a byte value.
     #[deprecated(since = "TBD", note = "Use `to_secret_bytes` instead.")]
     #[inline]
@@ -65,6 +68,11 @@ impl SharedSecret {
     /// Creates a shared secret from `bytes` array.
     #[inline]
     pub fn from_bytes(bytes: [u8; SHARED_SECRET_SIZE]) -> SharedSecret { SharedSecret(bytes) }
+
+    /// Creates a shared secret from a secret bytes array.
+    pub fn from_secret_bytes(bytes: [u8; SHARED_SECRET_SIZE]) -> SharedSecret {
+        SharedSecret(bytes)
+    }
 
     /// Creates a shared secret from `bytes` slice.
     #[deprecated(since = "0.31.0", note = "Use `from_bytes` instead.")]

--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -100,8 +100,14 @@ impl ElligatorSwift {
         ElligatorSwift(ffi::ElligatorSwift::from_array(ellswift))
     }
 
+    /// Creates an `ElligatorSwift` object from a byte array.
+    pub fn from_byte_array(ellswift: [u8; 64]) -> ElligatorSwift { Self::from_array(ellswift) }
+
     /// Returns the 64-byte array representation of this `ElligatorSwift` object.
     pub fn to_array(&self) -> [u8; 64] { self.0.to_array() }
+
+    /// Returns the 64-byte array representation of this `ElligatorSwift` object.
+    pub fn to_byte_array(&self) -> [u8; 64] { self.to_array() }
 
     /// Creates the Elligator Swift encoding from a secret key, using some aux_rand if defined.
     /// This method is preferred instead of just decoding, because the private key offers extra
@@ -264,6 +270,7 @@ impl ElligatorSwift {
 /// private key.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ElligatorSwiftSharedSecret([u8; 32]);
+impl_non_secure_erase!(ElligatorSwiftSharedSecret, 0, [0u8; 32]);
 
 impl ElligatorSwiftSharedSecret {
     /// Creates shared secret from bytes.
@@ -277,6 +284,10 @@ impl ElligatorSwiftSharedSecret {
 
     /// Returns the secret bytes as a reference to an array.
     pub const fn as_secret_bytes(&self) -> &[u8; 32] { &self.0 }
+}
+
+impl AsRef<[u8]> for ElligatorSwiftSharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
 }
 
 /// Represents the two parties in ECDH

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -388,7 +388,7 @@ mod tests {
         let (pk, _parity) = kp.x_only_public_key();
 
         let ser = pk.serialize();
-        let pubkey2 = XOnlyPublicKey::from_byte_array(ser).unwrap();
+        let pubkey2 = XOnlyPublicKey::from_byte_array(ser);
         assert_eq!(pk, pubkey2);
     }
 
@@ -514,7 +514,7 @@ mod tests {
             170, 12, 208, 84, 74, 200, 135, 254, 145, 221, 209, 102,
         ];
         static PK_STR: &str = "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
-        let pk = XOnlyPublicKey::from_byte_array(PK_BYTES).unwrap();
+        let pk = XOnlyPublicKey::from_byte_array(PK_BYTES);
 
         assert_tokens(&sig.compact(), &[Token::BorrowedBytes(&SIG_BYTES[..])]);
         assert_tokens(&sig.compact(), &[Token::Bytes(&SIG_BYTES[..])]);
@@ -733,7 +733,7 @@ mod tests {
                 assert_eq!(sig.to_byte_array(), signature);
             }
             let sig = Signature::from_byte_array(signature);
-            let is_verified = if let Ok(pubkey) = XOnlyPublicKey::from_byte_array(public_key) {
+            let is_verified = if let Ok(pubkey) = XOnlyPublicKey::try_from_byte_array(public_key) {
                 verify(&sig, &message, &pubkey).is_ok()
             } else {
                 false

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -54,11 +54,11 @@ macro_rules! bytes_rtt_test {
 
 // Message is special because its to/from methods havve the name "digest" in them
 // PublicKey is special because it has two serialization forms with different names (but maybe I should rename them?)
-// FIXME XOnlyPublicKey should pass this
 // ecdsa::Signature and SerializedSignature and RecoverableSignature are variable-length
-// FIXME ElligatorSwift should pass this
 // Scalar has to_be_bytes and to_le_bytes (and corresponding froms)
 bytes_rtt_test!(rtt_i, schnorr::Signature);
+bytes_rtt_test!(rtt_c, XOnlyPublicKey);
+bytes_rtt_test!(rtt_g, ellswift::ElligatorSwift);
 
 macro_rules! secret_bytes_rtt_test {
     ($name: ident, $ty:ty) => {
@@ -73,6 +73,6 @@ macro_rules! secret_bytes_rtt_test {
     };
 }
 secret_bytes_rtt_test!(secret_rtt_a, SecretKey);
-// FIXME ecdh::SharedSecret should pass this
-// FIXME unsure about Keypair -- it currently only roundtrips through secret keys
-// FIXME ellswift::ElligatorSwiftharedSecret should pass this
+secret_bytes_rtt_test!(secret_rtt_b, ecdh::SharedSecret);
+secret_bytes_rtt_test!(secret_rtt_c, Keypair);
+secret_bytes_rtt_test!(secret_rtt_d, ellswift::ElligatorSwiftSharedSecret);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -105,8 +105,7 @@ fn bincode_keypair() {
 
 #[test]
 fn bincode_x_only_public_key() {
-    let pk = XOnlyPublicKey::from_byte_array(XONLY_PK_BYTES)
-        .expect("failed to create xonly pk from slice");
+    let pk = XOnlyPublicKey::from_byte_array(XONLY_PK_BYTES);
     let ser = bincode::serialize(&pk).unwrap();
 
     assert_eq!(ser, XONLY_PK_BYTES);


### PR DESCRIPTION
Remove FIXME comments in `tests/api.rs` and enable the corresponding compilation checks by implementing missing byte conversion methods.

Changes include:
- `XOnlyPublicKey`: Rename `from_byte_array` to `try_from_byte_array` and modify `from_byte_array`.
- `Keypair`: Add `from_secret_bytes`, `as_secret_bytes`, and `AsRef<[u8]>`.
- `ellswift::ElligatorSwift`: Add `from_byte_array` and `to_byte_array`.
- `ecdh::SharedSecret`: Add `from_secret_bytes` and `as_secret_bytes`.
- `ellswift::ElligatorSwiftSharedSecret`: Add `AsRef<[u8]>` and `non_secure_erase`.

fixes #859 