### PR TITLE
Fixup `vendor-libsecp.sh` logging

### DIFF
--- a/secp256k1-sys/vendor-libsecp.sh
+++ b/secp256k1-sys/vendor-libsecp.sh
@@ -34,8 +34,8 @@ while (( "$#" )); do
         ;;
     *)
         if [ -z "$SECP_REV" ]; then
-            echo "Using secp256k1 revision $SECP_REV."
             SECP_REV="$1"
+            echo "Using secp256k1 revision $SECP_REV."
         else
             echo "WARNING: ignoring unknown command-line argument $1"
         fi


### PR DESCRIPTION
After the fix:
```
Using version code 0_13. Set SECP_VENDOR_VERSION_CODE to override.
Using depend directory /home/rzeyde/src/rust-secp256k1/secp256k1-sys/depend. Set SECP_VENDOR_DEPEND_DIR to override.
Using secp repository https://github.com/bitcoin-core/secp256k1.git. Set SECP_VENDOR_SECP_REPO to override.
Using secp256k1 revision a660a4976efe880bae7982ee410b9e0dc59ac983.
```

Before the fix, an empty revision is logged.