### PR TITLE
Fix racy test RNG

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,9 +515,13 @@ fn test_random_32_bytes() -> [u8; 32] {
 
     let mut ret = [0; 32];
     for i in 0..8 {
-        let rng = RNG.load(Ordering::Relaxed).wrapping_mul(PRIME_1).wrapping_add(PRIME_2);
+        let prev = RNG
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |rng| {
+                Some(rng.wrapping_mul(PRIME_1).wrapping_add(PRIME_2))
+            })
+            .unwrap();
+        let rng = prev.wrapping_mul(PRIME_1).wrapping_add(PRIME_2);
         ret[i * 4..(i + 1) * 4].copy_from_slice(&rng.to_be_bytes());
-        RNG.store(rng, Ordering::Relaxed);
     }
     ret
 }


### PR DESCRIPTION
The problem is that we’re using a shared RNG, and its state was updated through separate LOAD -> STORE sequence, which is not atomic as a whole (even tho each operation is atomic individually). So two threads can read the same value and produce the same random bytes, which caused `pubkey_hash` to [fail](https://github.com/rust-bitcoin/rust-secp256k1/actions/runs/22018991122/job/63625001587).

we changed the current implementation to use `fetch_update`, which, according to the docs
https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU32.html#method.fetch_update, guarantees an atomic read-modify-write operation