### PR TITLE
Implement byte array conversions for ElligatorSwift

### DIFF
--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -100,8 +100,16 @@ impl ElligatorSwift {
         ElligatorSwift(ffi::ElligatorSwift::from_array(ellswift))
     }
 
+    /// Creates an `ElligatorSwift` object from a byte array.
+    pub fn from_byte_array(ellswift: [u8; 64]) -> ElligatorSwift {
+        ElligatorSwift(ffi::ElligatorSwift::from_array(ellswift))
+    }
+
     /// Returns the 64-byte array representation of this `ElligatorSwift` object.
     pub fn to_array(&self) -> [u8; 64] { self.0.to_array() }
+
+    /// Returns the byte array representation of this `ElligatorSwift` object.
+    pub fn to_byte_array(&self) -> [u8; 64] { self.0.to_array() }
 
     /// Creates the Elligator Swift encoding from a secret key, using some aux_rand if defined.
     /// This method is preferred instead of just decoding, because the private key offers extra

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -56,9 +56,9 @@ macro_rules! bytes_rtt_test {
 // PublicKey is special because it has two serialization forms with different names (but maybe I should rename them?)
 // FIXME XOnlyPublicKey should pass this
 // ecdsa::Signature and SerializedSignature and RecoverableSignature are variable-length
-// FIXME ElligatorSwift should pass this
 // Scalar has to_be_bytes and to_le_bytes (and corresponding froms)
 bytes_rtt_test!(rtt_i, schnorr::Signature);
+bytes_rtt_test!(rtt_g, ellswift::ElligatorSwift);
 
 macro_rules! secret_bytes_rtt_test {
     ($name: ident, $ty:ty) => {


### PR DESCRIPTION
## Description

This PR implements the missing byte array conversion methods for `ElligatorSwift` to enable standard round-trip testing. Previously, the `ElligatorSwift` type lacked the necessary interface to satisfy the `bytes_rtt_test!` macro, leading to a pending `FIXME` in the test suite.

### Changes

- **Added `ElligatorSwift::to_byte_array`**: Extracts the underlying 64-byte array from the FFI wrapper.
- **Added `ElligatorSwift::from_byte_array`**: Constructs an `ElligatorSwift` instance from a 64-byte array.
- **Enabled RTT Test**: Activated the `rtt_g` test case and removed the associated `FIXME` comment.

Child #885 
References #859 