### PR TITLE
no_std_test: Remove pointless context construction

### DIFF
--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -105,7 +105,6 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
 
     #[cfg(feature = "alloc")]
     {
-        let secp_alloc = Secp256k1::new();
         let public_key = PublicKey::from_secret_key(&secret_key);
         let message = Message::from_digest_slice(&[0xab; 32]).expect("32 bytes");
 


### PR DESCRIPTION
The old context API is not used in the test. We must not be linting the `no_std_test` crate.