### PR TITLE
Fix `generate_keypair()` invocation at `bench_ecdh()`

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -255,7 +255,7 @@ mod benches {
 
     #[bench]
     pub fn bench_ecdh(bh: &mut Bencher) {
-        let (sk, pk) = s.generate_keypair(&mut rand::rng());
+        let (sk, pk) = crate::generate_keypair(&mut rand::rng());
 
         bh.iter(|| {
             let res = SharedSecret::new(&pk, &sk);

--- a/src/musig.rs
+++ b/src/musig.rs
@@ -5,9 +5,8 @@
 //! The documentation in this module is for reference and may not be sufficient
 //! for advanced use-cases. A full description of the C API usage along with security considerations
 //! can be found in [C-musig.md](secp256k1-sys/depend/secp256k1/src/modules/musig/musig.md).
-use core;
-use core::fmt;
 use core::mem::MaybeUninit;
+use core::{self, fmt};
 #[cfg(feature = "std")]
 use std;
 


### PR DESCRIPTION
Otherwise, the following command fails with:
```
$ RUSTFLAGS='--cfg=bench' cargo +nightly bench --all-targets --all-features
...
error[E0425]: cannot find value `s` in this scope
   --> src/ecdh.rs:258:24
    |
258 |         let (sk, pk) = s.generate_keypair(&mut rand::rng());
    |                        ^ not found in this scope

...
```