### PR TITLE
Implement AsRef for ElligatorSwiftSharedSecret

### DIFF
--- a/src/ellswift.rs
+++ b/src/ellswift.rs
@@ -288,6 +288,10 @@ impl ElligatorSwiftSharedSecret {
     pub const fn as_secret_bytes(&self) -> &[u8; 32] { &self.0 }
 }
 
+impl AsRef<[u8]> for ElligatorSwiftSharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
 /// Represents the two parties in ECDH
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Party {

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -73,6 +73,6 @@ macro_rules! secret_bytes_rtt_test {
     };
 }
 secret_bytes_rtt_test!(secret_rtt_a, SecretKey);
+secret_bytes_rtt_test!(secret_rtt_d, ellswift::ElligatorSwiftSharedSecret);
 // FIXME ecdh::SharedSecret should pass this
 // FIXME unsure about Keypair -- it currently only roundtrips through secret keys
-// FIXME ellswift::ElligatorSwiftharedSecret should pass this


### PR DESCRIPTION
## Description

Implements `AsRef<[u8]>` for `ElligatorSwiftSharedSecret` to conform to the standard secret types API.

### Changes

- **Implemented `AsRef<[u8]>`**: Allows the `ElligatorSwiftSharedSecret` to be treated as a byte slice for cryptographic operations and comparisons.
- **Updated Api test suite**: The type now satisfies the `secret_bytes_rtt_test!` macro requirements.

References #859 